### PR TITLE
Prep for 1.0; bump go to 1.10.3 (new build image); linter fix; refactor official build; misc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2
 defaultEnv: &defaultEnv
     docker:
       # specify the version
-      - image: istio/fortio.build:v7
+      - image: istio/fortio.build:v8
     working_directory: /go/src/istio.io/fortio
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM istio/fortio.build:v7 as build
+FROM istio/fortio.build:v8 as build
 WORKDIR /go/src/istio.io
 COPY . fortio
 # Submodule handling

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,26 +4,15 @@ WORKDIR /go/src/istio.io
 COPY . fortio
 # Submodule handling
 RUN make -C fortio submodule
-# Putting spaces in linker replaced variables is hard but does work.
-RUN echo "$(date +'%Y-%m-%d %H:%M') $(cd fortio; git rev-parse HEAD)" > /build-info.txt
-# Sets up the static directory outside of the go source tree and
-# the default data directory to a /var/lib/... volume
-# + rest of build time/git/version magic.
-RUN echo "-s -X istio.io/fortio/ui.resourcesDir=/usr/local/lib/fortio -X main.defaultDataDir=/var/lib/istio/fortio \
-  -X \"istio.io/fortio/version.buildInfo=$(cat /build-info.txt)\" \
-  -X istio.io/fortio/version.tag=$(cd fortio; git describe --tags --match 'v*') \
-  -X istio.io/fortio/version.gitstatus=$(cd fortio; git status --porcelain | wc -l)" | tee /link-flags.txt
-RUN go version
-RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags "$(cat /link-flags.txt)" -o fortio_go1.10.bin istio.io/fortio
-RUN ./fortio_go1.10.bin version
+# We moved a lot of the logic into the Makefile so it can be reused in brew
+# but that also couples the 2, this expects to find binaries in the right place etc
+RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_BIN=../fortio_go1.10.bin
 # Check we still build with go 1.8 (and macos does not break)
-RUN /usr/local/go/bin/go version
-RUN CGO_ENABLED=0 GOOS=darwin /usr/local/go/bin/go build -a -ldflags "$(cat /link-flags.txt)" -o fortio_go1.8.mac istio.io/fortio
-# Build with 1.8 for perf comparison
-#RUN CGO_ENABLED=0 GOOS=linux /usr/local/go/bin/go build -a -ldflags "$(cat /link-flags.txt)" -o fortio_go1.8.bin istio.io/fortio
-#RUN ./fortio_go1.8.bin version
+RUN make -C fortio official-build BUILD_DIR=/build OFFICIAL_BIN=../fortio_go1.8.mac GOOS=darwin GO_BIN=/usr/local/go/bin/go
+# Optionally (comment out) Build with 1.8 for perf comparison
+# RUN make -C fortio official-build-version BUILD_DIR= OFFICIAL_BIN=../fortio_go1.8.bin GO_BIN=/usr/local/go/bin/go
 # Just check it stays compiling on Windows (would need to set the rsrcDir too)
-RUN CGO_ENABLED=0 GOOS=windows go build -a -o fortio.exe istio.io/fortio
+RUN make -C fortio official-build BUILD_DIR=/build OFFICIAL_BIN=../fortio.exe GOOS=windows
 #RUN ln -s /usr/local/bin/fortio_go1.8 /usr/local/bin/fortio
 #RUN tar cvf /tmp/symlink.tar /usr/local/bin/fortio
 # Minimal image with just the binary and certs

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -5,12 +5,12 @@ RUN apt-get -y update && \
   apt-get --no-install-recommends -y upgrade && \
   apt-get --no-install-recommends -y install ca-certificates curl make git gcc \
   libc6-dev apt-transport-https ssh
-# Install both go1.10.1 and go1.8 so we don't become incompatible with 1.8
+# Install both go1.10.3 and go1.8.7 so we don't become incompatible with 1.8
 RUN curl -f https://storage.googleapis.com/golang/go1.8.7.linux-amd64.tar.gz | tar xfz - -C /usr/local
 # Newer go have no problem with being installed in random directories without requiring GOROOT so we
 # leave the old go in /usr/local and put the new one, despite being preferred, in a different root:
 RUN mkdir /go1.10
-RUN curl -f https://dl.google.com/go/go1.10.1.linux-amd64.tar.gz | tar xfz - -C /go1.10
+RUN curl -f https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz | tar xfz - -C /go1.10
 ENV GOPATH /go
 RUN mkdir -p $GOPATH/bin
 # We do pick the latest go first in the path

