### PR TITLE
Multiple improvements/fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: istio/fortio.build:v5
+      - image: istio/fortio.build:v6
     working_directory: /go/src/istio.io/fortio
     steps:
       - setup_remote_docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM istio/fortio.build:v5 as build
+FROM istio/fortio.build:v6 as build
 WORKDIR /go/src/istio.io
 COPY . fortio
 # Submodule handling
@@ -8,12 +8,16 @@ RUN make -C fortio submodule
 RUN echo "$(date +'%Y-%m-%d %H:%M') $(cd fortio; git rev-parse HEAD)" > /build-info.txt
 # Sets up the static directory outside of the go source tree and
 # the default data directory to a /var/lib/... volume
+RUN go version
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags \
   "-s -X istio.io/fortio/ui.resourcesDir=/usr/local/lib/fortio -X main.defaultDataDir=/var/lib/istio/fortio \
   -X \"istio.io/fortio/version.buildInfo=$(cat /build-info.txt)\" \
   -X istio.io/fortio/version.tag=$(cd fortio; git describe --tags) \
   -X istio.io/fortio/version.gitstatus=$(cd fortio; git status --porcelain | wc -l)" \
   -o fortio.bin istio.io/fortio
+# Check we still build with go 1.8 (and macos does not break)
+RUN /usr/local/go/bin/go version
+RUN CGO_ENABLED=0 GOOS=darwin /usr/local/go/bin/go build -a -ldflags -s -o fortio.go18.mac istio.io/fortio
 # Just check it stays compiling on Windows (would need to set the rsrcDir too)
 RUN CGO_ENABLED=0 GOOS=windows go build -a -o fortio.exe istio.io/fortio
 # Minimal image with just the binary and certs

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -5,12 +5,18 @@ RUN apt-get -y update && \
   apt-get --no-install-recommends -y upgrade && \
   apt-get --no-install-recommends -y install ca-certificates curl make git gcc \
   libc6-dev apt-transport-https ssh
-# Stay on go1.8 so we don't become incompatible with 1.8
-RUN curl https://storage.googleapis.com/golang/go1.8.7.linux-amd64.tar.gz | tar xfz - -C /usr/local
+# Install both go1.10 and go1.8 so we don't become incompatible with 1.8
+RUN curl -f https://storage.googleapis.com/golang/go1.8.7.linux-amd64.tar.gz | tar xfz - -C /usr/local
+RUN mkdir /go1.10
+RUN curl -f https://dl.google.com/go/go1.10.linux-amd64.tar.gz | tar xfz - -C /go1.10
 ENV GOPATH /go
-ENV PATH /usr/local/go/bin:$PATH:$GOPATH/bin
+RUN mkdir -p $GOPATH/bin
+ENV PATH /go1.10/go/bin:/usr/local/go/bin:$PATH:$GOPATH/bin
 # This is now handled through dep and vendor submodule
 # RUN go get -u google.golang.org/grpc
+# Install dep
+RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+# Install meta linters
 RUN go get -u github.com/alecthomas/gometalinter
 RUN gometalinter -i -u
 WORKDIR /go/src/istio.io

--- a/Dockerfile.echosrv
+++ b/Dockerfile.echosrv
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM istio/fortio.build:v5 as build
+FROM istio/fortio.build:v6 as build
 WORKDIR /go/src/istio.io
 COPY . fortio
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-s' -o echosrv.bin istio.io/fortio/echosrv

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,5 @@
 # Getting the source tree ready for running tests (sut)
-FROM istio/fortio.build:v5
+FROM istio/fortio.build:v6
 WORKDIR /go/src/istio.io
 RUN go get google.golang.org/grpc
 COPY . fortio

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,5 @@
 # Getting the source tree ready for running tests (sut)
 FROM istio/fortio.build:v6
 WORKDIR /go/src/istio.io
-RUN go get google.golang.org/grpc
 COPY . fortio
+RUN make submodule-sync

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -2,4 +2,3 @@
 FROM istio/fortio.build:v6
 WORKDIR /go/src/istio.io
 COPY . fortio
