### PR TITLE
fortio --help should go to stdout not stderr #130

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ or start simple http and grpc ping servers, as well as a basic web UI, result gr
 with the `server` command or issue grpc ping messages using the `grpcping` command.
 It can also fetch a single URL's for debugging when using the `curl` command (or the `-curl` flag to the load command).
 You can run just the redirector with `redirect`.
-Lastly if you saved JSON results (using the web UI or directly from the command line), you can browse and graph those results using the `report` command.
+If you saved JSON results (using the web UI or directly from the command line), you can browse and graph those results using the `report` command.
+You can learn current Fortio version using `version` command.
+Lastly, you can learn which flags are available using `help` command.
 
 Most important flags for http load generation:
 
@@ -133,8 +135,6 @@ target is a url (http load tests) or host:port (grpc health test).  flags are:
 	grpc ping client mode: use health instead of ping
   -healthservice string
 	which service string to pass to health check
-  -help
-    Shows the available flags and operations
   -http-port string
 	http echo server port. Can be in the form of host:port, ip:port or port.
 	(default "8080")
@@ -209,8 +209,6 @@ target is a url (http load tests) or host:port (grpc health test).  flags are:
   -user string
     	User credentials for basic authentication (for http). Input data format
     	should be user:password
-  -version
-    Show the current version of fortio project
 </pre>
 </details>
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ with the `server` command or issue grpc ping messages using the `grpcping` comma
 It can also fetch a single URL's for debugging when using the `curl` command (or the `-curl` flag to the load command).
 You can run just the redirector with `redirect`.
 If you saved JSON results (using the web UI or directly from the command line), you can browse and graph those results using the `report` command.
-You can learn current Fortio version using `version` command.
+The `version` command will print version and build information, `fortio version -s` just the version.
 Lastly, you can learn which flags are available using `help` command.
 
 Most important flags for http load generation:

--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ Most important flags for http load generation:
 | `-labels "l1 l2 ..."` |  Additional config data/labels to add to the resulting JSON, defaults to target URL and hostname|
 
 
