### PR TITLE
Allow disabled for grpc port too to skip without printing an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ docker run istio/fortio load http://www.google.com/ # For a test run
 Or download the binary distribution, for instance:
 
 ```shell
-curl -L https://github.com/istio/fortio/releases/download/v0.9.0/fortio-linux_x64-0.9.0.tgz \
+curl -L https://github.com/istio/fortio/releases/download/v0.9.1/fortio-linux_x64-0.9.1.tgz \
  | sudo tar -C / -xvzpf -
 ```
 
@@ -41,7 +41,7 @@ You can get a preview of the reporting/graphing UI at https://fortio.istio.io/
 Fortio can be an http or grpc load generator, gathering statistics using the `load` subcommand, or start simple http and grpc ping servers, as well as a basic web UI, result graphing and https redirector, with the `server` command or issue grpc ping messages using the `grpcping` command. It can also fetch a single URL's for debugging when using the `curl` command (or the `-curl` flag to the load command). You can run just the redirector with `redirect`. Lastly if you saved JSON results (using the web UI or directly from the command line), you can browse and graph those results using the `report` command.
 <!-- use release/updateFlags.sh to update this section -->
 ```
-Φορτίο 0.9.0 usage:
+Φορτίο 0.9.1 usage:
 	fortio command [flags] target
 where command is one of: load (load testing), server (starts grpc ping and http
 echo/ui/redirect/proxy servers), grpcping (grpc client), report (report only UI
@@ -83,8 +83,8 @@ target is a url (http load tests) or host:port (grpc health test).  flags are:
   -grpc-ping-delay duration
 	grpc ping delay in response
   -grpc-port string
-	grpc server port. Can be in the form of host:port, ip:port or port.
-	(default "8079")
+	grpc server port. Can be in the form of host:port, ip:port or port or
+	"disabled". (default "8079")
   -grpc-secure
 	Use secure transport (tls) for GRPC
   -halfclose
@@ -168,12 +168,12 @@ target is a url (http load tests) or host:port (grpc health test).  flags are:
 * Start the internal servers:
 ```
 $ fortio server &
-Fortio 0.9.0 grpc 'ping' server listening on [::]:8079
-Fortio 0.9.0 https redirector server listening on [::]:8081
-Fortio 0.9.0 echo server listening on [::]:8080
+Fortio 0.9.1 grpc 'ping' server listening on [::]:8079
+Fortio 0.9.1 https redirector server listening on [::]:8081
+Fortio 0.9.1 echo server listening on [::]:8080
 UI started - visit:
 http://localhost:8080/fortio/   (or any host/ip reachable on this server)
-21:45:23 I fortio_main.go:195> All fortio 0.9.0 buildinfo go1.10 servers started!
+21:45:23 I fortio_main.go:195> All fortio 0.9.1 buildinfo go1.10 servers started!
 ```
 
 * By default, Fortio's web/echo servers listen on port 8080 on all interfaces.
@@ -183,8 +183,8 @@ $ fortio server -http-port 10.10.10.10:8088
 UI starting - visit:
 http://10.10.10.10:8088/fortio/
 Https redirector running on :8081
-Fortio 0.9.0 grpc ping server listening on port :8079
-Fortio 0.9.0 echo server listening on port 10.10.10.10:8088
+Fortio 0.9.1 grpc ping server listening on port :8079
+Fortio 0.9.1 echo server listening on port 10.10.10.10:8088
 ```
 * Simple grpc ping:
 ```
@@ -219,7 +219,7 @@ RTT histogram usec : count 3 avg 305.334 +/- 27.22 min 279.517 max 342.97 sum 91
 * Load (low default qps/threading) test:
 ```
 $ fortio load http://www.google.com
-Fortio 0.3.6 running at 8 queries per second, 8->8 procs, for 5s: http://www.google.com
+Fortio 0.9.1 running at 8 queries per second, 8->8 procs, for 5s: http://www.google.com
 19:10:33 I httprunner.go:84> Starting http test for http://www.google.com with 4 threads at 8.0 qps
 Starting at 8 qps with 4 thread(s) [gomax 8] for 5s : 10 calls each (total 40)
 19:10:39 I periodic.go:314> T002 ended after 5.056753279s : 10 calls. qps=1.9775534712220633
