### PR TITLE
Support for exact number of calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,9 +321,9 @@ make lint
 make webtest
 ```
 
-When modifying Javascript:
+When modifying Javascript, check with [standard](https://github.com/standard/standard):
 ```
-standard --fix fortio_chart.js
+standard --fix ui/static/js/fortio_chart.js
 ```
 
 ## See also

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ tests) or host:port (grpc health test) and flags are:
     	Directory where JSON results are stored/read (default ".")
   -echo-debug-path string
     	http echo server URI for debug, empty turns off that part (more secure)
-      (default "/debug")
+    	(default "/debug")
   -gomaxprocs int
     	Setting for runtime.GOMAXPROCS, <1 doesn't change the default
   -grpc
@@ -71,7 +71,7 @@ tests) or host:port (grpc health test) and flags are:
     	grpc port (default 8079)
   -halfclose
     	When not keepalive, whether to half close the connection (only for fast
-      http)
+    	http)
   -health
     	client mode: use health instead of ping
   -healthservice string
@@ -82,19 +82,19 @@ tests) or host:port (grpc health test) and flags are:
     	Use http1.0 (instead of http 1.1)
   -httpbufferkb int
     	Size of the buffer (max data size) for the optimized http client in kbytes
-      (default 128)
+    	(default 128)
   -httpccch
     	Check for Connection: Close Header
   -httpreqtimeout duration
     	Http request timeout value (default 15s)
   -json string
     	Json output to provided file or '-' for stdout (empty = no json output,
-      unless -a is used)
+    	unless -a is used)
   -keepalive
     	Keep connection alive (only for fast http 1.1) (default true)
   -labels string
     	Additional config data/labels to add to the resulting JSON, defaults to
-      target URL and hostname
+    	target URL and hostname
   -logcaller
     	Logs filename and line number of callers to log (default true)
   -loglevel value
@@ -103,8 +103,8 @@ tests) or host:port (grpc health test) and flags are:
   -logprefix string
     	Prefix to log lines before logged messages (default "> ")
   -n int
-      Run for exactly this number of calls instead of duration. Default (0) is
-      to use duration (-t). Default is 1 when used as grpc ping count.
+    	Run for exactly this number of calls instead of duration. Default (0) is
+    	to use duration (-t). Default is 1 when used as grpc ping count.
   -p string
     	List of pXX to calculate (default "50,75,99,99.9")
   -payload string
@@ -117,7 +117,7 @@ tests) or host:port (grpc health test) and flags are:
     	Resolution of the histogram lowest buckets in seconds (default 0.001)
   -redirect-port int
     	Redirect all incoming traffic to https URL (need ingress to work properly)
-      -1 means off. (default 8081)
+    	-1 means off. (default 8081)
   -static-dir string
     	Absolute path to the dir containing the static files dir
   -stdclient
@@ -126,7 +126,7 @@ tests) or host:port (grpc health test) and flags are:
     	How long to run the test or 0 to run until ^C (default 5s)
   -ui-path string
     	http server URI for UI, empty turns off that part (more secure)
-      (default "/fortio/")
+    	(default "/fortio/")
 ```
 
 ## Example use and output

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 # Φορτίο
 <img src="https://github.com/istio/fortio/blob/master/docs/fortio-logo-color.png" height=141 width=141 align=right>
 
