### PR TITLE
Add unix domain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,9 @@ Fortio 1.1.0 grpc 'ping' server listening on [::]:8079
 Fortio 1.1.0 https redirector server listening on [::]:8081
 Fortio 1.1.0 echo server listening on [::]:8080
 UI started - visit:
-http://localhost:8080/fortio/   (or any host/ip reachable on this server)
-21:45:23 I fortio_main.go:195> All fortio 1.1.0 buildinfo go1.10 servers started!
+http://localhost:8080/fortio/
+(or any host/ip reachable on this server)
+14:57:12 I fortio_main.go:217> All fortio 1.1.0 unknown go1.10.3 servers started!
 ```
 
 * By default, Fortio's web/echo servers listen on port 8080 on all interfaces.
@@ -243,6 +244,35 @@ Https redirector running on :8081
 Fortio 1.1.0 grpc ping server listening on port :8079
 Fortio 1.1.0 echo server listening on port 10.10.10.10:8088
 ```
+
+* You can use unix domain socket for any server/client:
+```
+$ fortio server --http-port /tmp/fortio-uds-http &
+Fortio 1.1.0 grpc 'ping' server listening on [::]:8079
+Fortio 1.1.0 https redirector server listening on [::]:8081
+Fortio 1.1.0 echo server listening on /tmp/fortio-uds-http
+UI started - visit:
+fortio curl -unix-socket=/tmp/fortio-uds-http http://localhost/fortio/
+14:58:45 I fortio_main.go:217> All fortio 1.1.0 unknown go1.10.3 servers started!
+$ fortio curl -unix-socket=/tmp/fortio-uds-http http://foo.bar/debug
+15:00:48 I http_client.go:428> Using unix domain socket /tmp/fortio-uds-http instead of foo.bar http
+HTTP/1.1 200 OK
+Content-Type: text/plain; charset=UTF-8
+Date: Wed, 08 Aug 2018 22:00:48 GMT
+Content-Length: 231
+
+Φορτίο version 1.1.0 unknown go1.10.3 echo debug server up for 2m3.4s on ldemailly-macbookpro.roam.corp.google.com - request from 
+
+GET /debug HTTP/1.1
+
+headers:
+
+Host: foo.bar
+User-Agent: istio/fortio-1.1.0
+
+body:
+```
+
 * Simple grpc ping:
 ```
 $ fortio grpcping localhost

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ docker run istio/fortio load http://www.google.com/ # For a test run
 Or download the binary distribution, for instance:
 
 ```shell
-curl -L https://github.com/istio/fortio/releases/download/v1.0.0/fortio-linux_x64-1.0.0.tgz \
+curl -L https://github.com/istio/fortio/releases/download/v1.1.0/fortio-linux_x64-1.1.0.tgz \
  | sudo tar -C / -xvzpf -
 ```
 
@@ -214,7 +214,8 @@ target is a url (http load tests) or host:port (grpc health test).  flags are:
 	Unix domain socket to use for physical connection
   -user string
 	User credentials for basic authentication (for http). Input data format
-	should be user:password</pre>
+	should be user:password
+</pre>
 </details>
 
 See also the FAQ entry about [fortio flags for best results](https://github.com/istio/fortio/wiki/FAQ#i-want-to-get-the-best-results-what-flags-should-i-pass)
@@ -224,12 +225,12 @@ See also the FAQ entry about [fortio flags for best results](https://github.com/
 * Start the internal servers:
 ```
 $ fortio server &
-Fortio 1.0.0 grpc 'ping' server listening on [::]:8079
-Fortio 1.0.0 https redirector server listening on [::]:8081
-Fortio 1.0.0 echo server listening on [::]:8080
+Fortio 1.1.0 grpc 'ping' server listening on [::]:8079
+Fortio 1.1.0 https redirector server listening on [::]:8081
+Fortio 1.1.0 echo server listening on [::]:8080
 UI started - visit:
 http://localhost:8080/fortio/   (or any host/ip reachable on this server)