--- a/Dockerfile.echosrv
+++ b/Dockerfile.echosrv
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM istio/fortio.build:v7 as build
+FROM istio/fortio.build:v8 as build
 WORKDIR /go/src/istio.io
 COPY . fortio
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-s' -o echosrv.bin istio.io/fortio/echosrv

--- a/Dockerfile.fcurl
+++ b/Dockerfile.fcurl
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM istio/fortio.build:v7 as build
+FROM istio/fortio.build:v8 as build
 WORKDIR /go/src/istio.io
 COPY . fortio
 # TODO: share common part with main Dockerfile (have the main Dockerfile build more than 1 image - how?)

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,5 @@
 # Getting the source tree ready for running tests (sut)
-FROM istio/fortio.build:v7
+FROM istio/fortio.build:v8
 WORKDIR /go/src/istio.io
 COPY . fortio
 RUN make -C fortio dependencies

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 IMAGES=echosrv fcurl # plus the combo image / Dockerfile without ext.
 
 DOCKER_PREFIX := docker.io/istio/fortio
-BUILD_IMAGE_TAG := v7
+BUILD_IMAGE_TAG := v8
 BUILD_IMAGE := istio/fortio.build:$(BUILD_IMAGE_TAG)
 
 TAG:=$(USER)$(shell date +%y%m%d_%H%M%S)
@@ -128,8 +128,8 @@ all: test install lint docker-version docker-push-internal
 
 # Makefile should be edited first
 FILES_WITH_IMAGE:= .circleci/config.yml Dockerfile Dockerfile.echosrv \
-	Dockerfile.test Dockerfile.fcurl release/Dockerfile.in /etc/ssl/certs/ca-certificates.crt
-# Ran make update-build-image BUILD_IMAGE_TAG=v1 DOCKER_PREFIX=fortio/fortio
+	Dockerfile.test Dockerfile.fcurl release/Dockerfile.in Webtest.sh
+# than run make update-build-image and diff checked etc see release/README.md
 update-build-image:
 	$(MAKE) docker-push-internal IMAGE=.build TAG=$(BUILD_IMAGE_TAG)
 

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ pull:
 	git pull
 	$(MAKE) submodule-sync
 
-# https://github.com/istio/istio/wiki/Vendor-FAQ#how-do-i-add--change-a-dependency
+# https://github.com/istio/vendor-istio#how-do-i-add--change-a-dependency
 # PS: for fortio no dependencies should be added, only grpc updated.
 depend.status:
 	@echo "No error means your Gopkg.* are in sync and ok with vendor/"
@@ -127,7 +127,9 @@ all: test install lint docker-version docker-push-internal
 		$(MAKE) docker-push-internal IMAGE=.$$img TAG=$(TAG); \
 	done
 
-# Makefile should be edited first
+# When changing the build image, this Makefile should be edited first
+# (bump BUILD_IMAGE_TAG), also change this list if the image is used in
+# more places.
 FILES_WITH_IMAGE:= .circleci/config.yml Dockerfile Dockerfile.echosrv \
 	Dockerfile.test Dockerfile.fcurl release/Dockerfile.in Webtest.sh
 # then run make update-build-image and check the diff, etc... see release/README.md
@@ -161,3 +163,37 @@ authorize:
 .PHONY: install lint install-linters coverage webtest release-test update-build-image
 
 .PHONY: local-lint update-build-image-tag release submodule submodule-sync pull certs certs-clean
+
+# Targets used for official builds (initially from Dockerfile)
+BUILD_DIR := /tmp/fortio_build
+LIB_DIR := /usr/local/lib/fortio
+DATA_DIR := /var/lib/istio/fortio
+OFFICIAL_BIN := ../fortio_go1.10.bin
+GOOS := linux
+GO_BIN := go
+GIT_STATUS := $(strip $(shell git status --porcelain | wc -l))
+GIT_TAG := $(shell git describe --tags --match 'v*')
+
+# Putting spaces in linker replaced variables is hard but does work.
+# This sets up the static directory outside of the go source tree and
+# the default data directory to a /var/lib/... volume
+# + rest of build time/git/version magic.
+
+$(BUILD_DIR)/build-info.txt:
+	-mkdir -p $(BUILD_DIR)
+	echo "$(shell date +'%Y-%m-%d %H:%M') $(shell git rev-parse HEAD)" > $@
+
+$(BUILD_DIR)/link-flags.txt: $(BUILD_DIR)/build-info.txt
+	echo "-s -X istio.io/fortio/ui.resourcesDir=$(LIB_DIR) -X main.defaultDataDir=$(DATA_DIR) \
+  -X \"istio.io/fortio/version.buildInfo=$(shell cat $<)\" \
+  -X istio.io/fortio/version.tag=$(GIT_TAG) \
+  -X istio.io/fortio/version.gitstatus=$(GIT_STATUS)" | tee $@
+
+.PHONY: official-build official-build-version
+
+official-build: $(BUILD_DIR)/link-flags.txt
+	$(GO_BIN) version
+	CGO_ENABLED=0 GOOS=$(GOOS) $(GO_BIN) build -a -ldflags '$(shell cat $(BUILD_DIR)/link-flags.txt)' -o $(OFFICIAL_BIN) istio.io/fortio
+	
+official-build-version: official-build
+	$(OFFICIAL_BIN) version

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ all: test install lint docker-version docker-push-internal
 # Makefile should be edited first
 FILES_WITH_IMAGE:= .circleci/config.yml Dockerfile Dockerfile.echosrv \
 	Dockerfile.test Dockerfile.fcurl release/Dockerfile.in Webtest.sh
