### PR TITLE
Grpc cleanup and improve grpc test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ TAG:=$(USER)$(shell date +%y%m%d_%H%M%S)
 DOCKER_TAG = $(DOCKER_PREFIX)$(IMAGE):$(TAG)
 
 # go test ./... and others run in vendor/ and cause problems (!)
-PACKAGES:=$(shell find . -type d -print | egrep -v "/(\.|vendor|static|templates|release|docs)")
+PACKAGES:=$(shell find . -type d -print | egrep -v "/(\.|vendor|static|templates|release|docs|json)")
 #PACKAGES:=$(shell go list ./... | grep -v vendor)
 
 # Marker for whether vendor submodule is here or not already
@@ -29,17 +29,18 @@ install: submodule
 test: submodule
 	go test -timeout 60s -race $(PACKAGES)
 
-# To debug linters, uncomment
-#DEBUG_LINTERS="--debug"
+# To debug strange linter errors, uncomment
+# DEBUG_LINTERS="--debug"
 
 local-lint: submodule
 	gometalinter $(DEBUG_LINTERS) \
 	--deadline=180s --enable-all --aggregate \
-	--exclude=.pb.go --disable=gocyclo --line-length=132 $(LINT_PACKAGES)
+	--exclude=.pb.go --disable=gocyclo --disable=gas --line-length=132 \
+	$(LINT_PACKAGES)
 
 # Lint everything by default but ok to "make lint LINT_PACKAGES=./fhttp"
 LINT_PACKAGES:=$(PACKAGES)
-# TODO: do something about cyclomatic complexity
+# TODO: do something about cyclomatic complexity; maybe reenable gas
 # Note CGO_ENABLED=0 is needed to avoid errors as gcc isn't part of the
 # build image
 lint: submodule vendor.check

