### PR TITLE
Fixing panic bug when first chunk size is not in read buffer

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,6 +4,8 @@
 # for detailed Gopkg.toml documentation.
 #
 
+# DO NOT ADD MORE DEPENDENCIES TO FORTIO
+
 [[constraint]]
   name = "github.com/golang/protobuf"
   version = "1.0.0"

--- a/fhttp/http.go
+++ b/fhttp/http.go
@@ -713,6 +713,11 @@ func (c *BasicClient) readResponse(conn *net.TCPConn) {
 							chunkedMode = true
 							var dataStart int
 							dataStart, contentLength = ParseChunkSize(c.buffer[c.headerLen:c.size])
+							if contentLength == -1 {
+								// chunk length not available yet
+								log.LogVf("chunk mode but no first chunk length yet, reading more")
+								continue
+							}
 							max = c.headerLen + dataStart + contentLength + 2 // extra CR LF
 							log.Debugf("chunk-length is %d (%s) setting max to %d",
 								contentLength, c.buffer[c.headerLen:c.headerLen+dataStart-2],

--- a/fhttp/http.go
+++ b/fhttp/http.go
@@ -716,6 +716,7 @@ func (c *BasicClient) readResponse(conn *net.TCPConn) {
 							if contentLength == -1 {
 								// chunk length not available yet
 								log.LogVf("chunk mode but no first chunk length yet, reading more")
+								max = c.headerLen
 								continue
 							}
 							max = c.headerLen + dataStart + contentLength + 2 // extra CR LF

--- a/fhttp/http_loglevel_test.go
+++ b/fhttp/http_loglevel_test.go
@@ -28,4 +28,5 @@ import (
 func TestDebugMode(t *testing.T) {
 	log.SetLogLevel(log.Debug)
 	TestHTTPRunner(t)
+	TestNoFirstChunkSizeInitially(t)
 }


### PR DESCRIPTION
Fixes #127
Fixes https://github.com/istio/istio/issues/3585

Manual tested by cutting a http response just after headers in o1 and
rest in o2:
(cat /tmp/o1; sleep 10; cat /tmp/o2) | nc -v -l 8085

fortio curl -loglevel debug http://127.0.0.1:8085/ > /tmp/f

Without fix == crash, with fix
08:31:27 D http.go:486> ParseChunkSize()
08:31:27 V http.go:718> chunk mode but no chunk length yet, reading more