-RUN make submodule-sync

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 IMAGES=echosrv # plus the combo image / Dockerfile without ext.
 
 DOCKER_PREFIX := docker.io/istio/fortio
-BUILD_IMAGE_TAG := v5
+BUILD_IMAGE_TAG := v6
 BUILD_IMAGE := istio/fortio.build:$(BUILD_IMAGE_TAG)
 
 TAG:=$(USER)$(shell date +%y%m%d_%H%M%S)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docker run istio/fortio load http://www.google.com/ # For a test run
 Or download the binary distribution, for instance:
 
 ```shell
-curl -L https://github.com/istio/fortio/releases/download/v0.7.2/fortio-linux_x64-0.7.2.tgz \
+curl -L https://github.com/istio/fortio/releases/download/v0.7.3/fortio-linux_x64-0.7.3.tgz \
  | sudo tar -C / -xvzpf -
 ```
 
@@ -42,7 +42,7 @@ You can get a preview of the reporting/graphing UI at https://fortio.istio.io/
 Fortio can be an http or grpc load generator, gathering statistics using the `load` subcommand, or start simple http and grpc ping servers, as well as a basic web UI, result graphing and https redirector, with the `server` command or issue grpc ping messages using the `grpcping` command. It can also fetch a single URL's for debugging when using the `curl` command (or the `-curl` flag to the load command). You can run just the redirector with `redirect`. Lastly if you saved JSON results (using the web UI or directly from the command line), you can browse and graph those results using the `report` command.
 
 ```
-Φορτίο 0.7.2 usage:
+Φορτίο 0.7.3 usage:
 	fortio command [flags] target
 where command is one of: load (load testing), server (starts grpc ping and
 http echo/ui/redirect servers), grpcping (grpc client), report (report only UI
@@ -153,8 +153,8 @@ $ fortio server &
 Https redirector running on :8081
 UI starting - visit:
 http://localhost:8080/fortio/   (or any host/ip reachable on this server)
-Fortio 0.7.2 grpc ping server listening on port :8079
-Fortio 0.7.2 echo server listening on port :8080
+Fortio 0.7.3 grpc ping server listening on port :8079
+Fortio 0.7.3 echo server listening on port :8080
 ```
 
 * By default, Fortio's web/echo servers listen on port 8080 on all interfaces.
@@ -164,8 +164,8 @@ $ fortio server -http-port 10.10.10.10:8088
 UI starting - visit:
 http://10.10.10.10:8088/fortio/
 Https redirector running on :8081
-Fortio 0.7.2 grpc ping server listening on port :8079
-Fortio 0.7.2 echo server listening on port 10.10.10.10:8088
+Fortio 0.7.3 grpc ping server listening on port :8079
+Fortio 0.7.3 echo server listening on port 10.10.10.10:8088
 ```
 * Simple grpc ping:
 ```
@@ -235,14 +235,14 @@ Content-Type: text/plain; charset=UTF-8
 Date: Mon, 08 Jan 2018 22:26:26 GMT
 Content-Length: 230
 
-Φορτίο version 0.7.2 echo debug server up for 39s on ldemailly-macbookpro - request from [::1]:65055
+Φορτίο version 0.7.3 echo debug server up for 39s on ldemailly-macbookpro - request from [::1]:65055
 
 GET /debug HTTP/1.1
 
 headers:
 
 Host: localhost:8080
-User-Agent: istio/fortio-0.7.2
+User-Agent: istio/fortio-0.7.3
 Foo: Bar
 
 body:
@@ -271,6 +271,7 @@ For instance `curl -d abcdef http://localhost:8080/` returns `abcdef` back. It s
 | delay     | duration to delay the response by. Can be a single value or a coma separated list of probabilities, e.g `delay=150us:10,2ms:5,0.5s:1` for 10% of chance of a 150 us delay, 5% of a 2ms delay and 1% of a 1/2 second delay |
 | status    | http status to return instead of 200. Can be a single value or a coma separated list of probabilities, e.g `status=404:10,503:5,429:1` for 10% of chance of a 404 status, 5% of a 503 status and 1% of a 429 status |
 | size      | size of the payload to reply instead of echoing input. Also works as probabilities list. `size=1024:10,512:5` 10% of response will be 1k and 5% will be 512 bytes payload and the rest defaults to echoing back. |
