### PR TITLE
Switch CI badge to match style of other badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Go Report Card](https://goreportcard.com/badge/istio.io/fortio)](https://goreportcard.com/report/istio.io/fortio)
 [![GoDoc](https://godoc.org/istio.io/fortio?status.svg)](https://godoc.org/istio.io/fortio)
 [![codecov](https://codecov.io/gh/istio/fortio/branch/master/graph/badge.svg)](https://codecov.io/gh/istio/fortio)
-[![CircleCI](https://circleci.com/gh/istio/fortio.svg?style=svg)](https://circleci.com/gh/istio/fortio)
+[![CircleCI](https://circleci.com/gh/istio/fortio.svg?style=shield)](https://circleci.com/gh/istio/fortio)
 
 # Φορτίο
 <img src="https://github.com/istio/fortio/blob/master/docs/fortio-logo-color.png" height=141 width=141 align=right>


### PR DESCRIPTION
Switches the badge style to make the same style (shield) as the other readme badges.

[skip ci] is used since this is a readme fix and doesn't affect any code whatsoever.