### PR TITLE
Version bump and workaround/fix for unclean brew build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ Gopkg.*
 .idea
 # certs for testing
 cert-tmp/
+# brew binary bottles create a .brew_home/ dir in source tree
+.brew_home/

--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ BUILD_DIR := /tmp/fortio_build
 LIB_DIR := /usr/local/lib/fortio
 DATA_DIR := /var/lib/istio/fortio
 OFFICIAL_BIN := ../fortio_go1.10.bin
-GOOS := linux
+GOOS := 
 GO_BIN := go
 GIT_STATUS := $(strip $(shell git status --porcelain | wc -l))
 GIT_TAG := $(shell git describe --tags --match 'v*')
@@ -189,7 +189,7 @@ $(BUILD_DIR)/link-flags.txt: $(BUILD_DIR)/build-info.txt
   -X istio.io/fortio/version.tag=$(GIT_TAG) \
   -X istio.io/fortio/version.gitstatus=$(GIT_STATUS)" | tee $@
 
-.PHONY: official-build official-build-version
+.PHONY: official-build official-build-version official-build-clean
 
 official-build: $(BUILD_DIR)/link-flags.txt
 	$(GO_BIN) version
@@ -197,3 +197,6 @@ official-build: $(BUILD_DIR)/link-flags.txt
 	
 official-build-version: official-build
 	$(OFFICIAL_BIN) version
+
+official-build-clean:
+	-$(RM) $(BUILD_DIR)/build-info.txt $(BUILD_DIR)/link-flags.txt $(OFFICIAL_BIN)

--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	major = 1
 	minor = 0
-	patch = 0
+	patch = 1
 
 	debug = false // turn on to debug init()
 )


### PR DESCRIPTION
version bump missing from post release steps earlier
and fix for #259 (might drop that part if https://github.com/Homebrew/brew/pull/4355 gets merged)
Switch default `official-build` make target to "native" [from linux] (to make brew recipe smaller)
Also add a `official-build-clean` target