### PR TITLE
Adding periodic sync every `-sync-interval`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ docker run istio/fortio load http://www.google.com/ # For a test run
 Or download the binary distribution, for instance:
 
 ```shell
-curl -L https://github.com/istio/fortio/releases/download/v0.10.0/fortio-linux_x64-0.10.0.tgz \
+curl -L https://github.com/istio/fortio/releases/download/v0.10.1/fortio-linux_x64-0.10.1.tgz \
  | sudo tar -C / -xvzpf -
 ```
 
@@ -41,7 +41,7 @@ You can get a preview of the reporting/graphing UI at https://fortio.istio.io/
 Fortio can be an http or grpc load generator, gathering statistics using the `load` subcommand, or start simple http and grpc ping servers, as well as a basic web UI, result graphing and https redirector, with the `server` command or issue grpc ping messages using the `grpcping` command. It can also fetch a single URL's for debugging when using the `curl` command (or the `-curl` flag to the load command). You can run just the redirector with `redirect`. Lastly if you saved JSON results (using the web UI or directly from the command line), you can browse and graph those results using the `report` command.
 <!-- use release/updateFlags.sh to update this section -->
 ```
-Φορτίο 0.10.0 usage:
+Φορτίο 0.10.1 usage:
 	fortio command [flags] target
 where command is one of: load (load testing), server (starts grpc ping and http
 echo/ui/redirect/proxy servers), grpcping (grpc client), report (report only UI
@@ -154,6 +154,8 @@ target is a url (http load tests) or host:port (grpc health test).  flags are:
 	Use the slower net/http standard client (works for TLS)
   -sync string
 	index.tsv or s3/gcs bucket xml URL to fetch at startup for server modes.
+  -sync-interval duration
+	Refresh the url every given interval (default, no refresh)
   -t duration
 	How long to run the test or 0 to run until ^C (default 5s)
   -timeout duration
@@ -168,12 +170,12 @@ target is a url (http load tests) or host:port (grpc health test).  flags are:
 * Start the internal servers:
 ```
 $ fortio server &
-Fortio 0.10.0 grpc 'ping' server listening on [::]:8079
-Fortio 0.10.0 https redirector server listening on [::]:8081
-Fortio 0.10.0 echo server listening on [::]:8080
+Fortio 0.10.1 grpc 'ping' server listening on [::]:8079
+Fortio 0.10.1 https redirector server listening on [::]:8081
+Fortio 0.10.1 echo server listening on [::]:8080
 UI started - visit:
 http://localhost:8080/fortio/   (or any host/ip reachable on this server)
-21:45:23 I fortio_main.go:195> All fortio 0.10.0 buildinfo go1.10 servers started!
+21:45:23 I fortio_main.go:195> All fortio 0.10.1 buildinfo go1.10 servers started!
 ```
 
 * By default, Fortio's web/echo servers listen on port 8080 on all interfaces.
@@ -183,8 +185,8 @@ $ fortio server -http-port 10.10.10.10:8088
 UI starting - visit:
 http://10.10.10.10:8088/fortio/
 Https redirector running on :8081
-Fortio 0.10.0 grpc ping server listening on port :8079
-Fortio 0.10.0 echo server listening on port 10.10.10.10:8088
+Fortio 0.10.1 grpc ping server listening on port :8079
+Fortio 0.10.1 echo server listening on port 10.10.10.10:8088
 ```
 * Simple grpc ping:
 ```
@@ -219,7 +221,7 @@ RTT histogram usec : count 3 avg 305.334 +/- 27.22 min 279.517 max 342.97 sum 91
 * Load (low default qps/threading) test:
 ```
 $ fortio load http://www.google.com
-Fortio 0.10.0 running at 8 queries per second, 8->8 procs, for 5s: http://www.google.com
+Fortio 0.10.1 running at 8 queries per second, 8->8 procs, for 5s: http://www.google.com
 19:10:33 I httprunner.go:84> Starting http test for http://www.google.com with 4 threads at 8.0 qps
 Starting at 8 qps with 4 thread(s) [gomax 8] for 5s : 10 calls each (total 40)
 19:10:39 I periodic.go:314> T002 ended after 5.056753279s : 10 calls. qps=1.9775534712220633
