### PR TITLE
Converts -redirect-port flag to a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ and flags are:
     	Resolution of the histogram lowest buckets in seconds (default 0.001)
   -redirect-port string
     	Redirect all incoming traffic to https URL (need ingress to work properly).
-    	Can take the form of host:port, ip:port, port or disabled to disable the feature.
-    	(default 8081)
+    	Can take the form of host:port, ip:port, port or "disabled" to disable
+    	the feature. (default 8081)
   -static-dir string
     	Absolute path to the dir containing the static files dir
   -stdclient

--- a/README.md
+++ b/README.md
@@ -120,9 +120,10 @@ and flags are:
     	Quiet mode: sets the loglevel to Error and reduces the output.
   -r float
     	Resolution of the histogram lowest buckets in seconds (default 0.001)
-  -redirect-port int
-    	Redirect all incoming traffic to https URL (need ingress to work properly)
-    	-1 means off. (default 8081)
+  -redirect-port string
+    	Redirect all incoming traffic to https URL (need ingress to work properly).
+    	Can take the form of host:port, ip:port, port or disabled to disable the feature.
+    	(default 8081)
   -static-dir string
     	Absolute path to the dir containing the static files dir
   -stdclient

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -104,8 +104,8 @@ var (
 
 	allowInitialErrorsFlag = flag.Bool("allow-initial-errors", false, "Allow and don't abort on initial warmup errors")
 	autoSaveFlag           = flag.Bool("a", false, "Automatically save JSON result with filename based on labels & timestamp")
-	redirectFlag           = flag.Int("redirect-port", 8081,
-		"Redirect all incoming traffic to https URL (need ingress to work properly). -1 means off.")
+	redirectFlag           = flag.String("redirect-port", "8081", "Redirect all incoming traffic to https URL"+
+		" (need ingress to work properly). Can be in the form of host:port, ip:port, port or disabled to disable the feature.")
 	exactlyFlag = flag.Int64("n", 0,
 		"Run for exactly this number of calls instead of duration. Default (0) is to use duration (-t). "+
 			"Default is 1 when used as grpc ping count.")
@@ -155,12 +155,12 @@ func main() {
 	case "redirect":
 		ui.RedirectToHTTPS(*redirectFlag)
 	case "report":
-		if *redirectFlag >= 0 {
+		if *redirectFlag != "disabled" {
 			go ui.RedirectToHTTPS(*redirectFlag)
 		}
 		ui.Report(baseURL, *echoPortFlag, *staticDirFlag, *dataDirFlag)
 	case "server":
-		if *redirectFlag >= 0 {
+		if *redirectFlag != "disabled" {
 			go ui.RedirectToHTTPS(*redirectFlag)
 		}
 		go ui.Serve(baseURL, *echoPortFlag, *echoDbgPathFlag, *uiPathFlag, *staticDirFlag, *dataDirFlag)

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -105,7 +105,7 @@ var (
 	allowInitialErrorsFlag = flag.Bool("allow-initial-errors", false, "Allow and don't abort on initial warmup errors")
 	autoSaveFlag           = flag.Bool("a", false, "Automatically save JSON result with filename based on labels & timestamp")
 	redirectFlag           = flag.String("redirect-port", "8081", "Redirect all incoming traffic to https URL"+
-		" (need ingress to work properly). Can be in the form of host:port, ip:port, port or disabled to disable the feature.")
+		" (need ingress to work properly). Can be in the form of host:port, ip:port, port or \"disabled\" to disable the feature.")
 	exactlyFlag = flag.Int64("n", 0,
 		"Run for exactly this number of calls instead of duration. Default (0) is to use duration (-t). "+
 			"Default is 1 when used as grpc ping count.")

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -938,11 +938,11 @@ func RedirectToHTTPSHandler(w http.ResponseWriter, r *http.Request) {
 
 // RedirectToHTTPS Sets up a redirector to https on the given port.
 // (Do not create a loop, make sure this is addressed from an ingress)
-func RedirectToHTTPS(port int) {
+func RedirectToHTTPS(port string) {
 	m := http.NewServeMux()
 	m.HandleFunc("/", RedirectToHTTPSHandler)
 	s := &http.Server{
-		Addr:    fmt.Sprintf(":%d", port),
+		Addr:    fnet.NormalizePort(port),
 		Handler: m,
 	}
 	fmt.Printf("Https redirector running on %v\n", s.Addr)


### PR DESCRIPTION
Previously, the `-redirect-port` flag was an int and therefore could not take `ip/host:port` for binding the service to a specific address. This PR converts the flag to a string in support of this requirement. In doing so, the value to disable the redirector (`-1`), was changed to a string named `disabled`.

Fixes https://github.com/istio/fortio/issues/122