### PR TITLE
Change the long version to space separated + port 0 fixes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -91,6 +91,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b87fa2e8b347c2db684f38a5bdaa0874d1eff8c7210f75aafc4cce9b8cd4ea08"
+  inputs-digest = "609bfbdf38285567deed0838cd25fb06e5c090268c34b50f2da0873547106580"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 coverage:
   range: 60..99
-  precision: 1         # how many decimal places to display in the UI: 0 <= value <= 4
-  round: nearest       # how coverage is rounded: down/up/nearest
+  precision: 0         # how many decimal places to display in the UI: 0 <= value <= 4
+  round: up       # how coverage is rounded: down/up/nearest
   ignore:          # files and folders that will be removed during processing
     - "**.pb.go"

--- a/fhttp/http.go
+++ b/fhttp/http.go
@@ -1130,6 +1130,7 @@ func closingServer(listener net.Listener) error {
 // DynamicHTTPServer listens on an available port, sets up an http or https
 // (when secure is true) server on it and returns the listening port and
 // mux to which one can attach handlers to.
+// TODO: merge/refactor/share with Serve()
 func DynamicHTTPServer(secure bool) (int, *http.ServeMux) {
 	m := http.NewServeMux()
 	s := &http.Server{
@@ -1276,16 +1277,18 @@ func DebugHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // Serve starts a debug / echo http server on the given port.
-// Returns the port that opened for listing socket
-func Serve(port, debugPath string) int {
+// Returns the addr where the listening socket is bound.
+// The .Port can be retrived from it when requesting the 0 port as
+// input for dynamic http server.
+func Serve(port, debugPath string) *net.TCPAddr {
 	startTime = time.Now()
 	nPort := fnet.NormalizePort(port)
 	listener, err := net.Listen("tcp", nPort)
 	if err != nil {
 		log.Fatalf("Error occurred while listening %v: %v", nPort, err)
 	}
-	portValue := listener.Addr().(*net.TCPAddr).Port
-	fmt.Printf("Fortio %s echo server listening on port %d\n", version.Short(), portValue)
+	addr := listener.Addr().(*net.TCPAddr)
+	fmt.Printf("Fortio %s echo server listening on %s\n", version.Short(), addr.String())
 	go func() {
 		if debugPath != "" {
 			http.HandleFunc(debugPath, DebugHandler)
@@ -1295,5 +1298,5 @@ func Serve(port, debugPath string) int {
 			fmt.Println("Error starting server", err)
 		}
 	}()
-	return portValue
+	return addr
 }

--- a/fhttp/http.go
+++ b/fhttp/http.go
@@ -1278,7 +1278,7 @@ func DebugHandler(w http.ResponseWriter, r *http.Request) {
 
 // Serve starts a debug / echo http server on the given port.
 // Returns the addr where the listening socket is bound.
-// The .Port can be retrived from it when requesting the 0 port as
+// The .Port can be retrieved from it when requesting the 0 port as
 // input for dynamic http server.
 func Serve(port, debugPath string) *net.TCPAddr {
 	startTime = time.Now()

--- a/fhttp/httprunner_test.go
+++ b/fhttp/httprunner_test.go
@@ -114,8 +114,9 @@ func TestHTTPRunnerBadServer(t *testing.T) {
 // the error test for / url above fail:
 
 func TestServe(t *testing.T) {
-	port := Serve("0", "/debugx1")
-	log.Infof("Using port: %d", port)
+	addr := Serve("0", "/debugx1")
+	port := addr.Port
+	log.Infof("On addr %s found port: %d", addr, port)
 	url := fmt.Sprintf("http://localhost:%d/debugx1?env=dump", port)
 	if port == 0 {
 		t.Errorf("outport: %d must be different", port)

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -961,13 +961,14 @@ func RedirectToHTTPS(port string) {
 // setHostAndPort takes hostport in the form of hostname:port, ip:port or :port,
 // sets the urlHostPort variable and returns hostport unmodified.
 func setHostAndPort(inputPort string, addr *net.TCPAddr) {
-	if strings.HasPrefix(inputPort, ":") {
-		urlHostPort = "localhost" + inputPort
-		return
-	}
 	urlHostPort = inputPort
+	portStr := inputPort
 	if addr != nil {
 		urlHostPort = addr.String()
+		portStr = fmt.Sprintf(":%d", addr.Port)
 	}
-	return
+	if strings.HasPrefix(inputPort, ":") {
+		urlHostPort = "localhost" + portStr
+		return
+	}
 }

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -969,6 +969,5 @@ func setHostAndPort(inputPort string, addr *net.TCPAddr) {
 	}
 	if strings.HasPrefix(inputPort, ":") {
 		urlHostPort = "localhost" + portStr
-		return
 	}
 }

--- a/version/version.go
+++ b/version/version.go
@@ -30,7 +30,7 @@ const (
 
 var (
 	// The following are set by Dockerfile during link time:
-	tag       = "pre"
+	tag       = "n/a"
 	buildInfo = "unknown"
 	// Number of lines in git status --porcelain; 0 means clean
 	gitstatus = "0" // buildInfo default is unknown so no need to add -dirty
@@ -39,29 +39,34 @@ var (
 	longVersion = ""
 )
 
-// Major returns the numerical major version number (first digit of Version()).
+// Major returns the numerical major version number (first digit of version.Short()).
 func Major() int {
 	return major
 }
 
-// Minor returns the numerical minor version number (second digit of Version()).
+// Minor returns the numerical minor version number (second digit of version.Short()).
 func Minor() int {
 	return minor
 }
 
-// Patch returns the numerical patch level (third digit of Version()).
+// Patch returns the numerical patch level (third digit of version.Short()).
 func Patch() int {
 	return patch
 }
 
-// Short returns the 3 digit short version string Major.Minor.Patch[-build]
+// Short returns the 3 digit short version string Major.Minor.Patch[-pre]
 // version.Short() is the overall project version (used to version json
-// output too).
+// output too). "-pre" is added when the version doesn't match exactly
+// a git tag or the build isn't from a clean source tree. (only standard
+// dockerfile based build of a clean, tagged source tree should print "X.Y.Z"
+// as short version).
 func Short() string {
 	return version
 }
 
 // Long returns the full version and build information.
+// Format is "X.Y.X[-pre] YYYY-MM-DD HH:MM SHA[-dirty]" date and time is
+// the build date (UTC), sha is the git sha of the source tree.
 func Long() string {
 	return longVersion
 }

--- a/version/version.go
+++ b/version/version.go
@@ -83,5 +83,5 @@ func init() {
 		buildInfo += "-dirty"
 		log.Debugf("gitstatus is %q, marking buildinfo as dirty: %v", gitstatus, buildInfo)
 	}
-	longVersion = version + "-" + buildInfo
+	longVersion = version + " " + buildInfo
 }


### PR DESCRIPTION
```
$ docker run istio/fortio:webtest version
0.7.2-pre 2018-02-24 14:14 48d91e285fa8d1c6baf7e8bf741ea8a36bbe2fdf
```

also fixes UI URL printout for port 0 (#110)

```
ldemailly-macbookpro:fortio ldemailly$ fortio server --http-port :0
Https redirector running on :8081
Fortio 0.7.2-pre grpc ping server listening on port :8079
Fortio 0.7.2-pre echo server listening on [::]:57063
UI starting - visit:
http://localhost:57063/fortio/
^C
ldemailly-macbookpro:fortio ldemailly$ fortio server --http-port [::1]:0
Https redirector running on :8081
Fortio 0.7.2-pre grpc ping server listening on port :8079
Fortio 0.7.2-pre echo server listening on [::1]:57068
UI starting - visit:
http://[::1]:57068/fortio/
^C
ldemailly-macbookpro:fortio ldemailly$ fortio server --http-port
192.168.1.90:blp5
Https redirector running on :8081
Fortio 0.7.2-pre grpc ping server listening on port :8079
Fortio 0.7.2-pre echo server listening on 192.168.1.90:48129
UI starting - visit:
http://192.168.1.90:48129/fortio/
```

And also: extra test for #83 (all stats bucket boundaries)