### PR TITLE
Bump to next/future version to 1.1.0 (as I expect next release to have some significant change)

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -23,8 +23,8 @@ import (
 
 const (
 	major = 1
-	minor = 0
-	patch = 1
+	minor = 1
+	patch = 0
 
 	debug = false // turn on to debug init()
 )


### PR DESCRIPTION
Bump to next/future version to 1.1.0 (as I expect next release to have some
significant change now that minor build/brew stuff is done)