### PR TITLE
Fix #143 : sort the headers alphabetically for `fortio server` /debug endpoint

### DIFF
--- a/fhttp/http.go
+++ b/fhttp/http.go
@@ -35,6 +35,8 @@ import (
 	// get /debug/pprof endpoints on default server - make sure report only doesn't have it
 	_ "net/http/pprof"
 
+	"sort"
+
 	"istio.io/fortio/fnet"
 	"istio.io/fortio/log"
 	"istio.io/fortio/stats"
@@ -1232,11 +1234,18 @@ func DebugHandler(w http.ResponseWriter, r *http.Request) {
 	// Host is removed from headers map and put here (!)
 	buf.WriteString("Host: ")
 	buf.WriteString(r.Host)
-	for name, headers := range r.Header {
+
+	var keys []string
+	for k := range r.Header {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, name := range keys {
 		buf.WriteByte('\n')
 		buf.WriteString(name)
 		buf.WriteString(": ")
 		first := true
+		headers := r.Header[name]
 		for _, h := range headers {
 			if !first {
 				buf.WriteByte(',')

--- a/fhttp/http.go
+++ b/fhttp/http.go
@@ -27,6 +27,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -34,8 +35,6 @@ import (
 	"unicode/utf8"
 	// get /debug/pprof endpoints on default server - make sure report only doesn't have it
 	_ "net/http/pprof"
-
-	"sort"
 
 	"istio.io/fortio/fnet"
 	"istio.io/fortio/log"


### PR DESCRIPTION
fixes #143 