-21:45:23 I fortio_main.go:195> All fortio 1.0.0 buildinfo go1.10 servers started!
+21:45:23 I fortio_main.go:195> All fortio 1.1.0 buildinfo go1.10 servers started!
 ```
 
 * By default, Fortio's web/echo servers listen on port 8080 on all interfaces.
@@ -239,8 +240,8 @@ $ fortio server -http-port 10.10.10.10:8088
 UI starting - visit:
 http://10.10.10.10:8088/fortio/
 Https redirector running on :8081
-Fortio 1.0.0 grpc ping server listening on port :8079
-Fortio 1.0.0 echo server listening on port 10.10.10.10:8088
+Fortio 1.1.0 grpc ping server listening on port :8079
+Fortio 1.1.0 echo server listening on port 10.10.10.10:8088
 ```
 * Simple grpc ping:
 ```
@@ -280,8 +281,8 @@ $ fortio server -cert /path/to/fortio/server.crt -key /path/to/fortio/server.key
 UI starting - visit:
 http://localhost:8080/fortio/
 Https redirector running on :8081
-Fortio 1.0.0 grpc ping server listening on port :8079
-Fortio 1.0.0 echo server listening on port localhost:8080
+Fortio 1.1.0 grpc ping server listening on port :8079
+Fortio 1.1.0 echo server listening on port localhost:8080
 Using server certificate /path/to/fortio/server.crt to construct TLS credentials
 Using server key /path/to/fortio/server.key to construct TLS credentials
 ```
@@ -317,7 +318,7 @@ Clock skew histogram usec : count 1 avg 12329.795 +/- 0 min 12329.795 max 12329.
 * Load (low default qps/threading) test:
 ```
 $ fortio load http://www.google.com
-Fortio 1.0.0 running at 8 queries per second, 8->8 procs, for 5s: http://www.google.com
+Fortio 1.1.0 running at 8 queries per second, 8->8 procs, for 5s: http://www.google.com
 19:10:33 I httprunner.go:84> Starting http test for http://www.google.com with 4 threads at 8.0 qps
 Starting at 8 qps with 4 thread(s) [gomax 8] for 5s : 10 calls each (total 40)
 19:10:39 I periodic.go:314> T002 ended after 5.056753279s : 10 calls. qps=1.9775534712220633
@@ -347,7 +348,7 @@ All done 40 calls (plus 4 warmup) 60.588 ms avg, 7.9 qps
 Uses `-s` to use multiple (h2/grpc) streams per connection (`-c`), request to hit the fortio ping grpc endpoint with a delay in replies of 0.25s and an extra payload for 10 bytes and auto save the json result:
 ```bash
 $ fortio load -a -grpc -ping -grpc-ping-delay 0.25s -payload "01234567890" -c 2 -s 4 https://fortio-stage.istio.io
-Fortio 1.0.0 running at 8 queries per second, 8->8 procs, for 5s: https://fortio-stage.istio.io
+Fortio 1.1.0 running at 8 queries per second, 8->8 procs, for 5s: https://fortio-stage.istio.io
 16:32:56 I grpcrunner.go:139> Starting GRPC Ping Delay=250ms PayloadLength=11 test for https://fortio-stage.istio.io with 4*2 threads at 8.0 qps
 16:32:56 I grpcrunner.go:261> stripping https scheme. grpc destination: fortio-stage.istio.io. grpc port: 443
 16:32:57 I grpcrunner.go:261> stripping https scheme. grpc destination: fortio-stage.istio.io. grpc port: 443
@@ -449,14 +450,14 @@ Content-Type: text/plain; charset=UTF-8
 Date: Mon, 08 Jan 2018 22:26:26 GMT
 Content-Length: 230
 
-Φορτίο version 1.0.0 echo debug server up for 39s on ldemailly-macbookpro - request from [::1]:65055
+Φορτίο version 1.1.0 echo debug server up for 39s on ldemailly-macbookpro - request from [::1]:65055
 
 GET /debug HTTP/1.1
 
 headers:
 
 Host: localhost:8080
