### PR TITLE
Fix such as -ui-path /otherpath/ works and support link time setting of data dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,13 @@ FROM golang:1.8.3 as build
 WORKDIR /go/src/istio.io
 RUN go get google.golang.org/grpc
 COPY . fortio
-RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-s' -o fortio.bin istio.io/fortio
+# Demonstrate moving the static directory outside of the go source tree:
+RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-X istio.io/fortio/ui.dataDirectory=/usr/local/lib/fortio -s' -o fortio.bin istio.io/fortio
 # Minimal image with just the binary and certs
 FROM scratch
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /go/src/istio.io/fortio.bin /usr/local/bin/fortio
-COPY --from=build /go/src/istio.io/fortio/ui/static /go/src/istio.io/fortio/ui/static
+COPY --from=build /go/src/istio.io/fortio/ui/static /usr/local/lib/fortio/static
 EXPOSE 8079
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/fortio"]

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -2,7 +2,8 @@
 set -x
 # Check we can build the image
 make docker-internal TAG=webtest || exit 1
-DOCKERID=$(docker run -d --name fortio_server istio/fortio:webtest server)
+FORTIO_UI_PREFIX=/newprefix/ # test the non default prefix (not /fortio/)
+DOCKERID=$(docker run -d --name fortio_server istio/fortio:webtest server -ui-path $FORTIO_UI_PREFIX)
 function cleanup {
   docker stop $DOCKERID
   docker rm fortio_server
@@ -12,20 +13,20 @@ set -e
 set -o pipefail
 docker ps
 BASE_URL="http://localhost:8080"
+BASE_FORTIO="$BASE_URL$FORTIO_UI_PREFIX"
 # Check https works (certs are in the image)
 docker exec fortio_server /usr/local/bin/fortio load -curl -stdclient https://istio.io/robots.txt
-# Needed for circleci docker environment
-CURL="docker run --network container:fortio_server appropriate/curl --retry 10 --retry-connrefused"
+CURL="docker exec fortio_server /usr/local/bin/fortio load -curl"
 # Check we can connect, and run a QPS test against ourselves through fetch
-$CURL -f "$BASE_URL/fortio/fetch/localhost:8080/fortio/?url=http://localhost:8080/debug&load=Start&qps=-1&json=on" | grep ActualQPS
+$CURL "${BASE_FORTIO}fetch/localhost:8080/fortio/?url=http://localhost:8080/debug&load=Start&qps=-1&json=on" | grep ActualQPS
 # Check we get the logo
-LOGO_TYPE=$($CURL -o /dev/null -f -w '%{content_type}' "$BASE_URL/fortio/static/img/logo.svg")
-if [ "$LOGO_TYPE" != "image/svg+xml" ]; then
+LOGO_TYPE=$($CURL "${BASE_FORTIO}static/img/logo.svg" | grep Content-Type:)
+if [ "$LOGO_TYPE" != "Content-Type: image/svg+xml" ]; then
   echo "Unexpected content type for the logo: $LOGO_TYPE"
   exit 1
 fi
 # Check we can get the JS file through the proxy and it's > 50k
-SIZE=$($CURL -v -f "$BASE_URL/fortio/fetch/localhost:8080/fortio/static/js/Chart.min.js" |wc -c)
+SIZE=$($CURL "${BASE_FORTIO}fetch/localhost:8080/fortio/static/js/Chart.min.js" |wc -c)
 if [ "$SIZE" -lt 50000 ]; then
   echo "Too small fetch for js: $SIZE"
   exit 1

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -18,15 +18,15 @@ BASE_FORTIO="$BASE_URL$FORTIO_UI_PREFIX"
 docker exec fortio_server /usr/local/bin/fortio load -curl -stdclient https://istio.io/robots.txt
 CURL="docker exec fortio_server /usr/local/bin/fortio load -curl"
 # Check we can connect, and run a QPS test against ourselves through fetch
-$CURL "${BASE_FORTIO}fetch/localhost:8080/fortio/?url=http://localhost:8080/debug&load=Start&qps=-1&json=on" | grep ActualQPS
-# Check we get the logo
-LOGO_TYPE=$($CURL "${BASE_FORTIO}static/img/logo.svg" | grep Content-Type:)
-if [ "$LOGO_TYPE" != "Content-Type: image/svg+xml" ]; then
+$CURL "${BASE_FORTIO}fetch/localhost:8080$FORTIO_UI_PREFIX?url=http://localhost:8080/debug&load=Start&qps=-1&json=on" | grep ActualQPS
+# Check we get the logo (need to remove the CR from raw headers)
+LOGO_TYPE=$($CURL "${BASE_FORTIO}static/img/logo.svg" | grep -i Content-Type: | tr -d '\r'| awk '{print $2}')
+if [ "$LOGO_TYPE" != "image/svg+xml" ]; then
   echo "Unexpected content type for the logo: $LOGO_TYPE"
   exit 1
 fi
 # Check we can get the JS file through the proxy and it's > 50k
-SIZE=$($CURL "${BASE_FORTIO}fetch/localhost:8080/fortio/static/js/Chart.min.js" |wc -c)
+SIZE=$($CURL "${BASE_FORTIO}fetch/localhost:8080${FORTIO_UI_PREFIX}static/js/Chart.min.js" |wc -c)
 if [ "$SIZE" -lt 50000 ]; then
   echo "Too small fetch for js: $SIZE"
   exit 1

--- a/periodic/periodic.go
+++ b/periodic/periodic.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	// Version is the overall package version (used to version json output too).
-	Version = "0.3.7"
+	Version = "0.3.8"
 )
 
 // DefaultRunnerOptions are the default values for options (do not mutate!).


### PR DESCRIPTION
i.e. that static content is always under the UI path

Also simplified the code a bit

Updated the test to not need the curl image and use fortio -curl instead