@@ -249,7 +251,7 @@ All done 40 calls (plus 4 warmup) 60.588 ms avg, 7.9 qps
 Uses `-s` to use multiple (h2/grpc) streams per connection (`-c`), request to hit the fortio ping grpc endpoint with a delay in replies of 0.25s and an extra payload for 10 bytes and auto save the json result:
 ```bash
 $ fortio load -a -grpc -ping -grpc-ping-delay 0.25s -payload "01234567890" -c 2 -s 4 https://fortio-stage.istio.io
-Fortio 0.10.0 running at 8 queries per second, 8->8 procs, for 5s: https://fortio-stage.istio.io
+Fortio 0.10.1 running at 8 queries per second, 8->8 procs, for 5s: https://fortio-stage.istio.io
 16:32:56 I grpcrunner.go:139> Starting GRPC Ping Delay=250ms PayloadLength=11 test for https://fortio-stage.istio.io with 4*2 threads at 8.0 qps
 16:32:56 I grpcrunner.go:261> stripping https scheme. grpc destination: fortio-stage.istio.io. grpc port: 443
 16:32:57 I grpcrunner.go:261> stripping https scheme. grpc destination: fortio-stage.istio.io. grpc port: 443
@@ -287,7 +289,7 @@ And the JSON saved is
   "ActualQPS": 7.568383075162479,
   "ActualDuration": 5285144740,
   "NumThreads": 8,
-  "Version": "0.10.0",
+  "Version": "0.10.1",
   "DurationHistogram": {
     "Count": 40,
     "Min": 0.2741372,
@@ -346,14 +348,14 @@ Content-Type: text/plain; charset=UTF-8
 Date: Mon, 08 Jan 2018 22:26:26 GMT
 Content-Length: 230
 
-Φορτίο version 0.10.0 echo debug server up for 39s on ldemailly-macbookpro - request from [::1]:65055
+Φορτίο version 0.10.1 echo debug server up for 39s on ldemailly-macbookpro - request from [::1]:65055
 
 GET /debug HTTP/1.1
 
 headers:
 
 Host: localhost:8080
-User-Agent: istio/fortio-0.10.0
+User-Agent: istio/fortio-0.10.1
 Foo: Bar
 
 body:

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -24,6 +24,7 @@ import (
 	"path"
 	"runtime"
 	"strings"
+	"time"
 
 	"istio.io/fortio/bincommon"
 	"istio.io/fortio/fnet"
@@ -110,7 +111,9 @@ var (
 	exactlyFlag = flag.Int64("n", 0,
 		"Run for exactly this number of calls instead of duration. Default (0) is to use duration (-t). "+
 			"Default is 1 when used as grpc ping count.")
-	syncFlag    = flag.String("sync", "", "index.tsv or s3/gcs bucket xml URL to fetch at startup for server modes.")
+	syncFlag         = flag.String("sync", "", "index.tsv or s3/gcs bucket xml URL to fetch at startup for server modes.")
+	syncIntervalFlag = flag.Duration("sync-interval", 0, "Refresh the url every given interval (default, no refresh)")
+
 	baseURLFlag = flag.String("base-url", "",
 		"base URL used as prefix for data/index.tsv generation. (when empty, the url from the first request is used)")
 	newMaxPayloadSizeKb = flag.Int("maxpayloadsizekb", fhttp.MaxPayloadSize/1024,
@@ -197,7 +200,20 @@ func main() {
 	if isServer {
 		// To get a start time log/timestamp in the logs
 		log.Infof("All fortio %s servers started!", version.Long())
-		select {}
+		d := *syncIntervalFlag
+		if sync != "" && d > 0 {
+			log.Infof("Will re-sync data dir every %s", d)
+			ticker := time.NewTicker(d)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					ui.Sync(os.Stdout, sync, *dataDirFlag)
+				}
+			}
+		} else {
+			select {}
+		}
 	}
 }
 

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -205,11 +205,8 @@ func main() {
 			log.Infof("Will re-sync data dir every %s", d)
 			ticker := time.NewTicker(d)
 			defer ticker.Stop()
-			for {
-				select {
-				case <-ticker.C:
-					ui.Sync(os.Stdout, sync, *dataDirFlag)
-				}
+			for range ticker.C {
+				ui.Sync(os.Stdout, sync, *dataDirFlag)
 			}
 		} else {
 			select {}

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -256,7 +256,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 				i++
 			}
 			uiRunMapMutex.Unlock()
-			log.Infof("Interrupted %d runs", i)
+			log.Infof("Interrupted all %d runs", i)
 		} else { // Stop one
 			uiRunMapMutex.Lock()
 			v, found := runs[runid]
@@ -343,6 +343,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			res.Result().ActualQPS)))
 		ResultToJsData(w, json)
 		w.Write([]byte("</script><p>Go to <a href='./'>Top</a>.</p></body></html>\n")) // nolint: gas
+		delete(runs, runid)
 	}
 }
 


### PR DESCRIPTION
Fixes  #233

Also fixed bug in interrupt all / leak of runner options for UI runs

Manually tested
go install istio.io/fortio; fortio server -sync
https://fortio.istio.io/data/index.tsv -sync-interval 15s 1> /dev/null

To be added to admin-sites yaml