@@ -249,7 +249,7 @@ All done 40 calls (plus 4 warmup) 60.588 ms avg, 7.9 qps
 Uses `-s` to use multiple (h2/grpc) streams per connection (`-c`), request to hit the fortio ping grpc endpoint with a delay in replies of 0.25s and an extra payload for 10 bytes and auto save the json result:
 ```bash
 $ fortio load -a -grpc -ping -grpc-ping-delay 0.25s -payload "01234567890" -c 2 -s 4 https://fortio-stage.istio.io
-Fortio 0.9.0 running at 8 queries per second, 8->8 procs, for 5s: https://fortio-stage.istio.io
+Fortio 0.9.1 running at 8 queries per second, 8->8 procs, for 5s: https://fortio-stage.istio.io
 16:32:56 I grpcrunner.go:139> Starting GRPC Ping Delay=250ms PayloadLength=11 test for https://fortio-stage.istio.io with 4*2 threads at 8.0 qps
 16:32:56 I grpcrunner.go:261> stripping https scheme. grpc destination: fortio-stage.istio.io. grpc port: 443
 16:32:57 I grpcrunner.go:261> stripping https scheme. grpc destination: fortio-stage.istio.io. grpc port: 443
@@ -287,7 +287,7 @@ And the JSON saved is
   "ActualQPS": 7.568383075162479,
   "ActualDuration": 5285144740,
   "NumThreads": 8,
-  "Version": "0.9.0",
+  "Version": "0.9.1",
   "DurationHistogram": {
     "Count": 40,
     "Min": 0.2741372,
@@ -346,14 +346,14 @@ Content-Type: text/plain; charset=UTF-8
 Date: Mon, 08 Jan 2018 22:26:26 GMT
 Content-Length: 230
 
-Φορτίο version 0.9.0 echo debug server up for 39s on ldemailly-macbookpro - request from [::1]:65055
+Φορτίο version 0.9.1 echo debug server up for 39s on ldemailly-macbookpro - request from [::1]:65055
 
 GET /debug HTTP/1.1
 
 headers:
 
 Host: localhost:8080
-User-Agent: istio/fortio-0.9.0
+User-Agent: istio/fortio-0.9.1
 Foo: Bar
 
 body:

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -82,7 +82,7 @@ var (
 	httpsInsecureFlag = flag.Bool("https-insecure", false, "Long form of the -k flag")
 	echoPortFlag      = flag.String("http-port", "8080", "http echo server port. Can be in the form of host:port, ip:port or port.")
 	grpcPortFlag      = flag.String("grpc-port", fgrpc.DefaultGRPCPort,
-		"grpc server port. Can be in the form of host:port, ip:port or port.")
+		"grpc server port. Can be in the form of host:port, ip:port or port or \"disabled\".")
 	echoDbgPathFlag = flag.String("echo-debug-path", "/debug",
 		"http echo server URI for debug, empty turns off that part (more secure)")
 	jsonFlag = flag.String("json", "",
@@ -169,7 +169,9 @@ func main() {
 		}
 	case "server":
 		isServer = true
-		fgrpc.PingServer(*grpcPortFlag, fgrpc.DefaultHealthServiceName, uint32(*maxStreamsFlag))
+		if *grpcPortFlag != "disabled" {
+			fgrpc.PingServer(*grpcPortFlag, fgrpc.DefaultHealthServiceName, uint32(*maxStreamsFlag))
+		}
 		if *redirectFlag != "disabled" {
 			fhttp.RedirectToHTTPS(*redirectFlag)
 		}

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -67,6 +67,10 @@ func usage(msgs ...interface{}) {
 // Attention: every flag that is common to http client goes to bincommon/
 // for sharing between fortio and fcurl binaries
 
+const (
+	disabled = "disabled"
+)
+
 var (
 	defaults = &periodic.DefaultRunnerOptions
 	// Very small default so people just trying with random URLs don't affect the target
@@ -82,7 +86,7 @@ var (
 	httpsInsecureFlag = flag.Bool("https-insecure", false, "Long form of the -k flag")
 	echoPortFlag      = flag.String("http-port", "8080", "http echo server port. Can be in the form of host:port, ip:port or port.")
 	grpcPortFlag      = flag.String("grpc-port", fgrpc.DefaultGRPCPort,
-		"grpc server port. Can be in the form of host:port, ip:port or port or \"disabled\".")
+		"grpc server port. Can be in the form of host:port, ip:port or port or \""+disabled+"\" to not start the grpc server.")
 	echoDbgPathFlag = flag.String("echo-debug-path", "/debug",
 		"http echo server URI for debug, empty turns off that part (more secure)")
 	jsonFlag = flag.String("json", "",
@@ -102,7 +106,7 @@ var (
 	abortOnFlag            = flag.Int("abort-on", 0, "Http code that if encountered aborts the run. e.g. 503 or -1 for socket errors.")
 	autoSaveFlag           = flag.Bool("a", false, "Automatically save JSON result with filename based on labels & timestamp")
 	redirectFlag           = flag.String("redirect-port", "8081", "Redirect all incoming traffic to https URL"+
-		" (need ingress to work properly). Can be in the form of host:port, ip:port, port or \"disabled\" to disable the feature.")
+		" (need ingress to work properly). Can be in the form of host:port, ip:port, port or \""+disabled+"\" to disable the feature.")
 	exactlyFlag = flag.Int64("n", 0,
 		"Run for exactly this number of calls instead of duration. Default (0) is to use duration (-t). "+
 			"Default is 1 when used as grpc ping count.")
@@ -161,7 +165,7 @@ func main() {
 		fhttp.RedirectToHTTPS(*redirectFlag)
 	case "report":
 		isServer = true
-		if *redirectFlag != "disabled" {
+		if *redirectFlag != disabled {
 			fhttp.RedirectToHTTPS(*redirectFlag)
 		}
 		if !ui.Report(baseURL, *echoPortFlag, *staticDirFlag, *dataDirFlag) {
@@ -169,10 +173,10 @@ func main() {
 		}
 	case "server":
 		isServer = true
-		if *grpcPortFlag != "disabled" {
+		if *grpcPortFlag != disabled {
 			fgrpc.PingServer(*grpcPortFlag, fgrpc.DefaultHealthServiceName, uint32(*maxStreamsFlag))
 		}
-		if *redirectFlag != "disabled" {
+		if *redirectFlag != disabled {
 			fhttp.RedirectToHTTPS(*redirectFlag)
 		}
 		if !ui.Serve(baseURL, *echoPortFlag, *echoDbgPathFlag, *uiPathFlag, *staticDirFlag, *dataDirFlag, percList) {


### PR DESCRIPTION
So this works without spurious output:
```
$ fortio server --quiet --redirect-port "disabled" --grpc-port "disabled" -http-port 0 -ui-path "" | awk '{print $7}'
[::]:64474
```

Manually tested