### PR TITLE
Adds missing test for PR 229

### DIFF
--- a/fgrpc/grpcrunner_test.go
+++ b/fgrpc/grpcrunner_test.go
@@ -181,6 +181,11 @@ func TestGRPCDestination(t *testing.T) {
 			"1.2.3.4:5678",
 		},
 		{
+			"IPv4 address with http prefix and trailing /",
+			"http://1.2.3.4/",
+			"1.2.3.4:80",
+		},
+		{
 			"IPv6 address",
 			"2001:dba::1",
 			"[2001:dba::1]:8079",


### PR DESCRIPTION
https://github.com/istio/fortio/pull/229 is missing a test case for IPv4 with http prefix and trailing slash. This PR adds this test case.