-Φορτίο (fortio) is [Istio](https://istio.io/)'s load testing tool. Fortio runs at a specified query per second (qps) and records an histogram of execution time and calculates percentiles (e.g. p99 ie the response time such as 99% of the requests take less than that number (in seconds, SI unit))
+Φορτίο (fortio) is [Istio](https://istio.io/)'s load testing tool. Fortio runs at a specified query per second (qps) and records an histogram of execution time and calculates percentiles (e.g. p99 ie the response time such as 99% of the requests take less than that number (in seconds, SI unit)). It can run for a set duration, for a fixed number of calls, or until interrupted (at a constant target QPS, or max speed/load per connection/thread).
 
 The name fortio comes from greek φορτίο which is load/burden.
 
-Fortio is a reusable, embeddable go library as well as a command line tool and server process, the server includes a simple web UI and graphical representation of the results.
+Fortio is a reusable, embeddable go library as well as a command line tool and server process, the server includes a simple web UI and graphical representation of the results (both a single latency graph and a multiple results comparative min, max, avg and percentiles graphs).
 
 ## Installation
 
@@ -41,7 +41,7 @@ Fortio can be an http or grpc load generator, gathering statistics using the `lo
 
 ```
 $ fortio
-Φορτίο 0.6.1 usage:
+Φορτίο 0.6.2 usage:
 	fortio command [flags] target
 where command is one of: load (load testing), server (starts grpc ping and
 http echo/ui/redirect servers), grpcping (grpc client), report (report only UI
@@ -103,7 +103,8 @@ tests) or host:port (grpc health test) and flags are:
   -logprefix string
     	Prefix to log lines before logged messages (default "> ")
   -n int
-    	how many ping(s) the client will send (default 1)
+      Run for exactly this number of calls instead of duration. Default (0) is
+      to use duration (-t). Default is 1 when used as grpc ping count.
   -p string
     	List of pXX to calculate (default "50,75,99,99.9")
   -payload string

--- a/fgrpc/grpcrunner.go
+++ b/fgrpc/grpcrunner.go
@@ -83,10 +83,12 @@ func RunGRPCTest(o *GRPCRunnerOptions) (*GRPCRunnerResults, error) {
 			return nil, fmt.Errorf("unable to create client %d for %s", i, o.Destination)
 		}
 		grpcstate[i].req = grpc_health_v1.HealthCheckRequest{Service: o.Service}
-		_, err = grpcstate[i].client.Check(context.Background(), &grpcstate[i].req)
-		if err != nil {
-			log.Errf("Error in first grpc health check call for %s %v", o.Destination, err)
-			return nil, err
+		if o.Exactly <= 0 {
+			_, err = grpcstate[i].client.Check(context.Background(), &grpcstate[i].req)
+			if err != nil {
+				log.Errf("Error in first grpc health check call for %s %v", o.Destination, err)
+				return nil, err
+			}
 		}
 		// Setup the stats for each 'thread'
 		grpcstate[i].RetCodes = make(map[grpc_health_v1.HealthCheckResponse_ServingStatus]int64)

--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -87,12 +87,14 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 		if httpstate[i].client == nil {
 			return nil, fmt.Errorf("unable to create client %d for %s", i, o.URL)
 		}
-		code, data, headerSize := httpstate[i].client.Fetch()
-		if !o.AllowInitialErrors && code != http.StatusOK {
-			return nil, fmt.Errorf("error %d for %s: %q", code, o.URL, string(data))
-		}
-		if i == 0 && log.LogVerbose() {
-			log.LogVf("first hit of url %s: status %03d, headers %d, total %d\n%s\n", o.URL, code, headerSize, len(data), data)
+		if o.Exactly <= 0 {
+			code, data, headerSize := httpstate[i].client.Fetch()
+			if !o.AllowInitialErrors && code != http.StatusOK {
+				return nil, fmt.Errorf("error %d for %s: %q", code, o.URL, string(data))
+			}
+			if i == 0 && log.LogVerbose() {
+				log.LogVf("first hit of url %s: status %03d, headers %d, total %d\n%s\n", o.URL, code, headerSize, len(data), data)
+			}
 		}
 		// Setup the stats for each 'thread'
 		httpstate[i].sizes = total.sizes.Clone()

--- a/periodic/periodic.go
+++ b/periodic/periodic.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	// Version is the overall package version (used to version json output too).
-	Version = "0.6.1"
+	Version = "0.6.2"
 )
 
 // DefaultRunnerOptions are the default values for options (do not mutate!).
@@ -73,8 +73,10 @@ func (r *RunnerOptions) MakeRunners(rr Runnable) {
 // RunnerOptions are the parameters to the PeriodicRunner.
 type RunnerOptions struct {
 	// Array of objects to run in each thread (use MakeRunners() to clone the same one)
-	Runners  []Runnable
-	QPS      float64
+	Runners []Runnable
+	// At which (target) rate to run the Runners across NumThreads.
+	QPS float64
+	// How long to run the test for. Unless Exactly is specified.
 	Duration time.Duration
 	// Note that this actually maps to gorountines and not actual threads
 	// but threads seems like a more familiar name to use for non go users
@@ -90,6 +92,9 @@ type RunnerOptions struct {
 	// by the end of Run(). To abort a run call Runner.Abort(), don't close channel
 	// directly (or risk a panic that it's already closed).
 	Stop chan struct{}
+	// Mode where an exact number of iterations is requested. Default (0) is
+	// to not use that mode. If specified Duration is not used.
+	Exactly int64
 }
 
 // RunnerResults encapsulates the actual QPS observed and duration histogram.
@@ -251,16 +256,22 @@ func (r *periodicRunner) Run() RunnerResults {
 	runnerChan := r.Stop // need a copy to not race with assignement to nil
 	gAbortMutex.Unlock()
 	useQPS := (r.QPS > 0)
+	// r.Duration will be 0 if endless flag has been provided. Otherwise it will have the provided duration time.
 	hasDuration := (r.Duration > 0)
+	// r.Exactly is > 0 if we use Exactly iterations instead of the duration.
+	useExactly := (r.Exactly > 0)
 	var numCalls int64
+	var leftOver int64 // left over from r.Exactly / numThreads
 	requestedQPS := "max"
 	requestedDuration := "until stop"
 	if useQPS {
 		requestedQPS = fmt.Sprintf("%.9g", r.QPS)
-		// r.Duration will be 0 if endless flag has been provided. Otherwise it will have the provided duration time.
-		if hasDuration {
+		if hasDuration || useExactly {
 			requestedDuration = fmt.Sprint(r.Duration)
 			numCalls = int64(r.QPS * r.Duration.Seconds())
+			if useExactly {
+				numCalls = r.Exactly
+			}
 			if numCalls < 2 {
 				log.Warnf("Increasing the number of calls to the minimum of 2 with 1 thread. total duration will increase")
 				numCalls = 2
@@ -273,9 +284,16 @@ func (r *periodicRunner) Run() RunnerResults {
 			}
 			numCalls /= int64(r.NumThreads)
 			totalCalls := numCalls * int64(r.NumThreads)
-			// nolint: gas
-			fmt.Fprintf(r.Out, "Starting at %g qps with %d thread(s) [gomax %d] for %v : %d calls each (total %d)\n",
-				r.QPS, r.NumThreads, runtime.GOMAXPROCS(0), r.Duration, numCalls, totalCalls)
+			if useExactly {
+				leftOver = r.Exactly - totalCalls
+				// nolint: gas
+				fmt.Fprintf(r.Out, "Starting at %g qps with %d thread(s) [gomax %d] : exactly %d, %d calls each (total %d + %d)\n",
+					r.QPS, r.NumThreads, runtime.GOMAXPROCS(0), r.Exactly, numCalls, totalCalls, leftOver)
+			} else {
+				// nolint: gas
+				fmt.Fprintf(r.Out, "Starting at %g qps with %d thread(s) [gomax %d] for %v : %d calls each (total %d)\n",
+					r.QPS, r.NumThreads, runtime.GOMAXPROCS(0), r.Duration, numCalls, totalCalls)
+			}
 		} else {
 			// nolint: gas
 			fmt.Fprintf(r.Out, "Starting at %g qps with %d thread(s) [gomax %d] until interrupted\n",
@@ -286,12 +304,19 @@ func (r *periodicRunner) Run() RunnerResults {
 		// nolint: gas
 		fmt.Fprintf(r.Out, "Starting at max qps with %d thread(s) [gomax %d] ",
 			r.NumThreads, runtime.GOMAXPROCS(0))
-		if hasDuration {
-			requestedDuration = fmt.Sprint(r.Duration)
-			fmt.Fprintf(r.Out, "for %v\n", r.Duration)
+		if useExactly {
+			numCalls = r.Exactly / int64(r.NumThreads)
+			leftOver = r.Exactly % int64(r.NumThreads)
+			fmt.Fprintf(r.Out, "for exactly %d calls (%d per thread + %d)\n", r.Exactly, numCalls, leftOver)
 		} else {
-			fmt.Fprintf(r.Out, "until interrupted\n")
+			if hasDuration {
+				requestedDuration = fmt.Sprint(r.Duration)
+				fmt.Fprintf(r.Out, "for %v\n", r.Duration)
+			} else {
+				fmt.Fprintf(r.Out, "until interrupted\n")
+			}
 		}
+
 	}
 	runnersLen := len(r.Runners)
 	if runnersLen == 0 {
@@ -308,7 +333,7 @@ func (r *periodicRunner) Run() RunnerResults {
 	sleepTime := stats.NewHistogram(-0.001, 0.001)
 	if r.NumThreads <= 1 {
 		log.Infof("Running single threaded")
-		runOne(0, runnerChan, functionDuration, sleepTime, numCalls, start, r)
+		runOne(0, runnerChan, functionDuration, sleepTime, numCalls+leftOver, start, r)
 	} else {
 		var wg sync.WaitGroup
 		var fDs []*stats.Histogram
@@ -319,8 +344,13 @@ func (r *periodicRunner) Run() RunnerResults {
 			fDs = append(fDs, durP)
 			sDs = append(sDs, sleepP)
 			wg.Add(1)
+			thisNumCalls := numCalls
+			if (leftOver > 0) && (t == 0) {
+				// The first thread gets to do the additional work
+				thisNumCalls += leftOver
+			}
 			go func(t int, durP *stats.Histogram, sleepP *stats.Histogram) {
-				runOne(t, runnerChan, durP, sleepP, numCalls, start, r)
+				runOne(t, runnerChan, durP, sleepP, thisNumCalls, start, r)
 				wg.Done()
 			}(t, durP, sleepP)
 		}
@@ -373,12 +403,13 @@ func runOne(id int, runnerChan chan struct{},
 	perThreadQPS := r.QPS / float64(r.NumThreads)
 	useQPS := (perThreadQPS > 0)
 	hasDuration := (r.Duration > 0)
+	useExactly := (r.Exactly > 0)
 	f := r.Runners[id]
 
 MainLoop:
 	for {
 		fStart := time.Now()
-		if hasDuration && fStart.After(endTime) {
+		if !useExactly && (hasDuration && fStart.After(endTime)) {
 			if !useQPS {
 				// max speed test reached end:
 				break
@@ -395,7 +426,7 @@ MainLoop:
 		i++
 		// if using QPS / pre calc expected call # mode:
 		if useQPS {
-			if hasDuration && i >= numCalls {
+			if (useExactly || hasDuration) && i >= numCalls {
 				break // expected exit for that mode
 			}
 			elapsed := time.Since(start)
@@ -419,6 +450,9 @@ MainLoop:
 				// continue normal execution
 			}
 		} else { // Not using QPS
+			if useExactly && i >= numCalls {
+				break
+			}
 			select {
 			case <-runnerChan:
 				break MainLoop

--- a/pingsrv.go
+++ b/pingsrv.go
@@ -42,7 +42,6 @@ import (
 // GODEBUG="http2debug=2" GRPC_GO_LOG_VERBOSITY_LEVEL=99 GRPC_GO_LOG_SEVERITY_LEVEL=info grpcping -loglevel debug
 
 var (
-	countFlag     = flag.Int("n", 1, "how many ping(s) the client will send")
 	doHealthFlag  = flag.Bool("health", false, "client mode: use health instead of ping")
 	healthSvcFlag = flag.String("healthservice", "", "which service string to pass to health check")
 	payloadFlag   = flag.String("payload", "", "Payload string to send along")
@@ -154,9 +153,13 @@ func grpcClient() {
 	host := flag.Arg(0)
 	// TODO doesn't work for ipv6 addrs etc
 	dest := fmt.Sprintf("%s:%d", host, *grpcPortFlag)
+	count := int(*exactlyFlag)
+	if count <= 0 {
+		count = 1
+	}
 	if *doHealthFlag {
-		grpcHealthCheck(dest, *healthSvcFlag, *countFlag)
+		grpcHealthCheck(dest, *healthSvcFlag, count)
 	} else {
-		pingClientCall(dest, *countFlag, *payloadFlag)
+		pingClientCall(dest, count, *payloadFlag)
 	}
 }

--- a/ui/static/js/fortio_chart.js
+++ b/ui/static/js/fortio_chart.js
@@ -109,7 +109,7 @@ function makeTitle (res) {
   }
   title.push('Response time histogram at ' + res.RequestedQPS + ' target qps (' +
         myRound(res.ActualQPS, 1) + ' actual) ' + res.NumThreads + ' connections for ' +
-        res.RequestedDuration + ' (actual ' + myRound(res.ActualDuration / 1e9, 1) + 's), ' +
+        res.RequestedDuration + ' (actual time ' + myRound(res.ActualDuration / 1e9, 1) + 's), ' +
         errStr)
   title.push(percStr)
   return title

--- a/ui/templates/main.html
+++ b/ui/templates/main.html
@@ -40,7 +40,8 @@ Title/Labels: <input type="text" name="labels" size="40" value="Fortio" /> (empt
 URL: <input type="text" name="url" size="80" value="http://localhost:{{.Port}}/echo?delay=250us:30%,5ms:5%&status=503:0.5%,429:1.5%" /> <br />
 QPS: <input type="text" name="qps" size="6" value="1000" />
 Duration: <input id="duration" type="text" name="t" size="6" value="3s" />
-or run until interrupted: <input type="checkbox" name="t" onchange="toggleDuration(this)" /><br />
+or run until interrupted: <input type="checkbox" name="t" onchange="toggleDuration(this)" />
+or run for exactly <input type="text" name="n" size="6" value="" /> calls. <br />
 Threads/Simultaneous connections: <input type="text" name="c" size="6" value="8" /> <br />
 Percentiles: <input type="text" name="p" size="20" value="50, 75, 99, 99.9" /> <br />
 Histogram Resolution: <input type="text" name="r" size="8" value="0.0001" /> <br />


### PR DESCRIPTION
Fixes #75
If you set RunnerOptions.Exactly to any number that exact number of
calls will be made, and without additional warmup - it will still try
to reach the target QPS but if the service is slower it will take the
time it will take

On the command line this mode is selected using “-n num”
(The replaces/extends the grpc ping count flag)