### PR TITLE
Use proxy from environment

### DIFF
--- a/fhttp/http_client.go
+++ b/fhttp/http_client.go
@@ -374,6 +374,7 @@ func NewStdClient(o *HTTPOptions) *Client {
 		MaxIdleConnsPerHost: o.NumConnections,
 		DisableCompression:  !o.Compression,
 		DisableKeepAlives:   o.DisableKeepAlive,
+		Proxy:               http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
 			Timeout: o.HTTPReqTimeOut,
 		}).Dial,


### PR DESCRIPTION
Sorry for the previous PR, got mixed into vendor problems...

I'm using the 'std' http client, and want to test using HTTP_PROXY environment variable - istio has supported this for a while, but now we have a new 'Whitebox' mode, without any iptables - and outgoing
http traffic will all go trough HTTP_PROXY.  (TCP will go to localhost:port) 

The line just tells go to read the environment variable if set and use it when connecting. 