### PR TITLE
Fixes -H flag panic

### DIFF
--- a/Webtest.sh
+++ b/Webtest.sh
@@ -44,4 +44,7 @@ docker exec fortio_server /usr/local/bin/fortio load -stdclient -qps 1 -t 2s -c 
 docker exec fortio_server /usr/local/bin/fortio load -qps 1 -t 2s -c 2 http://www.google.com/
 # Do a grpcping
 docker exec fortio_server /usr/local/bin/fortio grpcping localhost
+# Test extra headers (-H) flag
+docker exec fortio_server /usr/local/bin/fortio load -H Foo:Bar -curl http://www.google.com
+docker exec fortio_server /usr/local/bin/fortio curl -H Foo:Bar -H Baz:Zab -curl http://www.google.com
 # TODO: check report mode

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -41,11 +41,17 @@ var httpOpts fhttp.HTTPOptions
 type flagList struct {
 }
 
-// Unclear when/why this is called and necessary
+// String is the method to format the flag's value, part of the flag.Value interface.
+// The String method's output will be used in diagnostics.
 func (f *flagList) String() string {
 	return ""
 }
+
+// Set is the method to set the flag value, part of the flag.Value interface.
+// Set's argument is a string to be parsed to set the flag.
+// It's a comma-separated list, so we split it.
 func (f *flagList) Set(value string) error {
+	httpOpts.Init(value)
 	return httpOpts.AddAndValidateExtraHeader(value)
 }
 


### PR DESCRIPTION
Updates headers flag to initialize the `httpOpts`. Also updates `Webtest.sh` script to inlcude `-H` tests to avoid future issues with the flag. Fixes Issue: https://github.com/istio/fortio/issues/148