### PR TITLE
Fix/workaround for half close and proxy erroneous More data is available

### DIFF
--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -70,6 +70,7 @@ type HTTPRunnerOptions struct {
 	DisableFastClient bool   // defaults to fast client
 	HTTP10            bool   // defaults to http1.1
 	DisableKeepAlive  bool   // so default is keep alive
+	AllowHalfClose    bool   // if not keepalive, whether to half close after request
 	Profiler          string // file to save profiles to. defaults to no profiling
 }
 
@@ -93,12 +94,12 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 	for i := 0; i < numThreads; i++ {
 		// Create a client (and transport) and connect once for each 'thread'
 		if o.DisableFastClient {
-			httpstate[i].client = NewStdClient(o.URL, 1, o.Compression)
+			httpstate[i].client = NewStdClient(o.URL, 1, !o.DisableKeepAlive, o.Compression)
 		} else {
 			if o.HTTP10 {
-				httpstate[i].client = NewBasicClient(o.URL, "1.0", !o.DisableKeepAlive)
+				httpstate[i].client = NewBasicClient(o.URL, "1.0", !o.DisableKeepAlive, o.AllowHalfClose)
 			} else {
-				httpstate[i].client = NewBasicClient(o.URL, "1.1", !o.DisableKeepAlive)
+				httpstate[i].client = NewBasicClient(o.URL, "1.1", !o.DisableKeepAlive, o.AllowHalfClose)
 			}
 		}
 		if httpstate[i].client == nil {

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -137,7 +137,8 @@ func fetchURL(url string) {
 	if client == nil {
 		return // error logged already
 	}
-	code, data, _ := client.Fetch()
+	code, data, header := client.Fetch()
+	log.LogVf("Fetch result code %d, data len %d, headerlen %d", code, len(data), header)
 	if code != http.StatusOK {
 		log.Errf("Error status %d : %s", code, fhttp.DebugSummary(data, 512))
 	}

--- a/periodic/periodic.go
+++ b/periodic/periodic.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	// Version is the overall package version (used to version json output too).
-	Version = "0.3.5"
+	Version = "0.3.6"
 )
 
 // DefaultRunnerOptions are the default values for options (do not mutate!).

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -483,7 +483,11 @@ func FetcherHandler(w http.ResponseWriter, r *http.Request) {
 	// Don't forget to close the connection:
 	defer conn.Close() // nolint: errcheck
 	url := r.URL.String()[len(fetchPath):]
-	client := fhttp.NewBasicClient("http://"+url, "1.1", false)
+	client := fhttp.NewBasicClient("http://"+url, "1.1",
+		/* keepalive: */
+		false,
+		/* halfclose: */
+		false)
 	if client == nil {
 		return // error logged already
 	}


### PR DESCRIPTION
Fix/workaround for half close and proxy erroneous More data is available:

Adding a flag (-halfclose) and http cli option to do/not do half close
(To workaround https://github.com/envoyproxy/envoy/issues/2066 set the
default to false)
Also pass the keep alive flag to the standard client

2nd commit: Fixes #24 

Needed to reset max when switching from expected keep alive to not keep
alive

Also removed 1 level of if/indentation
(Check diff -w to avoid the noise:)
```
--- a/fhttp/http.go
+++ b/fhttp/http.go
@@ -557,11 +557,11 @@ func (c *BasicClient) readResponse(conn
*net.TCPConn) {
log.Debugf("Read ok %d total %d so far (-%d
headers = %d data) %s",
n, c.size, c.headerLen,
c.size-c.headerLen, DebugSummary(c.buffer[c.size-n:c.size], 128))
}
-               if !parsedHeaders && c.parseHeaders {
-                       // enough to get the code?
-                       if c.size >= retcodeOffset+3 {
+               // Have not yet parsed the headers, need to parse the
headers, and have enough data to
+               // at least parse the http retcode:
+               if !parsedHeaders && c.parseHeaders && c.size >=
retcodeOffset+3 {
// even if the bytes are garbage we'll get a
non 200 code (bytes are unsigned)
-                               c.code =
ParseDecimal(c.buffer[retcodeOffset : retcodeOffset+3])
+                       c.code = ParseDecimal(c.buffer[retcodeOffset :
retcodeOffset+3]) //TODO do that only once...
// TODO handle 100 Continue
if c.code != http.StatusOK {
log.Warnf("Parsed non ok code %d (%v)",
c.code, string(c.buffer[:retcodeOffset+3]))
@@ -637,7 +637,7 @@ func (c *BasicClient) readResponse(conn
*net.TCPConn) {
if found, _ :=
FoldFind(c.buffer[:c.headerLen], connectionCloseHeader); found {

log.Infof("Server wants to close connection, no keep-alive!")
keepAlive =
false
-                                                       }
+                                                       max =
len(c.buffer) // reset to read as much as available
}
}
}
```