+| close     | close the socket after answering e.g `close=true` |
 - `/debug` will echo back the request in plain text for human debugging.
 - `/fortio/` A UI to
   - Run/Trigger tests and graph the results.

--- a/fgrpc/grpcrunner.go
+++ b/fgrpc/grpcrunner.go
@@ -99,7 +99,7 @@ func RunGRPCTest(o *GRPCRunnerOptions) (*GRPCRunnerResults, error) {
 		RetCodes: make(map[grpc_health_v1.HealthCheckResponse_ServingStatus]int64),
 	}
 	grpcstate := make([]GRPCRunnerResults, numThreads)
-
+	out := r.Options().Out // Important as the default value is set from nil to stdout inside NewPeriodicRunner
 	for i := 0; i < numThreads; i++ {
 		r.Options().Runners[i] = &grpcstate[i]
 		conn, err := Dial(o.Destination, o.Secure)
@@ -157,7 +157,7 @@ func RunGRPCTest(o *GRPCRunnerOptions) (*GRPCRunnerResults, error) {
 		}
 	}
 	for _, k := range keys {
-		fmt.Printf("Health %s : %d\n", k.String(), total.RetCodes[k])
+		fmt.Fprintf(out, "Health %s : %d\n", k.String(), total.RetCodes[k])
 	}
 	return &total, nil
 }