-Full list of command line flags:
+Full list of command line flags (`fortio help`):
 <details>
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
-Φορτίο 1.0.0 usage:
+Φορτίο 1.0.1 usage:
 	fortio command [flags] target
 where command is one of: load (load testing), server (starts grpc ping and http
 echo/ui/redirect/proxy servers), grpcping (grpc client), report (report only UI
@@ -207,8 +207,8 @@ target is a url (http load tests) or host:port (grpc health test).  flags are:
 	http server URI for UI, empty turns off that part (more secure) (default
 	"/fortio/")
   -user string
-    	User credentials for basic authentication (for http). Input data format
-    	should be user:password
+	User credentials for basic authentication (for http). Input data format
+	should be user:password
 </pre>
 </details>
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ target is a url (http load tests) or host:port (grpc health test).  flags are:
 	grpc ping client mode: use health instead of ping
   -healthservice string
 	which service string to pass to health check
+  -help
+    Shows the available flags and operations
   -http-port string
 	http echo server port. Can be in the form of host:port, ip:port or port.
 	(default "8080")
@@ -207,6 +209,8 @@ target is a url (http load tests) or host:port (grpc health test).  flags are:
   -user string
     	User credentials for basic authentication (for http). Input data format
     	should be user:password
+  -version
+    Show the current version of fortio project
 </pre>
 </details>
 

--- a/bincommon/commonflags.go
+++ b/bincommon/commonflags.go
@@ -58,7 +58,7 @@ func FlagsUsage(writer io.Writer, msgs ...interface{}) {
 
 // Usage prints usage according to input writer
 func Usage(writer io.Writer) {
-	fmt.Fprintf(writer, "Φορτίο %s usageErr:\n\t%s command [flags] target\n%s\n%s\n%s\n%s\n",
+	fmt.Fprintf(writer, "Φορτίο %s usage:\n\t%s command [flags] target\n%s\n%s\n%s\n%s\n",
 		version.Short(),
 		os.Args[0],
 		"where command is one of: load (load testing), server (starts grpc ping and",

--- a/bincommon/commonflags.go
+++ b/bincommon/commonflags.go
@@ -46,25 +46,14 @@ func (f *headersFlagList) Set(value string) error {
 // -- end of functions for -H support
 
 // FlagsUsage prints end of the usage() (flags part + error message).
-func FlagsUsage(writer io.Writer, msgs ...interface{}) {
+func FlagsUsage(w io.Writer, msgs ...interface{}) {
 	// nolint: gas
-	fmt.Fprintf(writer, "flags are:\n")
-	flag.CommandLine.SetOutput(writer)
+	fmt.Fprintf(w, "flags are:\n")
+	flag.CommandLine.SetOutput(w)
 	flag.PrintDefaults()
 	if len(msgs) > 0 {
-		fmt.Fprint(writer, msgs...) // nolint: gas
+		fmt.Fprintln(w, msgs...) // nolint: gas
 	}
-}
-
-// Usage prints usage according to input writer
-func Usage(writer io.Writer) {
-	fmt.Fprintf(writer, "Φορτίο %s usage:\n\t%s command [flags] target\n%s\n%s\n%s\n%s\n",
-		version.Short(),
-		os.Args[0],
-		"where command is one of: load (load testing), server (starts grpc ping and",
-		"http echo/ui/redirect/proxy servers), grpcping (grpc client), report (report only UI",
-		"server), redirect (redirect only server), or curl (single URL debug).",
-		"where target is a url (http load tests) or host:port (grpc health test).")
 }
 
 var (
@@ -86,7 +75,7 @@ var (
 )
 
 // SharedMain is the common part of main from fortio_main and fcurl.
-func SharedMain() {
+func SharedMain(usage func(io.Writer, ...interface{})) {
 	flag.Var(&headersFlags, "H", "Additional Header(s)")
 	flag.IntVar(&fhttp.BufferSizeKb, "httpbufferkb", fhttp.BufferSizeKb,
 		"Size of the buffer (max data size) for the optimized http client in kbytes")
@@ -105,9 +94,8 @@ func SharedMain() {
 		}
 		os.Exit(0)
 	}
-	if strings.Contains(os.Args[0], "fortio") && strings.Contains(os.Args[1], "help") {
-		Usage(os.Stdout)
-		FlagsUsage(os.Stdout)
+	if strings.Contains(os.Args[1], "help") {
+		usage(os.Stdout)
 		os.Exit(0)
 	}
 }

--- a/bincommon/commonflags.go
+++ b/bincommon/commonflags.go
@@ -56,17 +56,6 @@ func FlagsUsage(writer io.Writer, msgs ...interface{}) {
 	}
 }
 
-// Usage prints usage according to input writer
-func Usage(writer io.Writer) {
-	fmt.Fprintf(writer, "Φορτίο %s usageErr:\n\t%s command [flags] target\n%s\n%s\n%s\n%s\n",
-		version.Short(),
-		os.Args[0],
-		"where command is one of: load (load testing), server (starts grpc ping and",
-		"http echo/ui/redirect/proxy servers), grpcping (grpc client), report (report only UI",
-		"server), redirect (redirect only server), or curl (single URL debug).",
-		"where target is a url (http load tests) or host:port (grpc health test).")
-}
-
 var (
 	compressionFlag = flag.Bool("compression", false, "Enable http compression")
 	keepAliveFlag   = flag.Bool("keepalive", true, "Keep connection alive (only for fast http 1.1)")

--- a/bincommon/commonflags.go
+++ b/bincommon/commonflags.go
@@ -105,7 +105,7 @@ func SharedMain() {
 		}
 		os.Exit(0)
 	}
-	if strings.Contains(os.Args[1], "help") {
+	if strings.Contains(os.Args[0], "fortio") && strings.Contains(os.Args[1], "help") {
 		Usage(os.Stdout)
 		FlagsUsage(os.Stdout)
 		os.Exit(0)

--- a/bincommon/commonflags.go
+++ b/bincommon/commonflags.go
@@ -29,7 +29,6 @@ import (
 
 	"istio.io/fortio/fhttp"
 	"istio.io/fortio/log"
-	"istio.io/fortio/version"
 )
 
 // -- Support for multiple instances of -H flag on cmd line:
@@ -81,16 +80,6 @@ func SharedMain() {
 		"Size of the buffer (max data size) for the optimized http client in kbytes")
 	flag.BoolVar(&fhttp.CheckConnectionClosedHeader, "httpccch", fhttp.CheckConnectionClosedHeader,
 		"Check for Connection: Close Header")
-	// Special case so `fcurl -version` and `--version` and `version` and ... work
-	if len(os.Args) >= 2 && strings.Contains(os.Args[1], "version") {
-		if len(os.Args) >= 3 && strings.Contains(os.Args[2], "s") {
-			// so `fortio version -s` is the short version; everything else is long/full
-			fmt.Println(version.Short())
-		} else {
-			fmt.Println(version.Long())
-		}
-		os.Exit(0)
-	}
 }
 
 // FetchURL is fetching url content and exiting with 1 upon error.

--- a/bincommon/commonflags.go
+++ b/bincommon/commonflags.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"strings"
 
+	"io"
+
 	"istio.io/fortio/fhttp"
 	"istio.io/fortio/log"
 	"istio.io/fortio/version"
@@ -44,13 +46,25 @@ func (f *headersFlagList) Set(value string) error {
 // -- end of functions for -H support
 
 // FlagsUsage prints end of the usage() (flags part + error message).
-func FlagsUsage(msgs ...interface{}) {
+func FlagsUsage(writer io.Writer, msgs ...interface{}) {
 	// nolint: gas
-	fmt.Fprintf(os.Stderr, "flags are:\n")
+	fmt.Fprintf(writer, "flags are:\n")
+	flag.CommandLine.SetOutput(writer)
 	flag.PrintDefaults()
-	fmt.Fprint(os.Stderr, msgs...) // nolint: gas
-	os.Stderr.WriteString("\n")    // nolint: gas, errcheck
-	os.Exit(1)
+	if len(msgs) > 0 {
+		fmt.Fprint(writer, msgs...) // nolint: gas
+	}
+}
+
+// Usage prints usage according to input writer
+func Usage(writer io.Writer) {
+	fmt.Fprintf(writer, "Φορτίο %s usageErr:\n\t%s command [flags] target\n%s\n%s\n%s\n%s\n",
+		version.Short(),
+		os.Args[0],
+		"where command is one of: load (load testing), server (starts grpc ping and",
+		"http echo/ui/redirect/proxy servers), grpcping (grpc client), report (report only UI",
+		"server), redirect (redirect only server), or curl (single URL debug).",
+		"where target is a url (http load tests) or host:port (grpc health test).")
 }
 
 var (

--- a/fcurl/fcurl.go
+++ b/fcurl/fcurl.go
@@ -32,7 +32,7 @@ func usage(msgs ...interface{}) {
 	fmt.Fprintf(os.Stderr, "Φορτίο fortio-curl %s usage:\n\t%s [flags] url\n",
 		version.Short(),
 		os.Args[0])
-	bincommon.FlagsUsage(msgs...)
+	bincommon.FlagsUsage(os.Stderr, msgs...)
 }
 
 func main() {

--- a/fcurl/fcurl.go
+++ b/fcurl/fcurl.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 
 	"istio.io/fortio/bincommon"
@@ -27,20 +28,19 @@ import (
 )
 
 // Prints usage
-func usage(msgs ...interface{}) {
+func usage(w io.Writer, msgs ...interface{}) {
 	// nolint: gas
-	fmt.Fprintf(os.Stderr, "Φορτίο fortio-curl %s usage:\n\t%s [flags] url\n",
+	fmt.Fprintf(w, "Φορτίο fortio-curl %s usage:\n\t%s [flags] url\n",
 		version.Short(),
 		os.Args[0])
-	bincommon.FlagsUsage(os.Stderr, msgs...)
-	os.Stderr.WriteString("\n") // nolint: gas, errcheck
-	os.Exit(1)
+	bincommon.FlagsUsage(w, msgs...)
 }
 
 func main() {
-	bincommon.SharedMain()
+	bincommon.SharedMain(usage)
 	if len(os.Args) < 2 {
-		usage("Error: need a url as parameter")
+		usage(os.Stderr, "Error: need a url as parameter")
+		os.Exit(1)
 	}
 	flag.Parse()
 	if *bincommon.QuietFlag {

--- a/fcurl/fcurl.go
+++ b/fcurl/fcurl.go
@@ -33,6 +33,8 @@ func usage(msgs ...interface{}) {
 		version.Short(),
 		os.Args[0])
 	bincommon.FlagsUsage(os.Stderr, msgs...)
+	os.Stderr.WriteString("\n") // nolint: gas, errcheck
+	os.Exit(1)
 }
 
 func main() {

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"runtime"
@@ -55,15 +56,32 @@ func (f *proxiesFlagList) Set(value string) error {
 // Prints usage and error messages with StdErr writer
 func usageErr(msgs ...interface{}) {
 	// nolint: gas
-	bincommon.Usage(os.Stderr)
+	usage(os.Stderr)
 	bincommon.FlagsUsage(os.Stderr, msgs...)
 	os.Stderr.WriteString("\n") // nolint: gas, errcheck
 	os.Exit(1)
 }
 
+// Usage prints usage according to input writer
+func usage(writer io.Writer) {
+	fmt.Fprintf(writer, "Φορτίο %s usageErr:\n\t%s command [flags] target\n%s\n%s\n%s\n%s\n",
+		version.Short(),
+		os.Args[0],
+		"where command is one of: load (load testing), server (starts grpc ping and",
+		"http echo/ui/redirect/proxy servers), grpcping (grpc client), report (report only UI",
+		"server), redirect (redirect only server), or curl (single URL debug).",
+		"where target is a url (http load tests) or host:port (grpc health test).")
+}
+
+// versionInfo prints application name and its version.
+func versionInfo() {
+	fmt.Fprintf(os.Stdout, "Φορτίο version %s\n",
+		version.Short())
+}
+
 // Prints usage with stdOut writer
 func usageInfo() {
-	bincommon.Usage(os.Stdout)
+	usage(os.Stdout)
 	bincommon.FlagsUsage(os.Stdout)
 }
 
@@ -201,7 +219,13 @@ func main() {
 	case "grpcping":
 		grpcClient()
 	case "help":
+		fallthrough
+	case "-help":
 		usageInfo()
+	case "version":
+		fallthrough
+	case "-version":
+		versionInfo()
 	default:
 		usageErr("Error: unknown command ", command)
 	}

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -75,7 +75,7 @@ func usage(writer io.Writer) {
 
 // versionInfo prints application name and its version.
 func versionInfo() {
-	fmt.Fprintf(os.Stdout, "Φορτίο version %s\n",
+	fmt.Fprintf(os.Stdout, "Φορτίο version %s \n",
 		version.Short())
 }
 

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"runtime"
@@ -52,12 +53,21 @@ func (f *proxiesFlagList) Set(value string) error {
 
 // -- end of functions for -P support
 
+// Usage to a writer
+func usage(w io.Writer, msgs ...interface{}) {
+	fmt.Fprintf(w, "Φορτίο %s usage:\n\t%s command [flags] target\n%s\n%s\n%s\n%s\n",
+		version.Short(),
+		os.Args[0],
+		"where command is one of: load (load testing), server (starts grpc ping and",
+		"http echo/ui/redirect/proxy servers), grpcping (grpc client), report (report only UI",
+		"server), redirect (redirect only server), or curl (single URL debug).",
+		"where target is a url (http load tests) or host:port (grpc health test).")
+	bincommon.FlagsUsage(w, msgs...)
+}
+
 // Prints usage and error messages with StdErr writer
 func usageErr(msgs ...interface{}) {
-	// nolint: gas
-	bincommon.Usage(os.Stderr)
-	bincommon.FlagsUsage(os.Stderr, msgs...)
-	os.Stderr.WriteString("\n") // nolint: gas, errcheck
+	usage(os.Stderr)
 	os.Exit(1)
 }
 
@@ -134,8 +144,8 @@ var (
 )
 
 func main() {
-	bincommon.SharedMain()
 	flag.Var(&proxiesFlags, "P", "Proxies to run, e.g -P \"localport1 dest_host1:dest_port1\" -P \"[::1]:0 www.google.com:443\" ...")
+	bincommon.SharedMain(usage)
 	if len(os.Args) < 2 {
 		usageErr("Error: need at least 1 command parameter")
 	}

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"path"
 	"runtime"
@@ -56,33 +55,10 @@ func (f *proxiesFlagList) Set(value string) error {
 // Prints usage and error messages with StdErr writer
 func usageErr(msgs ...interface{}) {
 	// nolint: gas
-	usage(os.Stderr)
+	bincommon.Usage(os.Stderr)
 	bincommon.FlagsUsage(os.Stderr, msgs...)
 	os.Stderr.WriteString("\n") // nolint: gas, errcheck
 	os.Exit(1)
-}
-
-// Usage prints usage according to input writer
-func usage(writer io.Writer) {
-	fmt.Fprintf(writer, "Φορτίο %s usageErr:\n\t%s command [flags] target\n%s\n%s\n%s\n%s\n",
-		version.Short(),
-		os.Args[0],
-		"where command is one of: load (load testing), server (starts grpc ping and",
-		"http echo/ui/redirect/proxy servers), grpcping (grpc client), report (report only UI",
-		"server), redirect (redirect only server), or curl (single URL debug).",
-		"where target is a url (http load tests) or host:port (grpc health test).")
-}
-
-// versionInfo prints application name and its version.
-func versionInfo() {
-	fmt.Fprintf(os.Stdout, "Φορτίο version %s \n",
-		version.Short())
-}
-
-// Prints usage with stdOut writer
-func usageInfo() {
-	usage(os.Stdout)
-	bincommon.FlagsUsage(os.Stdout)
 }
 
 // Attention: every flag that is common to http client goes to bincommon/
@@ -218,14 +194,6 @@ func main() {
 		}
 	case "grpcping":
 		grpcClient()
-	case "help":
-		fallthrough
-	case "-help":
-		usageInfo()
-	case "version":
-		fallthrough
-	case "-version":
-		versionInfo()
 	default:
 		usageErr("Error: unknown command ", command)
 	}

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -67,7 +67,7 @@ func usage(w io.Writer, msgs ...interface{}) {
 
 // Prints usage and error messages with StdErr writer
 func usageErr(msgs ...interface{}) {
-	usage(os.Stderr)
+	usage(os.Stderr, msgs...)
 	os.Exit(1)
 }
 

--- a/release/updateFlags.sh
+++ b/release/updateFlags.sh
@@ -2,4 +2,4 @@
 # Extract fortio's help and rewrap it to 80 cols
 # fmt doesn't touch lines starting with . so we change the " -" to dot and back to keep
 # the option lines
-fortio 2>&1 | sed '$ d' | sed -e 's/^  -/./' | fmt -80 | sed -e 's/^\./  -/'
+fortio help | sed -e 's/^  -/./' | fmt -80 | sed -e 's/^\./  -/'


### PR DESCRIPTION
help is handled as an input argument and usage message is divided into two as info and error.