### PR TITLE
Add overlay chart if selecting two saved results

### DIFF
--- a/ui/static/js/fortio_chart.js
+++ b/ui/static/js/fortio_chart.js
@@ -400,7 +400,25 @@ function setChartOptions (chart) {
   }
 }
 
-function updateChart (chart) {
+function objHasProps (obj) {
+  return Object.keys(obj).length > 0
+}
+
+function getCurrentChart () {
+  var currentChart
+  if (objHasProps(chart)) {
+    currentChart = chart
+  } else if (objHasProps(overlayChart)) {
+    currentChart = overlayChart
+  } else if (objHasProps(mchart)) {
+    currentChart = mchart
+  } else {
+    currentChart = undefined
+  }
+  return currentChart
+}
+
+function updateChart (chart = getCurrentChart()) {
   setChartOptions(chart)
   chart.update()
 }

--- a/ui/static/js/fortio_chart.js
+++ b/ui/static/js/fortio_chart.js
@@ -67,6 +67,7 @@ var logYAxe = {
 }
 
 var chart = {}
+var overlayChart = {}
 var mchart = {}
 
 function myRound (v, digits = 6) {
@@ -189,13 +190,6 @@ function fortioResultToJsChartData (res) {
 
 function showChart (data) {
   toggleVisibility()
-  var isCurrentlyOverlayChart =
-      chart && chart.data && chart.data.datasets &&
-      chart.data.datasets.length > 2
-  // Reset the chart's data if previously showing overlay chart
-  if (isCurrentlyOverlayChart) {
-    deleteSingleChart()
-  }
   makeChart(data)
 }
 
@@ -219,9 +213,14 @@ function makeOverlayChartTitle (titleA, titleB) {
 function makeOverlayChart (dataA, dataB) {
   var chartEl = document.getElementById('chart1')
   chartEl.style.visibility = 'visible'
+  if (Object.keys(overlayChart).length !== 0) {
+    return
+  }
+  deleteSingleChart()
+  deleteMultiChart()
   var ctx = chartEl.getContext('2d')
   var title = makeOverlayChartTitle(dataA.title, dataB.title)
-  chart = new Chart(ctx, {
+  overlayChart = new Chart(ctx, {
     type: 'line',
     data: {
       // "Cumulative %" datasets are listed first so they are drawn on top of the histograms.
@@ -292,13 +291,14 @@ function makeOverlayChart (dataA, dataB) {
       }
     }
   })
-  updateChart()
+  updateChart(overlayChart)
 }
 
 function makeChart (data) {
   var chartEl = document.getElementById('chart1')
   chartEl.style.visibility = 'visible'
   if (Object.keys(chart).length === 0) {
+    deleteOverlayChart()
     deleteMultiChart()
       // Creation (first or switch) time
     var ctx = chartEl.getContext('2d')
@@ -361,11 +361,11 @@ function makeChart (data) {
     chart.data.datasets[0].data = data.dataP
     chart.data.datasets[1].data = data.dataH
     chart.options.title.text = data.title
-    updateChart()
+    updateChart(chart)
   }
 }
 
-function setChartOptions () {
+function setChartOptions (chart) {
   var form = document.getElementById('updtForm')
   var formMin = form.xmin.value.trim()
   var formMax = form.xmax.value.trim()
@@ -402,8 +402,8 @@ function setChartOptions () {
   }
 }
 
-function updateChart () {
-  setChartOptions()
+function updateChart (chart) {
+  setChartOptions(chart)
   chart.update()
 }
 
@@ -454,6 +454,14 @@ function endMultiChart (len) {
   mchart.update()
 }
 
+function deleteOverlayChart () {
+  if (Object.keys(overlayChart).length === 0) {
+    return
+  }
+  overlayChart.destroy()
+  overlayChart = {}
+}
+
 function deleteMultiChart () {
   if (Object.keys(mchart).length === 0) {
     return
@@ -479,6 +487,7 @@ function makeMultiChart () {
     return
   }
   deleteSingleChart()
+  deleteOverlayChart()
   var ctx = chartEl.getContext('2d')
   mchart = new Chart(ctx, {
     type: 'line',

--- a/ui/static/js/fortio_chart.js
+++ b/ui/static/js/fortio_chart.js
@@ -189,7 +189,13 @@ function fortioResultToJsChartData (res) {
 
 function showChart (data) {
   toggleVisibility()
-  deleteSingleChart()
+  var isCurrentlyOverlayChart =
+      chart && chart.data && chart.data.datasets &&
+      chart.data.datasets.length > 2
+  // Reset the chart's data if previously showing overlay chart
+  if (isCurrentlyOverlayChart) {
+    deleteSingleChart()
+  }
   makeChart(data)
 }
 

--- a/ui/static/js/fortio_chart.js
+++ b/ui/static/js/fortio_chart.js
@@ -202,11 +202,9 @@ function toggleVisibility () {
 function makeOverlayChartTitle (titleA, titleB) {
   // Each string in the array is a separate line
   return [
-    'A',
-    ...titleA,
+    'A: ' + titleA[0], titleA[1], // Skip 3rd line.
     '',
-    'B',
-    ...titleB
+    'B: ' + titleB[0], titleB[1], // Skip 3rd line.
   ]
 }
 

--- a/ui/static/js/fortio_chart.js
+++ b/ui/static/js/fortio_chart.js
@@ -189,6 +189,7 @@ function fortioResultToJsChartData (res) {
 
 function showChart (data) {
   toggleVisibility()
+  deleteSingleChart()
   makeChart(data)
 }
 
@@ -196,6 +197,84 @@ function toggleVisibility () {
   document.getElementById('running').style.display = 'none'
   document.getElementById('cc1').style.display = 'block'
   document.getElementById('update').style.visibility = 'visible'
+}
+
+function makeOverlayChart (dataA, dataB) {
+  var chartEl = document.getElementById('chart1')
+  chartEl.style.visibility = 'visible'
+  var ctx = chartEl.getContext('2d')
+  chart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      // "Cumulative %" datasets are listed first so they are drawn on top of the histograms.
+      datasets: [{
+        label: 'A: Cumulative %',
+        data: dataA.dataP,
+        fill: false,
+        yAxisID: 'P',
+        stepped: true,
+        backgroundColor: 'rgba(134, 87, 167, 1)',
+        borderColor: 'rgba(134, 87, 167, 1)',
+        cubicInterpolationMode: 'monotone'
+      }, {
+        label: 'B: Cumulative %',
+        data: dataB.dataP,
+        fill: false,
+        yAxisID: 'P',
+        stepped: true,
+        backgroundColor: 'rgba(204, 102, 0)',
+        borderColor: 'rgba(204, 102, 0)',
+        cubicInterpolationMode: 'monotone'
+      }, {
+        label: 'A: Histogram: Count',
+        data: dataA.dataH,
+        yAxisID: 'H',
+        pointStyle: 'rect',
+        radius: 1,
+        borderColor: 'rgba(87, 167, 134, .9)',
+        backgroundColor: 'rgba(87, 167, 134, .75)',
+        lineTension: 0
+      }, {
+        label: 'B: Histogram: Count',
+        data: dataB.dataH,
+        yAxisID: 'H',
+        pointStyle: 'rect',
+        radius: 1,
+        borderColor: 'rgba(36, 64, 238, .9)',
+        backgroundColor: 'rgba(36, 64, 238, .75)',
+        lineTension: 0
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      title: {
+        display: true,
+        fontStyle: 'normal',
+        text: data.title
+      },
+      scales: {
+        xAxes: [
+          linearXAxe
+        ],
+        yAxes: [{
+          id: 'P',
+          position: 'right',
+          ticks: {
+            beginAtZero: true,
+            max: 100
+          },
+          scaleLabel: {
+            display: true,
+            labelString: '%'
+          }
+        },
+          linearYAxe
+        ]
+      }
+    }
+  })
+  updateChart()
 }
 
 function makeChart (data) {

--- a/ui/static/js/fortio_chart.js
+++ b/ui/static/js/fortio_chart.js
@@ -205,10 +205,22 @@ function toggleVisibility () {
   document.getElementById('update').style.visibility = 'visible'
 }
 
+function makeOverlayChartTitle (titleA, titleB) {
+  // Each string in the array is a separate line
+  return [
+    'A',
+    ...titleA,
+    '',
+    'B',
+    ...titleB
+  ]
+}
+
 function makeOverlayChart (dataA, dataB) {
   var chartEl = document.getElementById('chart1')
   chartEl.style.visibility = 'visible'
   var ctx = chartEl.getContext('2d')
+  var title = makeOverlayChartTitle(dataA.title, dataB.title)
   chart = new Chart(ctx, {
     type: 'line',
     data: {
@@ -257,7 +269,7 @@ function makeOverlayChart (dataA, dataB) {
       title: {
         display: true,
         fontStyle: 'normal',
-        text: data.title
+        text: title
       },
       scales: {
         xAxes: [

--- a/ui/templates/browse.html
+++ b/ui/templates/browse.html
@@ -42,19 +42,37 @@ function fortio_load(url) {
   } else {
     var urldiv = document.getElementById('url')
     urldiv.innerHTML = "Multiple runs..."
-    makeMultiChart()
-    var promises = []
-    for (var i = 0, len = list.length; i < len; i++) {
-      var v = list[len-i-1].value;
-      (function (idx, u) {
-        promises.push(fetch("data/"+u).then(doc => doc.json()).then((out) => {
-          fortioAddToMultiResult(idx, out)
-        }))
-      })(i, v)
+    if (list.length == 2) {
+      var urlA = list[0].value
+      var dataPromiseA = fetch("data/"+urlA)
+          .then(response => response.json())
+          .then(fortioResult => fortioResultToJsChartData(fortioResult))
+
+      var urlB = list[1].value
+      var dataPromiseB = fetch("data/"+urlB)
+          .then(response => response.json())
+          .then(fortioResult => fortioResultToJsChartData(fortioResult))
+
+      Promise.all([dataPromiseA, dataPromiseB]).then(dataArray => {
+        var dataA = dataArray[0]
+        var dataB = dataArray[1]
+        makeOverlayChart(dataA, dataB)
+      })
+    } else {
+      makeMultiChart()
+      var promises = []
+      for (var i = 0, len = list.length; i < len; i++) {
+        var v = list[len-i-1].value;
+        (function (idx, u) {
+          promises.push(fetch("data/"+u).then(doc => doc.json()).then((out) => {
+            fortioAddToMultiResult(idx, out)
+          }))
+        })(i, v)
+      }
+      Promise.all(promises).then( () => {
+        endMultiChart(list.length)
+      }).catch(err => { throw err })
     }
-    Promise.all(promises).then( () => {
-      endMultiChart(list.length)
-    }).catch(err => { throw err })
   }
 }
 </script>


### PR DESCRIPTION
Resolves #180.

When two items are selected from the saved results, the chart displays 4 datasets, with one saved result's 2 datasets overlayed on top of the other result's 2 datasets.

This introduces a weird bug in which the chart sometimes temporarily stops displaying one of the two saved results. It is rather inconsistent to reproduce, but clicking to hide and show datasets often triggers the bug. I'm not sure if this bug lies in my code or in Chart.js