--- a/fgrpc/grpcrunner.go
+++ b/fgrpc/grpcrunner.go
@@ -85,10 +85,11 @@ func (grpcstate *GRPCRunnerResults) Run(t int) {
 // options.
 type GRPCRunnerOptions struct {
 	periodic.RunnerOptions
-	Destination string
-	Service     string
-	Profiler    string // file to save profiles to. defaults to no profiling
-	Secure      bool   // use tls transport
+	Destination        string
+	Service            string
+	Profiler           string // file to save profiles to. defaults to no profiling
+	Secure             bool   // use tls transport
+	AllowInitialErrors bool   // whether initial errors don't cause an abort
 }
 
 // RunGRPCTest runs an http test and returns the aggregated stats.
@@ -117,7 +118,7 @@ func RunGRPCTest(o *GRPCRunnerOptions) (*GRPCRunnerResults, error) {
 		grpcstate[i].req = grpc_health_v1.HealthCheckRequest{Service: o.Service}
 		if o.Exactly <= 0 {
 			_, err = grpcstate[i].client.Check(context.Background(), &grpcstate[i].req)
-			if err != nil {
+			if !o.AllowInitialErrors && err != nil {
 				log.Errf("Error in first grpc health check call for %s %v", o.Destination, err)
 				return nil, err
 			}

--- a/fgrpc/grpcrunner_test.go
+++ b/fgrpc/grpcrunner_test.go
@@ -21,37 +21,17 @@ package fgrpc
 
 import (
 	"fmt"
-	"net"
 	"testing"
 
-	"istio.io/fortio/fnet"
 	"istio.io/fortio/log"
 	"istio.io/fortio/periodic"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
-// DynamicGRPCHealthServer starts and returns the port where a GRPC Health
-// server is running. It runs until error or program exit (separate go routine)
-func DynamicGRPCHealthServer() int {
-	listener, addr := fnet.Listen("grpc health", ":0")
-	grpcServer := grpc.NewServer()
-	healthServer := health.NewServer()
-	healthServer.SetServingStatus("ping", grpc_health_v1.HealthCheckResponse_SERVING)
-	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
-	go func(socket net.Listener) {
-		if e := grpcServer.Serve(socket); e != nil {
-			log.Fatalf("failed to start grpc server: %v", e)
-		}
-	}(listener)
-	return addr.Port
-}
-
 func TestGRPCRunner(t *testing.T) {
 	log.SetLogLevel(log.Info)
-	port := DynamicGRPCHealthServer()
+	port := PingServer("0", "bar")
 	destination := fmt.Sprintf("localhost:%d", port)
 
 	opts := GRPCRunnerOptions{

--- a/fgrpc/grpcrunner_test.go
+++ b/fgrpc/grpcrunner_test.go
@@ -68,12 +68,12 @@ func TestGRPCRunnerWithError(t *testing.T) {
 		Destination: destination,
 		Service:     "svc2",
 	}
-	res, err := RunGRPCTest(&opts)
+	_, err := RunGRPCTest(&opts)
 	if err == nil {
 		t.Error("Was expecting initial error when connecting to secure without AllowInitialErrors")
 	}
 	opts.AllowInitialErrors = true
-	res, err = RunGRPCTest(&opts)
+	res, err := RunGRPCTest(&opts)
 	if err != nil {
 		t.Error(err)
 		return

--- a/fgrpc/pingsrv.go
+++ b/fgrpc/pingsrv.go
@@ -70,7 +70,7 @@ func PingServer(port string, healthServiceName string) int {
 // PingClientCall calls the ping service (presumably running as PingServer on
 // the destination).
 func PingClientCall(serverAddr string, tls bool, n int, payload string) (float64, error) {
-	conn, err := Dial(serverAddr, tls)
+	conn, err := Dial(serverAddr, tls) // somehow this never seem to error out, error comes later
 	if err != nil {
 		return -1, err // error already logged
 	}

--- a/fgrpc/pingsrv_test.go
+++ b/fgrpc/pingsrv_test.go
@@ -32,7 +32,10 @@ func TestPingServer(t *testing.T) {
 	addr := fmt.Sprintf("localhost:%d", port)
 	t.Logf("test grpc ping server running, will connect to %s", addr)
 	if latency, err := PingClientCall(addr, false, 7, "test payload"); err != nil || latency <= 0 {
-		t.Errorf("Unexpected result %+v, %v with ping calls", latency, err)
+		t.Errorf("Unexpected result %f, %v with ping calls", latency, err)
+	}
+	if latency, err := PingClientCall(addr, true, 1, ""); err == nil {
+		t.Errorf("Should have had an error instead of result %f for secure ping to insecure port", latency)
 	}
 	serving := grpc_health_v1.HealthCheckResponse_SERVING
 	if r, err := GrpcHealthCheck(addr, false, "", 1); err != nil || (*r)[serving] != 1 {

--- a/fgrpc/pingsrv_test.go
+++ b/fgrpc/pingsrv_test.go
@@ -1,0 +1,47 @@
+// Copyright 2017 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package fgrpc
+
+import (
+	"fmt"
+	"testing"
+
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"istio.io/fortio/log"
+)
+
+func init() {
+	log.SetLogLevel(log.Debug)
+}
+
+func TestPingServer(t *testing.T) {
+	port := PingServer("0", "foo")
+	addr := fmt.Sprintf("localhost:%d", port)
+	t.Logf("test grpc ping server running, will connect to %s", addr)
+	if latency, err := PingClientCall(addr, false, 7, "test payload"); err != nil || latency <= 0 {
+		t.Errorf("Unexpected result %+v, %v with ping calls", latency, err)
+	}
+	serving := grpc_health_v1.HealthCheckResponse_SERVING
+	if r, err := GrpcHealthCheck(addr, false, "", 1); err != nil || (*r)[serving] != 1 {
+		t.Errorf("Unexpected result %+v, %v with empty service health check", r, err)
+	}
+	if r, err := GrpcHealthCheck(addr, false, "foo", 3); err != nil || (*r)[serving] != 3 {
+		t.Errorf("Unexpected result %+v, %v with health check for same service as started (foo)", r, err)
+	}
+	if r, err := GrpcHealthCheck(addr, false, "willfail", 1); err == nil || r != nil {
+		t.Errorf("Was expecting error when using unknown service, didn't get one, got %+v", r)
+	}
+}

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -272,10 +272,11 @@ func fortioLoad(justCurl bool, percList []float64) {
 	var err error
 	if *grpcFlag {
 		o := fgrpc.GRPCRunnerOptions{
-			RunnerOptions: ro,
-			Destination:   url,
-			Secure:        *grpcSecureFlag,
-			Service:       *healthSvcFlag,
+			RunnerOptions:      ro,
+			Destination:        url,
+			Secure:             *grpcSecureFlag,
+			Service:            *healthSvcFlag,
+			AllowInitialErrors: *allowInitialErrorsFlag,
 		}
 		res, err = fgrpc.RunGRPCTest(&o)
 	} else {


### PR DESCRIPTION
so the grpc ping and health clients can be used as a library / from
istio tests (like pilot’s)

return errors instead of log fatal

Fixes #196

Dropped gas as linter