-# than run make update-build-image and diff checked etc see release/README.md
+# then run make update-build-image and check the diff, etc... see release/README.md
 update-build-image:
 	$(MAKE) docker-push-internal IMAGE=.build TAG=$(BUILD_IMAGE_TAG)
 

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,9 @@ CERT_TEMP_DIR := ./cert-tmp/
 # go test ./... and others run in vendor/ and cause problems (!)
 # so to avoid `can't load package: package istio.io/fortio/...: no Go files in ...`
 # note that only go1.8 needs the grep -v vendor but we are compatible with 1.8
-PACKAGES:=$(shell go list ./... | grep -v vendor)
-
+# ps: can't use go list (and get packages as canonical istio.io/fortio/x)
+# as somehow that makes gometaliner silently not find/report errors...
+PACKAGES:=$(shell find . -type d -print | egrep -v "/(\.|vendor|tmp|static|templates|release|docs|json|cert-tmp)")
 # Marker for whether vendor submodule is here or not already
 GRPC_DIR:=./vendor/google.golang.org/grpc
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ docker run istio/fortio load http://www.google.com/ # For a test run
 Or download the binary distribution, for instance:
 
 ```shell
-curl -L https://github.com/istio/fortio/releases/download/v0.11.0/fortio-linux_x64-0.11.0.tgz \
+curl -L https://github.com/istio/fortio/releases/download/v1.0.0/fortio-linux_x64-1.0.0.tgz \
  | sudo tar -C / -xvzpf -
 ```
 
@@ -46,7 +46,7 @@ You can get a preview of the reporting/graphing UI at https://fortio.istio.io/
 Fortio can be an http or grpc load generator, gathering statistics using the `load` subcommand, or start simple http and grpc ping servers, as well as a basic web UI, result graphing and https redirector, with the `server` command or issue grpc ping messages using the `grpcping` command. It can also fetch a single URL's for debugging when using the `curl` command (or the `-curl` flag to the load command). You can run just the redirector with `redirect`. Lastly if you saved JSON results (using the web UI or directly from the command line), you can browse and graph those results using the `report` command.
 <!-- use release/updateFlags.sh to update this section -->
 ```
-Φορτίο 0.11.0 usage:
+Φορτίο 1.0.0 usage:
 	fortio command [flags] target
 where command is one of: load (load testing), server (starts grpc ping and http
 echo/ui/redirect/proxy servers), grpcping (grpc client), report (report only UI
@@ -180,12 +180,12 @@ target is a url (http load tests) or host:port (grpc health test).  flags are:
 * Start the internal servers:
 ```
 $ fortio server &
-Fortio 0.11.0 grpc 'ping' server listening on [::]:8079
-Fortio 0.11.0 https redirector server listening on [::]:8081
-Fortio 0.11.0 echo server listening on [::]:8080
+Fortio 1.0.0 grpc 'ping' server listening on [::]:8079
+Fortio 1.0.0 https redirector server listening on [::]:8081
+Fortio 1.0.0 echo server listening on [::]:8080
 UI started - visit:
 http://localhost:8080/fortio/   (or any host/ip reachable on this server)