--- a/fhttp/http.go
+++ b/fhttp/http.go
@@ -618,7 +618,7 @@ func (c *FastClient) connect() *net.TCPConn {
 
 // Extra error codes outside of the HTTP Status code ranges. ie negative.
 const (
-	// SocketError is return when a transport error occured: unexpected EOF, connection error, etc...
+	// SocketError is return when a transport error occurred: unexpected EOF, connection error, etc...
 	SocketError = -1
 	// RetryOnce is used internally as an error code to allow 1 retry for bad socket reuse.
 	RetryOnce = -2

--- a/fhttp/http.go
+++ b/fhttp/http.go
@@ -1113,6 +1113,9 @@ func EchoHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	if r.FormValue("close") != "" {
+		w.Header().Set("Connection", "close")
+	}
 	size := generateSize(r.FormValue("size"))
 	if size >= 0 {
 		log.Errf("Writing %d size with %d status", size, status)

--- a/fhttp/http.go
+++ b/fhttp/http.go
@@ -710,7 +710,7 @@ func (c *FastClient) readResponse(conn *net.TCPConn, reusedSocket bool) {
 					c.errorCount++
 					err = conn.Close() // close the previous one
 					if err != nil {
-						log.Warnf("Error closing dead socket %v", *conn)
+						log.Warnf("Error closing dead socket %v: %v", *conn, err)
 					}
 					c.code = -2 // special "retry once" code
 					return

--- a/fhttp/http.go
+++ b/fhttp/http.go
@@ -1136,7 +1136,7 @@ func EchoHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	size := generateSize(r.FormValue("size"))
 	if size >= 0 {
-		log.Errf("Writing %d size with %d status", size, status)
+		log.LogVf("Writing %d size with %d status", size, status)
 		writePayload(w, status, size)
 		return
 	}

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -1,5 +1,5 @@
 # Concatenated after ../Dockerfile to create the tgz
-FROM istio/fortio.build:v5 as stage
+FROM istio/fortio.build:v6 as stage
 WORKDIR /stage
 COPY --from=release /usr/local usr/local
 RUN mkdir -p var/lib/istio/fortio

--- a/ui/templates/browse.html
+++ b/ui/templates/browse.html
@@ -37,7 +37,7 @@ function fortio_load(url) {
       data = fortioResultToJsChartData(res)
       showChart(data)
       var urldiv = document.getElementById('url')
-      urldiv.innerHTML = "<a href='browse?url=" + url + "'>" + url + "</a>"
+      urldiv.innerHTML = "<a href='browse?url=" + url + "'>" + url + "</a> (<a href='data/" + url +"'>json</a>)"
     }).catch(err => { throw err })
   } else {
     var urldiv = document.getElementById('url')
@@ -128,5 +128,6 @@ for (var i = 0; i < files.options.length; i++) {
 fortio_load(files.value)
 </script>
 {{end}}
+<p>Go to <a href='./'>Top</a>.</p>
 </body>
 </html>

--- a/ui/templates/main.html
+++ b/ui/templates/main.html
@@ -52,9 +52,10 @@ Headers: <br />
 {{end}}{{end}} <!-- 2 extra header lines, TODO: add a JS 'more headers' button -->
 <input type="text" name="H" size=40 value="" /> <br />
 <input type="text" name="H" size=40 value="" /> <br />
-http: <input type="radio" name="runner" value="http" checked/>,
-grpc: <input type="radio" name="runner" value="grpc"/><br/>
-Use secure transport (tls) for GRPC <input type="checkbox" name="grpc-secure"/><br/>
+Use standard go client instead of fastclient <input type="checkbox" name="stdclient"/> <br />
+Load using http: <input type="radio" name="runner" value="http" checked/> or
+grpc: <input type="radio" name="runner" value="grpc"/>
+(grpc secure transport (tls): <input type="checkbox" name="grpc-secure"/>) <br />
 JSON output: <input type="checkbox" name="json" />,
 Save output: <input type="checkbox" name="save" checked /> <br />
 <input type="submit" name="load" value="Start"/>

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -322,8 +322,9 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			log.Fatalf("Unable to json serialize result: %v", err)
 		}
 		savedAs := ""
+		id := res.Result().ID()
 		if DoSave {
-			savedAs = SaveJSON(res.Result().ID(), json)
+			savedAs = SaveJSON(id, json)
 		}
 		if JSONOnly {
 			w.Header().Set("Content-Type", "application/json")
@@ -335,7 +336,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		}
 		if savedAs != "" {
 			// nolint: errcheck, gas
-			w.Write([]byte(fmt.Sprintf("Saved result to <a href='%s'>%s</a>\n", savedAs, savedAs)))
+			w.Write([]byte(fmt.Sprintf("Saved result to <a href='%s'>%s</a>"+
+				" (<a href='browse?url=%s.json' target='_new'>graph link</a>)\n", savedAs, savedAs, id)))
 		}
 		// nolint: errcheck, gas
 		w.Write([]byte(fmt.Sprintf("All done %d calls %.3f ms avg, %.1f qps\n</pre>\n<script>\n",
@@ -343,7 +345,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			1000.*res.Result().DurationHistogram.Avg,
 			res.Result().ActualQPS)))
 		ResultToJsData(w, json)
-		w.Write([]byte("</script></body></html>\n")) // nolint: gas
+		w.Write([]byte("</script><p>Go to <a href='./'>Top</a>.</p></body></html>\n")) // nolint: gas
 	}
 }
 

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -166,6 +166,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	qps, _ := strconv.ParseFloat(r.FormValue("qps"), 64)      // nolint: gas
 	durStr := r.FormValue("t")
 	grpcSecure := (r.FormValue("grpc-secure") == "on")
+	stdClient := (r.FormValue("stdclient") == "on")
 	var dur time.Duration
 	if durStr == "on" || ((len(r.Form["t"]) > 1) && r.Form["t"][1] == "on") {
 		dur = -1
@@ -209,6 +210,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		log.Infof("New run id %d", runid)
 	}
 	httpopts := fhttp.NewHTTPOptions(url)
+	httpopts.DisableFastClient = stdClient
 	if !JSONOnly {
 		// Normal html mode
 		if mainTemplate == nil {


### PR DESCRIPTION
- add both link to UI and Json data from run results and browse UI And a back to top link

- Fix #172 (error logged when using -H)

- Initial version of #170  &close option for echo server

- Build with both go1.8 and 1.10; put 1.10 binaries in docker images/release

- Add StdClient option for the web UI runs

- Misc cleanups to front page (grpc secure option)

- Add socket use cout (#165)

- don't consider early EOF or other an error (fix 50% errors for some call client closes - like /fortio/fetch/ does)

- Reminder of fix for #168 show grpc result codes in UI/text