-User-Agent: istio/fortio-1.0.0
+User-Agent: istio/fortio-1.1.0
 Foo: Bar
 
 body:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Full list of command line flags (`fortio help`):
 <details>
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
-Φορτίο 1.0.1 usage:
+Φορτίο 1.1.0 usage:
 	fortio command [flags] target
 where command is one of: load (load testing), server (starts grpc ping and http
 echo/ui/redirect/proxy servers), grpcping (grpc client), report (report only UI
@@ -127,7 +127,8 @@ target is a url (http load tests) or host:port (grpc health test).  flags are:
 	grpc ping delay in response
   -grpc-port string
 	grpc server port. Can be in the form of host:port, ip:port or port or
-	"disabled" to not start the grpc server. (default "8079")
+	/unix/domain/path or "disabled" to not start the grpc server. (default
+	"8079")
   -halfclose
 	When not keepalive, whether to half close the connection (only for fast
 	http)
@@ -136,8 +137,8 @@ target is a url (http load tests) or host:port (grpc health test).  flags are:
   -healthservice string
 	which service string to pass to health check
   -http-port string
-	http echo server port. Can be in the form of host:port, ip:port or port.
-	(default "8080")
+	http echo server port. Can be in the form of host:port, ip:port, port or
+	/unix/domain/path. (default "8080")
   -http1.0
 	Use http1.0 (instead of http 1.1)
   -httpbufferkb int
@@ -176,7 +177,8 @@ target is a url (http load tests) or host:port (grpc health test).  flags are:
   -payload string
 	Payload string to send along
   -payload-size int
-    Additional random payload size, replaces -payload when set > 0, must be smaller than -maxpayloadsizekb
+	Additional random payload size, replaces -payload when set > 0, must be
+	smaller than -maxpayloadsizekb
   -ping
 	grpc load test: use ping instead of health
   -profile string
@@ -208,10 +210,11 @@ target is a url (http load tests) or host:port (grpc health test).  flags are:
   -ui-path string
 	http server URI for UI, empty turns off that part (more secure) (default
 	"/fortio/")
+  -unix-socket string
+	Unix domain socket to use for physical connection
   -user string
 	User credentials for basic authentication (for http). Input data format
-	should be user:password
-</pre>
+	should be user:password</pre>
 </details>
 
 See also the FAQ entry about [fortio flags for best results](https://github.com/istio/fortio/wiki/FAQ#i-want-to-get-the-best-results-what-flags-should-i-pass)

--- a/bincommon/commonflags.go
+++ b/bincommon/commonflags.go
@@ -72,6 +72,8 @@ var (
 		" should be user:password")
 	// QuietFlag is the value of -quiet.
 	QuietFlag = flag.Bool("quiet", false, "Quiet mode: sets the loglevel to Error and reduces the output.")
+	// UnixDomainSocket to use instead of regular host:port
+	unixDomainSocketFlag = flag.String("unix-socket", "", "Unix domain socket to use for physical connection")
 )
 
 // SharedMain is the common part of main from fortio_main and fcurl.
@@ -131,6 +133,7 @@ func SharedHTTPOptions() *fhttp.HTTPOptions {
 	httpOpts.HTTPReqTimeOut = *httpReqTimeoutFlag
 	httpOpts.Insecure = *httpsInsecureFlag
 	httpOpts.UserCredentials = *userCredentialsFlag
+	httpOpts.UnixDomainSocket = *unixDomainSocketFlag
 	if *followRedirectsFlag {
 		httpOpts.FollowRedirects = true
 		httpOpts.DisableFastClient = true

--- a/fgrpc/grpcrunner_test.go
+++ b/fgrpc/grpcrunner_test.go
@@ -42,9 +42,9 @@ var (
 
 func TestGRPCRunner(t *testing.T) {
 	log.SetLogLevel(log.Info)
-	iPort := PingServer("0", "", "", "bar", 0)
+	iPort := PingServerTCP("0", "", "", "bar", 0)
 	iDest := fmt.Sprintf("localhost:%d", iPort)
-	sPort := PingServer("0", svrCrt, svrKey, "bar", 0)
+	sPort := PingServerTCP("0", svrCrt, svrKey, "bar", 0)
 	sDest := fmt.Sprintf("localhost:%d", sPort)
 
 	ro := periodic.RunnerOptions{
@@ -158,7 +158,7 @@ func TestGRPCRunner(t *testing.T) {
 
 func TestGRPCRunnerMaxStreams(t *testing.T) {
 	log.SetLogLevel(log.Info)
-	port := PingServer("0", "", "", "maxstream", 10)
+	port := PingServerTCP("0", "", "", "maxstream", 10)
 	destination := fmt.Sprintf("localhost:%d", port)
 
 	opts := GRPCRunnerOptions{
@@ -207,9 +207,9 @@ func TestGRPCRunnerMaxStreams(t *testing.T) {
 
 func TestGRPCRunnerWithError(t *testing.T) {
 	log.SetLogLevel(log.Info)
-	iPort := PingServer("0", "", "", "bar", 0)
+	iPort := PingServerTCP("0", "", "", "bar", 0)
 	iDest := fmt.Sprintf("localhost:%d", iPort)
-	sPort := PingServer("0", svrCrt, svrKey, "bar", 0)
+	sPort := PingServerTCP("0", svrCrt, svrKey, "bar", 0)
 	sDest := fmt.Sprintf("localhost:%d", sPort)
 
 	ro := periodic.RunnerOptions{

--- a/fgrpc/grpcrunner_test.go
+++ b/fgrpc/grpcrunner_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/fortio/fnet"
 	"istio.io/fortio/log"
 	"istio.io/fortio/periodic"
 
@@ -46,6 +47,9 @@ func TestGRPCRunner(t *testing.T) {
 	iDest := fmt.Sprintf("localhost:%d", iPort)
 	sPort := PingServerTCP("0", svrCrt, svrKey, "bar", 0)
 	sDest := fmt.Sprintf("localhost:%d", sPort)
+	uds := fnet.GetUniqueUnixDomainPath("fortio-grpc-test")
+	uPath := PingServer(uds, "", "", "", 10)
+	uDest := "foo.bar:125"
 
 	ro := periodic.RunnerOptions{
 		QPS:        10, // some internet outcalls, not too fast
@@ -70,6 +74,14 @@ func TestGRPCRunner(t *testing.T) {
 			runnerOpts: GRPCRunnerOptions{
 				Destination: sDest,
 				CACert:      caCrt,
+			},
+			expect: true,
+		},
+		{
+			name: "valid unix domain socket runner",
+			runnerOpts: GRPCRunnerOptions{
+				Destination:      uDest,
+				UnixDomainSocket: uPath.String(),
 			},
 			expect: true,
 		},

--- a/fgrpc/pingsrv.go
+++ b/fgrpc/pingsrv.go
@@ -17,6 +17,7 @@ package fgrpc
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"time"
 
@@ -57,10 +58,10 @@ func (s *pingSrv) Ping(c context.Context, in *PingMessage) (*PingMessage, error)
 // get a dynamic server). Pass the healthServiceName to use for the
 // grpc service name health check (or pass DefaultHealthServiceName)
 // to be marked as SERVING. Pass maxConcurrentStreams > 0 to set that option.
-func PingServer(port, cert, key, healthServiceName string, maxConcurrentStreams uint32) int {
+func PingServer(port, cert, key, healthServiceName string, maxConcurrentStreams uint32) net.Addr {
 	socket, addr := fnet.Listen("grpc '"+healthServiceName+"'", port)
 	if addr == nil {
-		return -1
+		return nil
 	}
 	var grpcOptions []grpc.ServerOption
 	if maxConcurrentStreams > 0 {
@@ -87,7 +88,17 @@ func PingServer(port, cert, key, healthServiceName string, maxConcurrentStreams 
 			log.Fatalf("failed to start grpc server: %v", err)
 		}
 	}()
-	return addr.Port
+	return addr
+}
+
+// PingServerTCP is PingServer() assuming tcp instead of possible unix domain socket port, returns
+// the numeric port.
+func PingServerTCP(port, cert, key, healthServiceName string, maxConcurrentStreams uint32) int {
+	addr := PingServer(port, cert, key, healthServiceName, maxConcurrentStreams)
+	if addr == nil {
+		return -1
+	}
+	return addr.(*net.TCPAddr).Port
 }
 
 // PingClientCallPayloadSize calls the ping service. It is similar to PingClientCall instead of using payload, it uses
@@ -101,7 +112,8 @@ func PingClientCallPayloadSize(serverAddr, cacert string, n int, payloadSize int
 // PingClientCall calls the ping service (presumably running as PingServer on
 // the destination). returns the average round trip in seconds.
 func PingClientCall(serverAddr, cacert string, n int, payload string, delay time.Duration) (float64, error) {
-	conn, err := Dial(serverAddr, cacert, "") // somehow this never seem to error out, error comes later
+	o := GRPCRunnerOptions{Destination: serverAddr, CACert: cacert}
+	conn, err := Dial(&o) // somehow this never seem to error out, error comes later
 	if err != nil {
 		return -1, err // error already logged
 	}
@@ -159,7 +171,8 @@ type HealthResultMap map[grpc_health_v1.HealthCheckResponse_ServingStatus]int64
 // service.
 func GrpcHealthCheck(serverAddr, cacert string, svcname string, n int) (*HealthResultMap, error) {
 	log.Debugf("GrpcHealthCheck for %s svc '%s', %d iterations", serverAddr, svcname, n)
-	conn, err := Dial(serverAddr, cacert, "")
+	o := GRPCRunnerOptions{Destination: serverAddr, CACert: cacert}
+	conn, err := Dial(&o)
 	if err != nil {
 		return nil, err
 	}

--- a/fgrpc/pingsrv_test.go
+++ b/fgrpc/pingsrv_test.go
@@ -33,10 +33,10 @@ func init() {
 }
 
 func TestPingServer(t *testing.T) {
-	iPort := PingServer("0", "", "", "foo", 0)
+	iPort := PingServerTCP("0", "", "", "foo", 0)
 	iAddr := fmt.Sprintf("localhost:%d", iPort)
 	t.Logf("insecure grpc ping server running, will connect to %s", iAddr)
-	sPort := PingServer("0", svrCrt, svrKey, "foo", 0)
+	sPort := PingServerTCP("0", svrCrt, svrKey, "foo", 0)
 	sAddr := fmt.Sprintf("localhost:%d", sPort)
 	t.Logf("secure grpc ping server running, will connect to %s", sAddr)
 	delay := 100 * time.Millisecond
@@ -92,7 +92,7 @@ func TestPingServer(t *testing.T) {
 		t.Errorf("Was expecting dial error when using invalid certificate, didn't get one, got %+v", r)
 	}
 	// 2nd server on same port should fail to bind:
-	newPort := PingServer(strconv.Itoa(iPort), "", "", "will fail", 0)
+	newPort := PingServerTCP(strconv.Itoa(iPort), "", "", "will fail", 0)
 	if newPort != -1 {
 		t.Errorf("Didn't expect 2nd server on same port to succeed: %d %d", newPort, iPort)
 	}

--- a/fhttp/http_client.go
+++ b/fhttp/http_client.go
@@ -478,7 +478,7 @@ func (c *FastClient) connect() net.Conn {
 	}
 	tcpSock, ok := socket.(*net.TCPConn)
 	if !ok {
-		log.Warnf("Not setting socket options on non tcp socket %v", socket.RemoteAddr())
+		log.LogVf("Not setting socket options on non tcp socket %v", socket.RemoteAddr())
 		return socket
 	}
 	// For now those errors are not critical/breaking

--- a/fhttp/http_test.go
+++ b/fhttp/http_test.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -730,7 +729,7 @@ func TestDebugHandlerSortedHeaders(t *testing.T) {
 }
 
 func TestEchoHeaders(t *testing.T) {
-	_, a := Serve("0", "")
+	_, a := ServeTCP("0", "")
 	var headers = []struct {
 		key   string
 		value string
@@ -777,7 +776,8 @@ func TestEchoHeaders(t *testing.T) {
 }
 
 func TestPPROF(t *testing.T) {
-	mux, addr := HTTPServer("test pprof", "0")
+	mux, addrN := HTTPServer("test pprof", "0")
+	addr := addrN.(*net.TCPAddr)
 	url := fmt.Sprintf("localhost:%d/debug/pprof/heap?debug=1", addr.Port)
 	code, _ := Fetch(&HTTPOptions{URL: url})
 	if code != http.StatusNotFound {
@@ -794,7 +794,7 @@ func TestPPROF(t *testing.T) {
 }
 
 func TestFetchAndOnBehalfOf(t *testing.T) {
-	mux, addr := Serve("0", "/debug")
+	mux, addr := ServeTCP("0", "/debug")
 	mux.Handle("/fetch/", http.StripPrefix("/fetch/", http.HandlerFunc(FetcherHandler)))
 	url := fmt.Sprintf("localhost:%d/fetch/localhost:%d/debug", addr.Port, addr.Port)
 	code, data := Fetch(&HTTPOptions{URL: url})
@@ -809,9 +809,10 @@ func TestFetchAndOnBehalfOf(t *testing.T) {
 
 func TestServeError(t *testing.T) {
 	_, addr := Serve("0", "")
-	mux2, addr2 := Serve(strconv.Itoa(addr.Port), "")
+	port := fnet.GetPort(addr)
+	mux2, addr2 := Serve(port, "")
 	if mux2 != nil || addr2 != nil {
-		t.Errorf("2nd Serve() on same port %d should have failed: %v %v", addr.Port, mux2, addr2)
+		t.Errorf("2nd Serve() on same port %v should have failed: %v %v", port, mux2, addr2)
 	}
 }
 
@@ -822,7 +823,7 @@ func testCacheHeaderHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestCache(t *testing.T) {
-	mux, addr := Serve("0", "")
+	mux, addr := ServeTCP("0", "")
 	mux.HandleFunc("/cached", testCacheHeaderHandler)
 	baseURL := fmt.Sprintf("http://localhost:%d/", addr.Port)
 	o := NewHTTPOptions(baseURL)
@@ -847,7 +848,8 @@ func TestCache(t *testing.T) {
 func TestRedirector(t *testing.T) {
 	addr := RedirectToHTTPS(":0")
 	relativeURL := "/foo/bar?some=param&anotherone"
-	url := fmt.Sprintf("http://localhost:%d%s", addr.Port, relativeURL)
+	port := fnet.GetPort(addr)
+	url := fmt.Sprintf("http://localhost:%s%s", port, relativeURL)
 	opts := NewHTTPOptions(url)
 	opts.AddAndValidateExtraHeader("Host: foo.istio.io")
 	code, data := Fetch(opts)
@@ -858,9 +860,9 @@ func TestRedirector(t *testing.T) {
 		t.Errorf("Result %s doesn't contain Location: redirect", DebugSummary(data, 1024))
 	}
 	// 2nd one should fail
-	addr2 := RedirectToHTTPS(strconv.Itoa(addr.Port))
+	addr2 := RedirectToHTTPS(port)
 	if addr2 != nil {
-		t.Errorf("2nd RedirectToHTTPS() on same port %d should have failed: %v", addr.Port, addr2)
+		t.Errorf("2nd RedirectToHTTPS() on same port %s should have failed: %v", port, addr2)
 
 	}
 }
@@ -876,7 +878,7 @@ func escapeTestHandler(w http.ResponseWriter, r *http.Request) {
 func TestHTMLEscapeWriter(t *testing.T) {
 	mux, addr := HTTPServer("test escape", ":0")
 	mux.HandleFunc("/", escapeTestHandler)
-	url := fmt.Sprintf("http://localhost:%d/", addr.Port)
+	url := fmt.Sprintf("http://localhost:%s/", fnet.GetPort(addr))
 	code, data := FetchURL(url)
 	if code != http.StatusOK {
 		t.Errorf("Got %d %s instead of ok for %s", code, DebugSummary(data, 256), url)
@@ -896,7 +898,7 @@ func TestNewHTMLEscapeWriterError(t *testing.T) {
 }
 
 func TestDefaultHeadersAndOptionsInit(t *testing.T) {
-	_, addr := Serve("0", "/debug")
+	_, addr := ServeTCP("0", "/debug")
 	// Un initialized http options:
 	o := HTTPOptions{URL: fmt.Sprintf("http://localhost:%d/debug", addr.Port)}
 	o1 := o

--- a/fhttp/httprunner_test.go
+++ b/fhttp/httprunner_test.go
@@ -203,7 +203,7 @@ func TestHTTPRunnerBadServer(t *testing.T) {
 // the error test for / url above fail:
 
 func TestServe(t *testing.T) {
-	_, addr := Serve("0", "/debugx1")
+	_, addr := ServeTCP("0", "/debugx1")
 	port := addr.Port
 	log.Infof("On addr %s found port: %d", addr, port)
 	url := fmt.Sprintf("http://localhost:%d/debugx1?env=dump", port)

--- a/fnet/network.go
+++ b/fnet/network.go
@@ -277,7 +277,8 @@ func GetUniqueUnixDomainPath(prefix string) string {
 		return "/tmp/fortio-default-uds"
 	}
 	fname := f.Name()
-	f.Close()
-	os.Remove(fname) // for the bind to succeed
+	_ = f.Close()
+	// for the bind to succeed we need the file to not pre exist:
+	_ = os.Remove(fname)
 	return fname
 }

--- a/fnet/network.go
+++ b/fnet/network.go
@@ -103,9 +103,8 @@ func Listen(name string, port string) (net.Listener, net.Addr) {
 		return nil, nil
 	}
 	lAddr := listener.Addr()
-	lPort := GetPort(lAddr)
 	if len(name) > 0 {
-		fmt.Printf("Fortio %s %s server listening on %s\n", version.Short(), name, lPort)
+		fmt.Printf("Fortio %s %s server listening on %s\n", version.Short(), name, lAddr)
 	}
 	return listener, lAddr
 }

--- a/fnet/network.go
+++ b/fnet/network.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"math/rand"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -37,6 +38,8 @@ const (
 	PrefixHTTP = "http://"
 	// PrefixHTTPS is a constant value for representing secure http protocol that can be added prefix of url
 	PrefixHTTPS = "https://"
+	// UnixDomainSocket type for network addresses.
+	UnixDomainSocket = "unix"
 )
 
 var (
@@ -80,25 +83,46 @@ func NormalizePort(port string) string {
 // Listen returns a listener for the port. Port can be a port or a
 // bind address and a port (e.g. "8080" or "[::1]:8080"...). If the
 // port component is 0 a free port will be returned by the system.
+// If the port is a pathname (contains a /) a unix domain socket listener
+// will be used instead of regular tcp socket.
 // This logs critical on error and returns nil (is meant for servers
 // that must start).
-func Listen(name string, port string) (net.Listener, *net.TCPAddr) {
-	nPort := NormalizePort(port)
-	listener, err := net.Listen("tcp", nPort)
+func Listen(name string, port string) (net.Listener, net.Addr) {
+	sockType := "tcp"
+	nPort := port
+	if strings.Contains(port, "/") {
+		sockType = UnixDomainSocket
+	} else {
+		nPort = NormalizePort(port)
+	}
+	listener, err := net.Listen(sockType, nPort)
 	if err != nil {
-		log.Critf("Can't listen to %v for %s: %v", nPort, name, err)
+		log.Critf("Can't listen to %s socket %v (%v) for %s: %v", sockType, port, nPort, name, err)
 		return nil, nil
 	}
-	addr := listener.Addr().(*net.TCPAddr)
+	lAddr := listener.Addr()
+	lPort := GetPort(lAddr)
 	if len(name) > 0 {
-		fmt.Printf("Fortio %s %s server listening on %s\n", version.Short(), name, addr.String())
+		fmt.Printf("Fortio %s %s server listening on %s\n", version.Short(), name, lPort)
 	}
-	return listener, addr
+	return listener, lAddr
+}
+
+// GetPort extracts the port for TCP sockets and the path for unix domain sockets.
+func GetPort(lAddr net.Addr) string {
+	var lPort string
+	// Note: might panic if called with something else than unix or tcp socket addr, it's ok.
+	if lAddr.Network() == UnixDomainSocket {
+		lPort = lAddr.(*net.UnixAddr).Name
+	} else {
+		lPort = strconv.Itoa(lAddr.(*net.TCPAddr).Port)
+	}
+	return lPort
 }
 
 // ResolveDestination returns the TCP address of the "host:port" suitable for net.Dial.
 // nil in case of errors.
-func ResolveDestination(dest string) *net.TCPAddr {
+func ResolveDestination(dest string) net.Addr {
 	i := strings.LastIndex(dest, ":") // important so [::1]:port works
 	if i < 0 {
 		log.Errf("Destination '%s' is not host:port format", dest)
@@ -111,7 +135,8 @@ func ResolveDestination(dest string) *net.TCPAddr {
 
 // Resolve returns the TCP address of the host,port suitable for net.Dial.
 // nil in case of errors.
-func Resolve(host string, port string) *net.TCPAddr {
+func Resolve(host string, port string) net.Addr {
+	log.Debugf("Resolve() called with host=%s port=%s", host, port)
 	dest := &net.TCPAddr{}
 	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
 		log.Debugf("host %s looks like an IPv6, stripping []", host)
@@ -143,22 +168,32 @@ func Resolve(host string, port string) *net.TCPAddr {
 	return dest
 }
 
-func transfer(wg *sync.WaitGroup, dst *net.TCPConn, src *net.TCPConn) {
+func transfer(wg *sync.WaitGroup, dst net.Conn, src net.Conn) {
 	n, oErr := io.Copy(dst, src) // keep original error for logs below
 	log.LogVf("Proxy: transferred %d bytes from %v to %v (err=%v)", n, src.RemoteAddr(), dst.RemoteAddr(), oErr)
-	err := src.CloseRead()
-	if err != nil { // We got an eof so it's already half closed.
-		log.LogVf("Proxy: semi expected error CloseRead on src %v: %v,%v", src.RemoteAddr(), err, oErr)
+	sTCP, ok := src.(*net.TCPConn)
+	if ok {
+		err := sTCP.CloseRead()
+		if err != nil { // We got an eof so it's already half closed.
+			log.LogVf("Proxy: semi expected error CloseRead on src %v: %v,%v", src.RemoteAddr(), err, oErr)
+		}
 	}
-	err = dst.CloseWrite()
-	if err != nil {
-		log.Errf("Proxy: error CloseWrite on dst %v: %v,%v", dst.RemoteAddr(), err, oErr)
+	dTCP, ok := dst.(*net.TCPConn)
+	if ok {
+		err := dTCP.CloseWrite()
+		if err != nil {
+			log.Errf("Proxy: error CloseWrite on dst %v: %v,%v", dst.RemoteAddr(), err, oErr)
+		}
 	}
 	wg.Done()
 }
 
-func handleProxyRequest(conn *net.TCPConn, dest *net.TCPAddr) {
-	d, err := net.DialTCP("tcp", nil, dest)
+func handleProxyRequest(conn net.Conn, dest net.Addr) {
+	err := fmt.Errorf("nil destination")
+	var d net.Conn
+	if dest != nil {
+		d, err = net.Dial(dest.Network(), dest.String())
+	}
 	if err != nil {
 		log.Errf("Proxy: unable to connect to %v for %v : %v", dest, conn.RemoteAddr(), err)
 		_ = conn.Close()
@@ -176,9 +211,9 @@ func handleProxyRequest(conn *net.TCPConn, dest *net.TCPAddr) {
 }
 
 // Proxy starts a tcp proxy.
-func Proxy(port string, dest *net.TCPAddr) *net.TCPAddr {
-	listener, addr := Listen("proxy for "+dest.String(), port)
-	if addr == nil {
+func Proxy(port string, dest net.Addr) net.Addr {
+	listener, lAddr := Listen(fmt.Sprintf("proxy for %v", dest), port)
+	if listener == nil {
 		return nil // error already logged
 	}
 	go func() {
@@ -187,29 +222,32 @@ func Proxy(port string, dest *net.TCPAddr) *net.TCPAddr {
 			if err != nil {
 				log.Critf("Proxy: error accepting: %v", err) // will this loop with error?
 			} else {
-				tcpConn := conn.(*net.TCPConn)
 				log.LogVf("Proxy: Accepted proxy connection from %v -> %v (for listener %v)",
 					conn.RemoteAddr(), conn.LocalAddr(), dest)
 				// TODO limit number of go request, use worker pool, etc...
-				go handleProxyRequest(tcpConn, dest)
+				go handleProxyRequest(conn, dest)
 			}
 		}
 	}()
-	return addr
+	return lAddr
 }
 
-// ProxyToDestination opens a proxy from the listenPort (or addr:port) and forwards
+// ProxyToDestination opens a proxy from the listenPort (or addr:port or unix domain socket path) and forwards
 // all traffic to destination (host:port)
-func ProxyToDestination(listenPort string, destination string) *net.TCPAddr {
+func ProxyToDestination(listenPort string, destination string) net.Addr {
 	return Proxy(listenPort, ResolveDestination(destination))
 }
 
 // NormalizeHostPort generates host:port string for the address or uses localhost instead of [::]
 // when the original port binding input didn't specify an address
-func NormalizeHostPort(inputPort string, addr *net.TCPAddr) string {
+func NormalizeHostPort(inputPort string, addr net.Addr) string {
 	urlHostPort := addr.String()
-	if strings.HasPrefix(inputPort, ":") || !strings.Contains(inputPort, ":") {
-		urlHostPort = fmt.Sprintf("localhost:%d", addr.Port)
+	if addr.Network() == UnixDomainSocket {
+		urlHostPort = fmt.Sprintf("-unix-socket=%s", urlHostPort)
+	} else {
+		if strings.HasPrefix(inputPort, ":") || !strings.Contains(inputPort, ":") {
+			urlHostPort = fmt.Sprintf("localhost:%d", addr.(*net.TCPAddr).Port)
+		}
 	}
 	return urlHostPort
 }

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -95,9 +95,11 @@ var (
 	caCertFlag        = flag.String("cacert", "",
 		"Path to a custom CA certificate file to be used for the GRPC client TLS, "+
 			"if empty, use https:// prefix for standard internet CAs TLS")
-	echoPortFlag = flag.String("http-port", "8080", "http echo server port. Can be in the form of host:port, ip:port or port.")
+	echoPortFlag = flag.String("http-port", "8080",
+		"http echo server port. Can be in the form of host:port, ip:port, port or /unix/domain/path.")
 	grpcPortFlag = flag.String("grpc-port", fnet.DefaultGRPCPort,
-		"grpc server port. Can be in the form of host:port, ip:port or port or \""+disabled+"\" to not start the grpc server.")
+		"grpc server port. Can be in the form of host:port, ip:port or port or /unix/domain/path or \""+disabled+
+			"\" to not start the grpc server.")
 	echoDbgPathFlag = flag.String("echo-debug-path", "/debug",
 		"http echo server URI for debug, empty turns off that part (more secure)")
 	jsonFlag = flag.String("json", "",
@@ -295,6 +297,7 @@ func fortioLoad(justCurl bool, percList []float64) {
 			Payload:            *payloadFlag,
 			Delay:              *pingDelayFlag,
 			UsePing:            *doPingLoadFlag,
+			UnixDomainSocket:   httpOpts.UnixDomainSocket,
 		}
 		res, err = fgrpc.RunGRPCTest(&o)
 	} else {

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -915,11 +915,16 @@ func Serve(baseurl, port, debugpath, uipath, staticRsrcDir string, datadir strin
 		mux.Handle(uiPath+"data/", LogAndFilterDataRequest(http.StripPrefix(uiPath+"data", fs)))
 	}
 	urlHostPort = fnet.NormalizeHostPort(port, addr)
-	uiMsg := fmt.Sprintf("UI started - visit:\nhttp://%s%s", urlHostPort, uiPath)
-	if !strings.Contains(port, ":") {
-		uiMsg += "   (or any host/ip reachable on this server)"
+	uiMsg := "UI started - visit:\n"
+	if strings.Contains(urlHostPort, "-unix-socket=") {
+		uiMsg += fmt.Sprintf("fortio curl %s http://localhost%s", urlHostPort, uiPath)
+	} else {
+		uiMsg += fmt.Sprintf("http://%s%s", urlHostPort, uiPath)
+		if strings.Contains(urlHostPort, "localhost") {
+			uiMsg += "\n(or any host/ip reachable on this server)"
+		}
 	}
-	fmt.Printf(uiMsg + "\n")
+	fmt.Println(uiMsg)
 	defaultPercentileList = percentileList
 	return true
 }


### PR DESCRIPTION
Fixes #275

Allows -unix-socket option for client side and use a path for server 'ports',
eg. 
`fortio server -http-port /tmp/fortio/http-uds1`
and
`fortio load -unix-socket /tmp/fortio/http-uds1 http://localhost/echo`