-21:45:23 I fortio_main.go:195> All fortio 0.11.0 buildinfo go1.10 servers started!
+21:45:23 I fortio_main.go:195> All fortio 1.0.0 buildinfo go1.10 servers started!
 ```
 
 * By default, Fortio's web/echo servers listen on port 8080 on all interfaces.
@@ -195,8 +195,8 @@ $ fortio server -http-port 10.10.10.10:8088
 UI starting - visit:
 http://10.10.10.10:8088/fortio/
 Https redirector running on :8081
-Fortio 0.11.0 grpc ping server listening on port :8079
-Fortio 0.11.0 echo server listening on port 10.10.10.10:8088
+Fortio 1.0.0 grpc ping server listening on port :8079
+Fortio 1.0.0 echo server listening on port 10.10.10.10:8088
 ```
 * Simple grpc ping:
 ```
@@ -236,8 +236,8 @@ $ fortio server -cert /path/to/fortio/server.crt -key /path/to/fortio/server.key
 UI starting - visit:
 http://localhost:8080/fortio/
 Https redirector running on :8081
-Fortio 0.11.0 grpc ping server listening on port :8079
-Fortio 0.11.0 echo server listening on port localhost:8080
+Fortio 1.0.0 grpc ping server listening on port :8079
+Fortio 1.0.0 echo server listening on port localhost:8080
 Using server certificate /path/to/fortio/server.crt to construct TLS credentials
 Using server key /path/to/fortio/server.key to construct TLS credentials
 ```
@@ -273,7 +273,7 @@ Clock skew histogram usec : count 1 avg 12329.795 +/- 0 min 12329.795 max 12329.
 * Load (low default qps/threading) test:
 ```
 $ fortio load http://www.google.com
-Fortio 0.11.0 running at 8 queries per second, 8->8 procs, for 5s: http://www.google.com
+Fortio 1.0.0 running at 8 queries per second, 8->8 procs, for 5s: http://www.google.com
 19:10:33 I httprunner.go:84> Starting http test for http://www.google.com with 4 threads at 8.0 qps
 Starting at 8 qps with 4 thread(s) [gomax 8] for 5s : 10 calls each (total 40)
 19:10:39 I periodic.go:314> T002 ended after 5.056753279s : 10 calls. qps=1.9775534712220633
@@ -303,7 +303,7 @@ All done 40 calls (plus 4 warmup) 60.588 ms avg, 7.9 qps
 Uses `-s` to use multiple (h2/grpc) streams per connection (`-c`), request to hit the fortio ping grpc endpoint with a delay in replies of 0.25s and an extra payload for 10 bytes and auto save the json result:
 ```bash
 $ fortio load -a -grpc -ping -grpc-ping-delay 0.25s -payload "01234567890" -c 2 -s 4 https://fortio-stage.istio.io
-Fortio 0.11.0 running at 8 queries per second, 8->8 procs, for 5s: https://fortio-stage.istio.io
+Fortio 1.0.0 running at 8 queries per second, 8->8 procs, for 5s: https://fortio-stage.istio.io
 16:32:56 I grpcrunner.go:139> Starting GRPC Ping Delay=250ms PayloadLength=11 test for https://fortio-stage.istio.io with 4*2 threads at 8.0 qps
 16:32:56 I grpcrunner.go:261> stripping https scheme. grpc destination: fortio-stage.istio.io. grpc port: 443
 16:32:57 I grpcrunner.go:261> stripping https scheme. grpc destination: fortio-stage.istio.io. grpc port: 443
@@ -410,14 +410,14 @@ Content-Type: text/plain; charset=UTF-8
 Date: Mon, 08 Jan 2018 22:26:26 GMT
 Content-Length: 230
 
-Φορτίο version 0.11.0 echo debug server up for 39s on ldemailly-macbookpro - request from [::1]:65055
+Φορτίο version 1.0.0 echo debug server up for 39s on ldemailly-macbookpro - request from [::1]:65055
 
 GET /debug HTTP/1.1
 
 headers:
 
 Host: localhost:8080
-User-Agent: istio/fortio-0.11.0
+User-Agent: istio/fortio-1.0.0
 Foo: Bar
 
 body:

--- a/README.md
+++ b/README.md
@@ -6,11 +6,18 @@
 [![CircleCI](https://circleci.com/gh/istio/fortio.svg?style=shield)](https://circleci.com/gh/istio/fortio)
 <img src="https://github.com/istio/fortio/blob/master/docs/fortio-logo-color.png" height=141 width=141 align=right>
 
-Fortio (Φορτίο) is [Istio](https://istio.io/)'s load testing tool. Fortio runs at a specified query per second (qps) and records an histogram of execution time and calculates percentiles (e.g. p99 ie the response time such as 99% of the requests take less than that number (in seconds, SI unit)). It can run for a set duration, for a fixed number of calls, or until interrupted (at a constant target QPS, or max speed/load per connection/thread).
+Fortio (Φορτίο) started as [Istio](https://istio.io/)'s load testing tool.
+Fortio runs at a specified query per second (qps) and records an histogram of execution time
+and calculates percentiles (e.g. p99 ie the response time such as 99% of the requests take less than that number (in seconds, SI unit)).
+It can run for a set duration, for a fixed number of calls, or until interrupted (at a constant target QPS, or max speed/load per connection/thread).
 
 The name fortio comes from greek [φορτίο](https://translate.google.com/translate_tts?q=Φορτίο&tl=el&tk=452076.38818&client=t) which means load/burden.
 
-Fortio is a fast, small (3Mb docker image, minimal dependencies), reusable, embeddable go library as well as a command line tool and server process, the server includes a simple web UI and graphical representation of the results (both a single latency graph and a multiple results comparative min, max, avg and percentiles graphs).
+Fortio is a fast, small (3Mb docker image, minimal dependencies), reusable, embeddable go library as well as a command line tool and server process,
+the server includes a simple web UI and graphical representation of the results (both a single latency graph and a multiple results comparative min, max, avg, qps and percentiles graphs).
+
+Fortio is quite mature and very stable with no known major bugs (lots of possible improvements if you want to contribute though!),
+and when bugs are found they are fixed quickly, so after 1 year of development and 42 incremental releases, I'm proud to announce we just reached 1.0 !
 
 ## Installation
 
@@ -40,12 +47,36 @@ brew install fortio
 Once `fortio server` is running, you can visit its web UI at http://localhost:8080/fortio/
 
 You can get a preview of the reporting/graphing UI at https://fortio.istio.io/
+and on https://istio.io/docs/performance-and-scalability/synthetic-benchmarks/
 
 ## Command line arguments
 
-Fortio can be an http or grpc load generator, gathering statistics using the `load` subcommand, or start simple http and grpc ping servers, as well as a basic web UI, result graphing and https redirector, with the `server` command or issue grpc ping messages using the `grpcping` command. It can also fetch a single URL's for debugging when using the `curl` command (or the `-curl` flag to the load command). You can run just the redirector with `redirect`. Lastly if you saved JSON results (using the web UI or directly from the command line), you can browse and graph those results using the `report` command.
+Fortio can be an http or grpc load generator, gathering statistics using the `load` subcommand,
+or start simple http and grpc ping servers, as well as a basic web UI, result graphing and https redirector,
+with the `server` command or issue grpc ping messages using the `grpcping` command.
+It can also fetch a single URL's for debugging when using the `curl` command (or the `-curl` flag to the load command).
+You can run just the redirector with `redirect`.
+Lastly if you saved JSON results (using the web UI or directly from the command line), you can browse and graph those results using the `report` command.
+
+Most important flags for http load generation:
+
+| Flag         | Description, example |
+| -------------|----------------------|
+| `-qps rate` | Queries Per Seconds or 0 for no wait/max qps |
+| `-c connections` | Number of parallel simultaneous connections (and matching go routine) |
+| `-t duration` | How long to run the test  (for instance `-t 30min` for 30 minutes) or 0 to run until ^C, example (default 5s) |
+| `-n numcalls` | Run for exactly this number of calls instead of duration. Default (0) is to use duration (-t). |
+| `-r resolution` | Resolution of the histogram lowest buckets in seconds (default 0.001 i.e 1ms), use 1/10th of your expected typical latency |
+| `-H "header: value"` | Can be specified multiple times to add headers (including Host:) |
+| `-a`     |  Automatically save JSON result with filename based on labels and timestamp |
+| `-json filename` | Filename or `-` for stdout to output json result (relative to `-data-dir` by default, should end with .json if you want `fortio report` to show them; using `-a` is typicallly a better option)|
+| `-labels "l1 l2 ..."` |  Additional config data/labels to add to the resulting JSON, defaults to target URL and hostname|
+
+
+Full list of command line flags:
+<details>
 <!-- use release/updateFlags.sh to update this section -->
-```
+<pre>
 Φορτίο 1.0.0 usage:
 	fortio command [flags] target
 where command is one of: load (load testing), server (starts grpc ping and http
@@ -173,7 +204,10 @@ target is a url (http load tests) or host:port (grpc health test).  flags are:
   -ui-path string
 	http server URI for UI, empty turns off that part (more secure) (default
 	"/fortio/")
-```
+</pre>
+</details>
+
+See also the FAQ entry about [fortio flags for best results](https://github.com/istio/fortio/wiki/FAQ#i-want-to-get-the-best-results-what-flags-should-i-pass)
 
 ## Example use and output
 
@@ -262,8 +296,8 @@ RTT histogram usec : count 3 avg 501.45233 +/- 94.7 min 371.828 max 595.441 sum 
 * `grpcping` can connect to a non-Fortio TLS server by prefacing the destination with
 `https://`:
 ```
-$ fortio grpcping https://fortio.istio.io:443
-16:26:47 I grpcrunner.go:194> stripping https scheme. grpc destination: fortio.istio.io:443
+$ fortio grpcping https://fortio.istio.io
+11:07:55 I grpcrunner.go:275> stripping https scheme. grpc destination: fortio.istio.io. grpc port: 443
 Clock skew histogram usec : count 1 avg 12329.795 +/- 0 min 12329.795 max 12329.795 sum 12329.795
 # range, mid point, percentile, count
 >= 12329.8 <= 12329.8 , 12329.8 , 100.00, 1
@@ -309,13 +343,7 @@ Fortio 1.0.0 running at 8 queries per second, 8->8 procs, for 5s: https://fortio
 16:32:57 I grpcrunner.go:261> stripping https scheme. grpc destination: fortio-stage.istio.io. grpc port: 443
 Starting at 8 qps with 8 thread(s) [gomax 8] for 5s : 5 calls each (total 40)
 16:33:04 I periodic.go:533> T005 ended after 5.283227589s : 5 calls. qps=0.9463911814835126
-16:33:04 I periodic.go:533> T004 ended after 5.28322456s : 5 calls. qps=0.9463917240723911
-16:33:04 I periodic.go:533> T007 ended after 5.283190069s : 5 calls. qps=0.9463979025358817
-16:33:04 I periodic.go:533> T006 ended after 5.283201068s : 5 calls. qps=0.9463959322473395
-16:33:04 I periodic.go:533> T003 ended after 5.285025049s : 5 calls. qps=0.9460693097275045
-16:33:04 I periodic.go:533> T000 ended after 5.285041154s : 5 calls. qps=0.9460664267894554
-16:33:04 I periodic.go:533> T001 ended after 5.285061297s : 5 calls. qps=0.9460628210382703
-16:33:04 I periodic.go:533> T002 ended after 5.285081735s : 5 calls. qps=0.946059162507919
+[...]
 Ended after 5.28514474s : 40 calls. qps=7.5684
 Sleep times : count 32 avg 0.97034752 +/- 0.002338 min 0.967323561 max 0.974838789 sum 31.0511206
 Aggregated Function Time : count 40 avg 0.27731944 +/- 0.001606 min 0.2741372 max 0.280604967 sum 11.0927778
@@ -331,7 +359,8 @@ All done 40 calls (plus 2 warmup) 277.319 ms avg, 7.6 qps
 Successfully wrote 1210 bytes of Json data to 2018-04-03-163258_fortio_stage_istio_io_ldemailly_macbookpro.json
 ```
 And the JSON saved is
-```json
+<details>
+<pre>
 {
   "RunType": "GRPC Ping Delay=250ms PayloadLength=11",
   "Labels": "fortio-stage.istio.io , ldemailly-macbookpro",
@@ -388,7 +417,7 @@ And the JSON saved is
   "Streams": 4,
   "Ping": true
 }
-```
+</pre></details>
 
 * Load test using gRPC and TLS security. First, start Fortio server with the `-cert` and `-key` flags:
 ```
@@ -437,7 +466,7 @@ Https redirector running on :8081
 
 ## Server URLs and features
 
-Fortio `server` - has the following feature - http listening on 8080 (all paths and ports are configurable through flags above):
+Fortio `server` has the following feature for the http listening on 8080 (all paths and ports are configurable through flags above):
 - A simple echo server which will echo back posted data (for any path not mentioned below).
 For instance `curl -d abcdef http://localhost:8080/` returns `abcdef` back. It supports the following optional query argument parameters:
 
@@ -459,6 +488,8 @@ For instance `curl -d abcdef http://localhost:8080/` returns `abcdef` back. It s
 
 The `report` mode is a readonly subset of the above directly on `/`.
 
+There is also the GRPC health and ping servers, as well as the http->https redirector.
+
 ## Implementation details
 
 Fortio is written in the [Go](https://golang.org) language and includes a scalable semi log histogram in [stats.go](stats/stats.go) and a periodic runner engine in [periodic.go](periodic/periodic.go) with specializations for [http](http/httprunner.go) and [grpc](fortiogrpc/grpcrunner.go).
@@ -470,10 +501,10 @@ You can run the histogram code standalone as a command line in [histogram/](hist
 There is also [fcurl/](fcurl/) which is the `fortio curl` part of the code (if you need a light http client without grpc or server side).
 A matching tiny (2Mb compressed) docker image is [istio/fortio.fcurl](https://hub.docker.com/r/istio/fortio.fcurl/tags/)
 
-## Another example output
+## More examples
 
-With 5k qps: (includes envoy and mixer in the calls)
-```
+You can get the data on the console, for instance, with 5k qps: (includes envoy and mixer in the calls)
+<details><pre>
 $ time fortio load -qps 5000 -t 60s -c 8 -r 0.0001 -H "Host: perf-cluster" http://benchmark-2:9090/echo
 2017/07/09 02:31:05 Will be setting special Host header to perf-cluster
 Fortio running at 5000 queries per second for 1m0s: http://benchmark-2:9090/echo
@@ -531,7 +562,7 @@ Aggregated Function Time : count 300000 avg 0.00094608764 +/- 0.0007901 min 0.00
 # target 99.9% 0.0155152
 Code 200 : 300000
 Response Body Sizes : count 300000 avg 0 +/- 0 min 0 max 0 sum 0
-```
+</pre></details>
 
 Or you can get the data in [JSON format](https://github.com/istio/fortio/wiki/Sample-JSON-output) (using `-json result.json`)
 
@@ -543,17 +574,20 @@ Simple form/UI:
 
 Sample requests with responses delayed by 250us and 0.5% of 503 and 1.5% of 429 simulated http errors.
 
-![Web UI form screenshot](https://user-images.githubusercontent.com/3664595/34192808-1983be12-e505-11e7-9c16-2ee9f101f2ce.png)
+![Web UI form screenshot](https://user-images.githubusercontent.com/3664595/41430618-53d911d4-6fc5-11e8-8e35-d4f5fea4426a.png)
 
 Run result:
 
-![Graphical result](https://user-images.githubusercontent.com/3664595/34192806-16f1740a-e505-11e7-9534-3e703222c1d3.png)
+![Graphical result](https://user-images.githubusercontent.com/3664595/41430735-bb95eb3a-6fc5-11e8-8174-be4a6251058f.png)
 
 ```
-Code 200 : 2939 (98.0 %)
-Code 429 : 47 (1.6 %)
-Code 503 : 14 (0.5 %)
+Code 200 : 2929 (97.6 %)
+Code 429 : 56 (1.9 %)
+Code 503 : 15 (0.5 %)
 ```
+
+There are newer/live examples on https://istio.io/docs/performance-and-scalability/synthetic-benchmarks/
+
 ## Contributing
 Contributions whether through issues, documentation, bug fixes, or new features
 are most welcome !

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -78,7 +78,7 @@ docker exec $DOCKERNAME /usr/local/bin/fortio grpcping localhost
 PPROF_URL="$BASE_URL/debug/pprof/heap?debug=1"
 $CURL $PPROF_URL | grep -i TotalAlloc # should find this in memory profile
 # creating dummy container to hold a volume for test certs due to remote docker bind mount limitation.
-DOCKERVOLID=$(docker create -v $TEST_CERT_VOL --name $DOCKERSECVOLNAME istio/fortio.build:v7 /bin/true)
+DOCKERVOLID=$(docker create -v $TEST_CERT_VOL --name $DOCKERSECVOLNAME istio/fortio.build:v8 /bin/true)
 # copying cert files into the certs volume of the dummy container
 for f in ca.crt server.crt server.key; do docker cp $PWD/cert-tmp/$f $DOCKERSECVOLNAME:$TEST_CERT_VOL/$f; done
 # start server in secure grpc mode. uses non-default ports to avoid conflicts with fortio_server container.

--- a/fgrpc/grpcrunner.go
+++ b/fgrpc/grpcrunner.go
@@ -50,7 +50,8 @@ func Dial(serverAddr, cacert, override string) (conn *grpc.ClientConn, err error
 	var opts []grpc.DialOption
 	switch {
 	case cacert != "":
-		creds, err := credentials.NewClientTLSFromFile(cacert, override)
+		var creds credentials.TransportCredentials
+		creds, err = credentials.NewClientTLSFromFile(cacert, override)
 		if err != nil {
 			log.Errf("Invalid TLS credentials: %v\n", err)
 			return nil, err

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -87,7 +87,8 @@ var (
 	certFlag          = flag.String("cert", "", "Path to the certificate file to be used for GRPC server TLS")
 	keyFlag           = flag.String("key", "", "Path to the key file used for GRPC server TLS")
 	caCertFlag        = flag.String("cacert", "",
-		"Path to a custom CA certificate file to be used for the GRPC client TLS, if empty, use https:// prefix for standard internet CAs TLS")
+		"Path to a custom CA certificate file to be used for the GRPC client TLS, "+
+			"if empty, use https:// prefix for standard internet CAs TLS")
 	echoPortFlag = flag.String("http-port", "8080", "http echo server port. Can be in the form of host:port, ip:port or port.")
 	grpcPortFlag = flag.String("grpc-port", fgrpc.DefaultGRPCPort,
 		"grpc server port. Can be in the form of host:port, ip:port or port or \""+disabled+"\" to not start the grpc server.")

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -1,5 +1,5 @@
 # Concatenated after ../Dockerfile to create the tgz
-FROM istio/fortio.build:v7 as stage
+FROM istio/fortio.build:v8 as stage
 WORKDIR /stage
 COPY --from=release /usr/local usr/local
 RUN mkdir -p var/lib/istio/fortio

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -965,16 +965,9 @@ func Report(baseurl, port, staticRsrcDir string, datadir string) bool {
 // setHostAndPort takes hostport in the form of hostname:port, ip:port or :port,
 // sets the urlHostPort variable.
 func setHostAndPort(inputPort string, addr *net.TCPAddr) {
-	urlHostPort = inputPort
-	portStr := inputPort
-	if addr != nil {
-		urlHostPort = addr.String()
-		portStr = fmt.Sprintf(":%d", addr.Port)
-	}
-	if !strings.Contains(inputPort, ":") {
-		inputPort = ":" + inputPort
-	}
-	if strings.HasPrefix(inputPort, ":") {
+	urlHostPort = addr.String()
+	portStr := fmt.Sprintf(":%d", addr.Port)
+	if strings.HasPrefix(inputPort, ":") || !strings.Contains(inputPort, ":") {
 		urlHostPort = "localhost" + portStr
 	}
 }

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -962,23 +962,22 @@ func Report(baseurl, port, staticRsrcDir string, datadir string) bool {
 	return true
 }
 
-// setHostAndPort takes hostport in the form of hostname:port, ip:port or :port,
-// sets the urlHostPort variable.
+// setHostAndPort takes the bind address and sets urlHostPort as bind-address:port
+// unless the original input port didn't specify an address (starts with : or is just a port,
+// no colon) in which case it uses localhost:port
 func setHostAndPort(inputPort string, addr *net.TCPAddr) {
 	urlHostPort = addr.String()
-	portStr := fmt.Sprintf(":%d", addr.Port)
 	if strings.HasPrefix(inputPort, ":") || !strings.Contains(inputPort, ":") {
-		urlHostPort = "localhost" + portStr
+		urlHostPort = fmt.Sprintf("localhost:%d", addr.Port)
 	}
 }
 
 // addHTTPS replaces "http://" in url with "https://" or prepends "https://"
 // if url does not contain prefix "http://".
-func addHTTPS(url string) (pURL string) {
+func addHTTPS(url string) string {
 	if strings.HasPrefix(url, "http://") {
 		log.Infof("Replacing http scheme with https for url: %s", url)
-		pURL = strings.TrimPrefix(url, "http://")
-		return "https://" + pURL
+		return "https://" + strings.TrimPrefix(url, "http://")
 	}
 	// return url unchanged since it already has "https://"
 	if strings.HasPrefix(url, "https://") {
@@ -986,6 +985,5 @@ func addHTTPS(url string) (pURL string) {
 	}
 	// url must not contain any prefix, so add https prefix
 	log.Infof("Prepending https:// to url: %s", url)
-	pURL = "https://" + url
-	return pURL
+	return "https://" + url
 }

--- a/version/version.go
+++ b/version/version.go
@@ -22,9 +22,9 @@ import (
 )
 
 const (
-	major = 0
-	minor = 11
-	patch = 1
+	major = 1
+	minor = 0
+	patch = 0
 
 	debug = false // turn on to debug init()
 )


### PR DESCRIPTION
Prep for 1.0; also bump go to 1.10.3 / new build image and fixes
previous pr broke the build update and missed 1 file
and gometalinter doesn't report errors when using go list canonical package names (istio.io/fortio/x)

Also moved logic for official builds from Dockerfile to Makefile, fixes #252 

And better docs #234 