### PR TITLE
Prefix headers are moved to common file

### DIFF
--- a/fgrpc/grpcrunner.go
+++ b/fgrpc/grpcrunner.go
@@ -248,7 +248,7 @@ func RunGRPCTest(o *GRPCRunnerOptions) (*GRPCRunnerResults, error) {
 // a hostname, IP address, hostname:port, or ip:port. The original dest is
 // returned if dest is an invalid hostname or invalid IP address. An http/https
 // prefix is removed from dest if one exists and the port number is set to
-// DefaultHTTPPort for http, DefaultHTTPSPort for https, or DefaultGRPCPort
+// StandardHTTPPort for http, StandardHTTPSPort for https, or DefaultGRPCPort
 // if http, https, or :port is not specified in dest.
 // TODO: change/fix this (NormalizePort and more)
 func grpcDestination(dest string) (parsedDest string) {
@@ -258,12 +258,12 @@ func grpcDestination(dest string) (parsedDest string) {
 	switch {
 	case strings.HasPrefix(dest, fnet.PrefixHTTP):
 		parsedDest = strings.TrimSuffix(strings.Replace(dest, fnet.PrefixHTTP, "", 1), "/")
-		port = fnet.DefaultHTTPPort
+		port = fnet.StandardHTTPPort
 		log.Infof("stripping http scheme. grpc destination: %v: grpc port: %s",
 			parsedDest, port)
 	case strings.HasPrefix(dest, fnet.PrefixHTTPS):
 		parsedDest = strings.TrimSuffix(strings.Replace(dest, fnet.PrefixHTTPS, "", 1), "/")
-		port = fnet.DefaultHTTPSPort
+		port = fnet.StandardHTTPSPort
 		log.Infof("stripping https scheme. grpc destination: %v. grpc port: %s",
 			parsedDest, port)
 	default:

--- a/fgrpc/grpcrunner.go
+++ b/fgrpc/grpcrunner.go
@@ -34,15 +34,6 @@ import (
 	"istio.io/fortio/periodic"
 )
 
-const (
-	// DefaultGRPCPort is the Fortio gRPC server default port number.
-	DefaultGRPCPort  = "8079"
-	defaultHTTPPort  = "80"
-	defaultHTTPSPort = "443"
-	prefixHTTP       = "http://"
-	prefixHTTPS      = "https://"
-)
-
 // Dial dials grpc using insecure or tls transport security when serverAddr
 // has prefixHTTPS or cert is provided. If override is set to a non empty string,
 // it will override the virtual host name of authority in requests.
@@ -58,7 +49,7 @@ func Dial(serverAddr, cacert, override string) (conn *grpc.ClientConn, err error
 		}
 		log.Infof("Using CA certificate %v to construct TLS credentials", cacert)
 		opts = append(opts, grpc.WithTransportCredentials(creds))
-	case strings.HasPrefix(serverAddr, prefixHTTPS):
+	case strings.HasPrefix(serverAddr, fnet.PrefixHTTPS):
 		creds := credentials.NewTLS(nil)
 		opts = append(opts, grpc.WithTransportCredentials(creds))
 	default:
@@ -265,19 +256,19 @@ func grpcDestination(dest string) (parsedDest string) {
 	// strip any unintentional http/https scheme prefixes from dest
 	// and set the port number.
 	switch {
-	case strings.HasPrefix(dest, prefixHTTP):
-		parsedDest = strings.TrimSuffix(strings.Replace(dest, prefixHTTP, "", 1), "/")
-		port = defaultHTTPPort
+	case strings.HasPrefix(dest, fnet.PrefixHTTP):
+		parsedDest = strings.TrimSuffix(strings.Replace(dest, fnet.PrefixHTTP, "", 1), "/")
+		port = fnet.DefaultHTTPPort
 		log.Infof("stripping http scheme. grpc destination: %v: grpc port: %s",
 			parsedDest, port)
-	case strings.HasPrefix(dest, prefixHTTPS):
-		parsedDest = strings.TrimSuffix(strings.Replace(dest, prefixHTTPS, "", 1), "/")
-		port = defaultHTTPSPort
+	case strings.HasPrefix(dest, fnet.PrefixHTTPS):
+		parsedDest = strings.TrimSuffix(strings.Replace(dest, fnet.PrefixHTTPS, "", 1), "/")
+		port = fnet.DefaultHTTPSPort
 		log.Infof("stripping https scheme. grpc destination: %v. grpc port: %s",
 			parsedDest, port)
 	default:
 		parsedDest = dest
-		port = DefaultGRPCPort
+		port = fnet.DefaultGRPCPort
 	}
 	if _, _, err := net.SplitHostPort(parsedDest); err == nil {
 		return parsedDest

--- a/fgrpc/pingsrv_test.go
+++ b/fgrpc/pingsrv_test.go
@@ -23,6 +23,8 @@ import (
 
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"istio.io/fortio/fnet"
 	"istio.io/fortio/log"
 )
 
@@ -42,7 +44,7 @@ func TestPingServer(t *testing.T) {
 	if err != nil || latency < delay.Seconds() || latency > 10.*delay.Seconds() {
 		t.Errorf("Unexpected result %f, %v with ping calls and delay of %v", latency, err, delay)
 	}
-	if latency, err := PingClientCall(prefixHTTPS+"fortio.istio.io:443", "", 7,
+	if latency, err := PingClientCall(fnet.PrefixHTTPS+"fortio.istio.io:443", "", 7,
 		"test payload", 0); err != nil || latency <= 0 {
 		t.Errorf("Unexpected result %f, %v with ping calls", latency, err)
 	}
@@ -65,7 +67,7 @@ func TestPingServer(t *testing.T) {
 	if r, err := GrpcHealthCheck(sAddr, caCrt, "", 1); err != nil || (*r)[serving] != 1 {
 		t.Errorf("Unexpected result %+v, %v with empty service health check", r, err)
 	}
-	if r, err := GrpcHealthCheck(prefixHTTPS+"fortio.istio.io:443", "", "", 1); err != nil || (*r)[serving] != 1 {
+	if r, err := GrpcHealthCheck(fnet.PrefixHTTPS+"fortio.istio.io:443", "", "", 1); err != nil || (*r)[serving] != 1 {
 		t.Errorf("Unexpected result %+v, %v with empty service health check", r, err)
 	}
 	if r, err := GrpcHealthCheck(iAddr, "", "foo", 3); err != nil || (*r)[serving] != 3 {

--- a/fhttp/http_utils.go
+++ b/fhttp/http_utils.go
@@ -25,6 +25,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"istio.io/fortio/fnet"
 	"istio.io/fortio/log"
 	"istio.io/fortio/stats"
 )
@@ -450,26 +451,21 @@ func OnBehalfOf(o *HTTPOptions, r *http.Request) {
 	_ = o.AddAndValidateExtraHeader("X-On-Behalf-Of: " + r.RemoteAddr)
 }
 
-const (
-	httpPrefix  = "http://"
-	httpsPrefix = "https://"
-)
-
 // AddHTTPS replaces "http://" in url with "https://" or prepends "https://"
 // if url does not contain prefix "http://".
 func AddHTTPS(url string) string {
-	if len(url) > len(httpPrefix) {
-		if strings.EqualFold(url[:len(httpPrefix)], httpPrefix) {
+	if len(url) > len(fnet.PrefixHTTP) {
+		if strings.EqualFold(url[:len(fnet.PrefixHTTP)], fnet.PrefixHTTP) {
 			log.Infof("Replacing http scheme with https for url: %s", url)
-			return httpsPrefix + url[len(httpPrefix):]
+			return fnet.PrefixHTTPS + url[len(fnet.PrefixHTTP):]
 		}
 		// returns url with normalized lowercase https prefix
-		if strings.EqualFold(url[:len(httpsPrefix)], httpsPrefix) {
-			return httpsPrefix + url[len(httpsPrefix):]
+		if strings.EqualFold(url[:len(fnet.PrefixHTTPS)], fnet.PrefixHTTPS) {
+			return fnet.PrefixHTTPS + url[len(fnet.PrefixHTTP):]
 		}
 	}
 	// url must not contain any prefix, so add https prefix
 	log.Infof("Prepending https:// to url: %s", url)
-	return httpsPrefix + url
+	return fnet.PrefixHTTPS + url
 
 }

--- a/fhttp/http_utils.go
+++ b/fhttp/http_utils.go
@@ -461,7 +461,7 @@ func AddHTTPS(url string) string {
 		}
 		// returns url with normalized lowercase https prefix
 		if strings.EqualFold(url[:len(fnet.PrefixHTTPS)], fnet.PrefixHTTPS) {
-			return fnet.PrefixHTTPS + url[len(fnet.PrefixHTTP):]
+			return fnet.PrefixHTTPS + url[len(fnet.PrefixHTTPS):]
 		}
 	}
 	// url must not contain any prefix, so add https prefix

--- a/fnet/network.go
+++ b/fnet/network.go
@@ -28,10 +28,10 @@ import (
 const (
 	// DefaultGRPCPort is the Fortio gRPC server default port number.
 	DefaultGRPCPort = "8079"
-	// DefaultHTTPPort is the Standard http port number.
-	DefaultHTTPPort = "80"
-	// DefaultHTTPSPort is the Standard https port number.
-	DefaultHTTPSPort = "443"
+	// StandardHTTPPort is the Standard http port number.
+	StandardHTTPPort = "80"
+	// StandardHTTPSPort is the Standard https port number.
+	StandardHTTPSPort = "443"
 	// PrefixHTTP is a constant value for representing http protocol that can be added prefix of url
 	PrefixHTTP = "http://"
 	// PrefixHTTPS is a constant value for representing secure http protocol that can be added prefix of url

--- a/fnet/network.go
+++ b/fnet/network.go
@@ -28,9 +28,9 @@ import (
 const (
 	// DefaultGRPCPort is the Fortio gRPC server default port number.
 	DefaultGRPCPort = "8079"
-	// DefaultHTTPPort is the Fortio http server default port number.
+	// DefaultHTTPPort is the Standard http port number.
 	DefaultHTTPPort = "80"
-	// DefaultHTTPSPort is the Fortio https server default port number.
+	// DefaultHTTPSPort is the Standard https port number.
 	DefaultHTTPSPort = "443"
 	// PrefixHTTP is a constant value for representing http protocol that can be added prefix of url
 	PrefixHTTP = "http://"

--- a/fnet/network.go
+++ b/fnet/network.go
@@ -25,6 +25,15 @@ import (
 	"istio.io/fortio/version"
 )
 
+const (
+	// DefaultGRPCPort is the Fortio gRPC server default port number.
+	DefaultGRPCPort  = "8079"
+	DefaultHTTPPort  = "80"
+	DefaultHTTPSPort = "443"
+	PrefixHTTP       = "http://"
+	PrefixHTTPS      = "https://"
+)
+
 // NormalizePort parses port and returns host:port if port is in the form
 // of host:port already or :port if port is only a port (doesn't contain :).
 func NormalizePort(port string) string {

--- a/fnet/network.go
+++ b/fnet/network.go
@@ -27,11 +27,15 @@ import (
 
 const (
 	// DefaultGRPCPort is the Fortio gRPC server default port number.
-	DefaultGRPCPort  = "8079"
-	DefaultHTTPPort  = "80"
+	DefaultGRPCPort = "8079"
+	// DefaultHTTPPort is the Fortio http server default port number.
+	DefaultHTTPPort = "80"
+	// DefaultHTTPSPort is the Fortio https server default port number.
 	DefaultHTTPSPort = "443"
-	PrefixHTTP       = "http://"
-	PrefixHTTPS      = "https://"
+	// PrefixHTTP is a constant value for representing http protocol that can be added prefix of url
+	PrefixHTTP = "http://"
+	// PrefixHTTPS is a constant value for representing secure http protocol that can be added prefix of url
+	PrefixHTTPS = "https://"
 )
 
 // NormalizePort parses port and returns host:port if port is in the form

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -90,7 +90,7 @@ var (
 		"Path to a custom CA certificate file to be used for the GRPC client TLS, "+
 			"if empty, use https:// prefix for standard internet CAs TLS")
 	echoPortFlag = flag.String("http-port", "8080", "http echo server port. Can be in the form of host:port, ip:port or port.")
-	grpcPortFlag = flag.String("grpc-port", fgrpc.DefaultGRPCPort,
+	grpcPortFlag = flag.String("grpc-port", fnet.DefaultGRPCPort,
 		"grpc server port. Can be in the form of host:port, ip:port or port or \""+disabled+"\" to not start the grpc server.")
 	echoDbgPathFlag = flag.String("echo-debug-path", "/debug",
 		"http echo server URI for debug, empty turns off that part (more secure)")


### PR DESCRIPTION
In #254 PR, decided to move prefix http to common file. They are moved to network.