### PR TITLE
fixing duplicate headers, because generate is called more than once, …

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CircleCI](https://circleci.com/gh/fortio/fortio.svg?style=shield)](https://circleci.com/gh/fortio/fortio)
 <img src="https://fortio.org/fortio-logo-color.png" height=141 width=141 align=right>
 
-Fortio (Φορτίο) started as [Istio](https://fortio.org/)'s load testing tool and now graduated to be its own project.
+Fortio (Φορτίο) started as [Istio](https://istio.io/)'s load testing tool and now graduated to be its own project.
 Fortio runs at a specified query per second (qps) and records an histogram of execution time
 and calculates percentiles (e.g. p99 ie the response time such as 99% of the requests take less than that number (in seconds, SI unit)).
 It can run for a set duration, for a fixed number of calls, or until interrupted (at a constant target QPS, or max speed/load per connection/thread).

--- a/fhttp/http_client.go
+++ b/fhttp/http_client.go
@@ -87,6 +87,7 @@ const (
 // GenerateHeaders completes the header generation, including Content-Type/Length
 // and user credential coming from the http options in addition to extra headers
 // coming from flags and AddAndValidateExtraHeader().
+// Warning this gets called more than once, do not generate duplicate headers.
 func (h *HTTPOptions) GenerateHeaders() http.Header {
 	if h.extraHeaders == nil { // not already initialized from flags.
 		h.InitHeaders()
@@ -99,11 +100,11 @@ func (h *HTTPOptions) GenerateHeaders() http.Header {
 		h.ContentType = "application/octet-stream"
 	}
 	if len(h.ContentType) > 0 {
-		allHeaders.Add(contentType, h.ContentType)
+		allHeaders.Set(contentType, h.ContentType)
 	}
 	// Add content-length unless already set in custom headers (or we're not doing a POST)
 	if (payloadLen > 0 || len(h.ContentType) > 0) && len(allHeaders.Get(contentLength)) == 0 {
-		allHeaders.Add(contentLength, strconv.Itoa(payloadLen))
+		allHeaders.Set(contentLength, strconv.Itoa(payloadLen))
 	}
 	err := h.ValidateAndAddBasicAuthentication(allHeaders)
 	if err != nil {
@@ -207,7 +208,7 @@ func (h *HTTPOptions) ValidateAndAddBasicAuthentication(headers http.Header) err
 	if len(s) != 2 {
 		return fmt.Errorf("invalid user credentials \"%s\", expecting \"user:password\"", h.UserCredentials)
 	}
-	headers.Add("Authorization", generateBase64UserCredentials(h.UserCredentials))
+	headers.Set("Authorization", generateBase64UserCredentials(h.UserCredentials))
 	return nil
 }
 


### PR DESCRIPTION
…use Set instead of Add. Fixes #291. (would need a test and maybe better refactoring)


repro is
```
fortio load -user foo:bar -content-type foo/bar -loglevel debug -c 2 -n 2 www.google.com
```

before:
```
POST / HTTP/1.1
Host: www.google.com
Authorization: Basic Zm9vOmJhcg==
Authorization: Basic Zm9vOmJhcg==
Content-Length: 0
Content-Type: foo/bar
Content-Type: foo/bar
User-Agent: fortio.org/fortio-1.2.0-pre
```
on the 2nd connection,
after
```
POST / HTTP/1.1
Host: www.google.com
Authorization: Basic Zm9vOmJhcg==
Content-Length: 0
Content-Type: foo/bar
User-Agent: fortio.org/fortio-1.2.0-pre
```