### PR TITLE
Trims any trailing slashes in grpcDest func

### DIFF
--- a/fgrpc/grpcrunner.go
+++ b/fgrpc/grpcrunner.go
@@ -264,36 +264,21 @@ func grpcDestination(dest string) (parsedDest string) {
 		parsedDest = dest
 		port = DefaultGRPCPort
 	}
-	host, sPort, err := net.SplitHostPort(parsedDest)
-	// parsedDest is in the form of host:port or ip:port
-	if err == nil {
-		if ip := net.ParseIP(host); ip != nil {
-			switch {
-			case ip.To4() != nil:
-				parsedDest = ip.String() + fnet.NormalizePort(sPort)
-				return parsedDest
-			case ip.To16() != nil:
-				parsedDest = "[" + ip.String() + "]" + fnet.NormalizePort(sPort)
-				return parsedDest
-			}
-		}
-		parsedDest = strings.TrimSuffix(host, "/") + fnet.NormalizePort(sPort)
+	if _, _, err := net.SplitHostPort(parsedDest); err == nil {
 		return parsedDest
 	}
-	ip := net.ParseIP(parsedDest)
-	if ip != nil {
-		// parsedDest is in the form of an IP address
+	if ip := net.ParseIP(parsedDest); ip != nil {
 		switch {
 		case ip.To4() != nil:
 			parsedDest = ip.String() + fnet.NormalizePort(port)
 			return parsedDest
 		case ip.To16() != nil:
 			parsedDest = "[" + ip.String() + "]" + fnet.NormalizePort(port)
+			return parsedDest
 		}
-	} else {
-		// parsedDest is in the form of a domain name,
-		// append ":port" and return.
-		parsedDest += fnet.NormalizePort(port)
 	}
+	// parsedDest is in the form of a domain name,
+	// append ":port" and return.
+	parsedDest += fnet.NormalizePort(port)
 	return parsedDest
 }

--- a/fgrpc/grpcrunner_test.go
+++ b/fgrpc/grpcrunner_test.go
@@ -181,11 +181,6 @@ func TestGRPCDestination(t *testing.T) {
 			"1.2.3.4:5678",
 		},
 		{
-			"IPv4 address:port with http prefix and trailing /",
-			"http://1.2.3.4/:80",
-			"1.2.3.4:80",
-		},
-		{
 			"IPv6 address",
 			"2001:dba::1",
 			"[2001:dba::1]:8079",
@@ -203,11 +198,6 @@ func TestGRPCDestination(t *testing.T) {
 		{
 			"IPv6 address with https prefix",
 			"https://2001:dba::1",
-			"[2001:dba::1]:443",
-		},
-		{
-			"IPv6 address with https prefix and trailing /",
-			"https://2001:dba::1/",
 			"[2001:dba::1]:443",
 		},
 	}

--- a/fgrpc/grpcrunner_test.go
+++ b/fgrpc/grpcrunner_test.go
@@ -156,8 +156,18 @@ func TestGRPCDestination(t *testing.T) {
 			"localhost:80",
 		},
 		{
+			"Hostname with http prefix and trailing /",
+			"http://localhost/",
+			"localhost:80",
+		},
+		{
 			"Hostname with https prefix",
 			"https://localhost",
+			"localhost:443",
+		},
+		{
+			"Hostname with https prefix and trailing /",
+			"https://localhost/",
 			"localhost:443",
 		},
 		{
@@ -169,6 +179,11 @@ func TestGRPCDestination(t *testing.T) {
 			"IPv4 address and port",
 			"1.2.3.4:5678",
 			"1.2.3.4:5678",
+		},
+		{
+			"IPv4 address:port with http prefix and trailing /",
+			"http://1.2.3.4/:80",
+			"1.2.3.4:80",
 		},
 		{
 			"IPv6 address",
@@ -188,6 +203,11 @@ func TestGRPCDestination(t *testing.T) {
 		{
 			"IPv6 address with https prefix",
 			"https://2001:dba::1",
+			"[2001:dba::1]:443",
+		},
+		{
+			"IPv6 address with https prefix and trailing /",
+			"https://2001:dba::1/",
 			"[2001:dba::1]:443",
 		},
 	}

--- a/fgrpc/grpcrunner_test.go
+++ b/fgrpc/grpcrunner_test.go
@@ -200,6 +200,11 @@ func TestGRPCDestination(t *testing.T) {
 			"https://2001:dba::1",
 			"[2001:dba::1]:443",
 		},
+		{
+			"IPv6 address with https prefix and trailing /",
+			"https://2001:dba::1/",
+			"[2001:dba::1]:443",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Removes a trailing slash ("/") from an IPv4/IPv6 address or hostname in a url provided to the grpcDestination function.

Fixes Issue https://github.com/istio/fortio/issues/226