### PR TITLE
adding a flag to put some jitters between requests of parallel clients

### DIFF
--- a/fgrpc/grpcrunner.go
+++ b/fgrpc/grpcrunner.go
@@ -245,6 +245,7 @@ func RunGRPCTest(o *GRPCRunnerOptions) (*GRPCRunnerResults, error) {
 	if o.UsePing {
 		which = "Ping"
 	}
+	_, _ = fmt.Fprintf(out, "Request Jitter: %t\n", total.RequestJitter)
 	for _, k := range keys {
 		_, _ = fmt.Fprintf(out, "%s %s : %d\n", which, k, total.RetCodes[k])
 	}

--- a/fgrpc/grpcrunner.go
+++ b/fgrpc/grpcrunner.go
@@ -245,7 +245,7 @@ func RunGRPCTest(o *GRPCRunnerOptions) (*GRPCRunnerResults, error) {
 	if o.UsePing {
 		which = "Ping"
 	}
-	_, _ = fmt.Fprintf(out, "Request Jitter: %t\n", total.RequestJitter)
+	_, _ = fmt.Fprintf(out, "Jitter: %t\n", total.Jitter)
 	for _, k := range keys {
 		_, _ = fmt.Fprintf(out, "%s %s : %d\n", which, k, total.RetCodes[k])
 	}

--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -159,6 +159,7 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 	sort.Ints(keys)
 	totalCount := float64(total.DurationHistogram.Count)
 	_, _ = fmt.Fprintf(out, "Sockets used: %d (for perfect keepalive, would be %d)\n", total.SocketCount, r.Options().NumThreads)
+	_, _ = fmt.Fprintf(out, "Request Jitter: %t\n", total.RequestJitter)
 	for _, k := range keys {
 		_, _ = fmt.Fprintf(out, "Code %3d : %d (%.1f %%)\n", k, total.RetCodes[k], 100.*float64(total.RetCodes[k])/totalCount)
 	}

--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -159,7 +159,7 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 	sort.Ints(keys)
 	totalCount := float64(total.DurationHistogram.Count)
 	_, _ = fmt.Fprintf(out, "Sockets used: %d (for perfect keepalive, would be %d)\n", total.SocketCount, r.Options().NumThreads)
-	_, _ = fmt.Fprintf(out, "Request Jitter: %t\n", total.RequestJitter)
+	_, _ = fmt.Fprintf(out, "Jitter: %t\n", total.Jitter)
 	for _, k := range keys {
 		_, _ = fmt.Fprintf(out, "Code %3d : %d (%.1f %%)\n", k, total.RetCodes[k], 100.*float64(total.RetCodes[k])/totalCount)
 	}

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -272,14 +272,14 @@ func fortioLoad(justCurl bool, percList []float64) {
 		log.LogVf("Generated Labels: %s", labels)
 	}
 	ro := periodic.RunnerOptions{
-		QPS:         qps,
-		Duration:    *durationFlag,
-		NumThreads:  *numThreadsFlag,
-		Percentiles: percList,
-		Resolution:  *resolutionFlag,
-		Out:         out,
-		Labels:      labels,
-		Exactly:     *exactlyFlag,
+		QPS:           qps,
+		Duration:      *durationFlag,
+		NumThreads:    *numThreadsFlag,
+		Percentiles:   percList,
+		Resolution:    *resolutionFlag,
+		Out:           out,
+		Labels:        labels,
+		Exactly:       *exactlyFlag,
 		RequestJitter: *requestJitterFlag,
 	}
 	var res periodic.HasRunnerResult

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -142,6 +142,7 @@ var (
 
 	maxStreamsFlag = flag.Uint("grpc-max-streams", 0,
 		"MaxConcurrentStreams for the grpc server. Default (0) is to leave the option unset.")
+	requestJitterFlag = flag.Bool("request-jitter", false, "set to true to de-synchronize parallel clients' requests")
 )
 
 func main() {
@@ -279,6 +280,7 @@ func fortioLoad(justCurl bool, percList []float64) {
 		Out:         out,
 		Labels:      labels,
 		Exactly:     *exactlyFlag,
+		RequestJitter: *requestJitterFlag,
 	}
 	var res periodic.HasRunnerResult
 	var err error

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -142,7 +142,7 @@ var (
 
 	maxStreamsFlag = flag.Uint("grpc-max-streams", 0,
 		"MaxConcurrentStreams for the grpc server. Default (0) is to leave the option unset.")
-	requestJitterFlag = flag.Bool("request-jitter", false, "set to true to de-synchronize parallel clients' requests")
+	jitterFlag = flag.Bool("jitter", false, "set to true to de-synchronize parallel clients' requests")
 )
 
 func main() {
@@ -272,15 +272,15 @@ func fortioLoad(justCurl bool, percList []float64) {
 		log.LogVf("Generated Labels: %s", labels)
 	}
 	ro := periodic.RunnerOptions{
-		QPS:           qps,
-		Duration:      *durationFlag,
-		NumThreads:    *numThreadsFlag,
-		Percentiles:   percList,
-		Resolution:    *resolutionFlag,
-		Out:           out,
-		Labels:        labels,
-		Exactly:       *exactlyFlag,
-		RequestJitter: *requestJitterFlag,
+		QPS:         qps,
+		Duration:    *durationFlag,
+		NumThreads:  *numThreadsFlag,
+		Percentiles: percList,
+		Resolution:  *resolutionFlag,
+		Out:         out,
+		Labels:      labels,
+		Exactly:     *exactlyFlag,
+		Jitter:      *jitterFlag,
 	}
 	var res periodic.HasRunnerResult
 	var err error

--- a/periodic/periodic.go
+++ b/periodic/periodic.go
@@ -128,10 +128,10 @@ type RunnerOptions struct {
 	// to not use that mode. If specified Duration is not used.
 	Exactly int64
 	// When multiple clients are used to generate requests, they tend to send
-	// the requests very close to one another, causing a thundering herb problem
-	// Jitter (+/-10%) added allows the requests to be de-synchronized
+	// requests very close to one another, causing a thundering herd problem
+	// Enabling jitter (+/-10%) allows these requests to be de-synchronized
 	// When enabled, it is only effective in the '-qps' mode
-	RequestJitter bool
+	Jitter bool
 }
 
 // RunnerResults encapsulates the actual QPS observed and duration histogram.
@@ -147,7 +147,7 @@ type RunnerResults struct {
 	Version           string
 	DurationHistogram *stats.HistogramData
 	Exactly           int64 // Echo back the requested count
-	RequestJitter     bool
+	Jitter            bool
 }
 
 // HasRunnerResult is the interface implictly implemented by HTTPRunnerResults
@@ -449,7 +449,7 @@ func (r *periodicRunner) Run() RunnerResults {
 		requestedDuration += fmt.Sprintf(", interrupted after %d", actualCount)
 	}
 	result := RunnerResults{r.RunType, r.Labels, start, requestedQPS, requestedDuration,
-		actualQPS, elapsed, r.NumThreads, version.Short(), functionDuration.Export().CalcPercentiles(r.Percentiles), r.Exactly, r.RequestJitter}
+		actualQPS, elapsed, r.NumThreads, version.Short(), functionDuration.Export().CalcPercentiles(r.Percentiles), r.Exactly, r.Jitter}
 	if log.Log(log.Warning) {
 		result.DurationHistogram.Print(r.Out, "Aggregated Function Time")
 	} else {
@@ -515,8 +515,8 @@ MainLoop:
 			}
 			targetElapsedDuration := time.Duration(int64(targetElapsedInSec * 1e9))
 			sleepDuration := targetElapsedDuration - elapsed
-			if r.RequestJitter {
-				sleepDuration += addJitter(sleepDuration)
+			if r.Jitter {
+				sleepDuration += getJitter(sleepDuration)
 			}
 			log.Debugf("%s target next dur %v - sleep %v", tIDStr, targetElapsedDuration, sleepDuration)
 			sleepTimes.Record(sleepDuration.Seconds())
@@ -556,8 +556,8 @@ func formatDate(d *time.Time) string {
 		d.Hour(), d.Minute(), d.Second())
 }
 
-// Return a jitter time that is (+/-)10% of the duration t
-func addJitter(t time.Duration) time.Duration {
+// getJitter returns a jitter time that is (+/-)10% of the duration t if t is >0
+func getJitter(t time.Duration) time.Duration {
 	if t <= 0 {
 		return time.Duration(0)
 	}

--- a/periodic/periodic.go
+++ b/periodic/periodic.go
@@ -147,6 +147,7 @@ type RunnerResults struct {
 	Version           string
 	DurationHistogram *stats.HistogramData
 	Exactly           int64 // Echo back the requested count
+	RequestJitter     bool
 }
 
 // HasRunnerResult is the interface implictly implemented by HTTPRunnerResults
@@ -448,7 +449,7 @@ func (r *periodicRunner) Run() RunnerResults {
 		requestedDuration += fmt.Sprintf(", interrupted after %d", actualCount)
 	}
 	result := RunnerResults{r.RunType, r.Labels, start, requestedQPS, requestedDuration,
-		actualQPS, elapsed, r.NumThreads, version.Short(), functionDuration.Export().CalcPercentiles(r.Percentiles), r.Exactly}
+		actualQPS, elapsed, r.NumThreads, version.Short(), functionDuration.Export().CalcPercentiles(r.Percentiles), r.Exactly, r.RequestJitter}
 	if log.Log(log.Warning) {
 		result.DurationHistogram.Print(r.Out, "Aggregated Function Time")
 	} else {

--- a/periodic/periodic.go
+++ b/periodic/periodic.go
@@ -25,12 +25,12 @@ package periodic // import "fortio.org/fortio/periodic"
 import (
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"os/signal"
 	"runtime"
 	"sync"
 	"time"
-	"math/rand"
 
 	"fortio.org/fortio/log"
 	"fortio.org/fortio/stats"
@@ -557,8 +557,8 @@ func formatDate(d *time.Time) string {
 
 // Return a jitter time that is (+/-)10% of the duration t
 func addJitter(t time.Duration) time.Duration {
-	i := int64(t/10)
-	j := rand.Int63n(2*i)-i
+	i := int64(t / 10)
+	j := rand.Int63n(2*i) - i
 	return time.Duration(j)
 }
 

--- a/periodic/periodic.go
+++ b/periodic/periodic.go
@@ -558,6 +558,9 @@ func formatDate(d *time.Time) string {
 
 // Return a jitter time that is (+/-)10% of the duration t
 func addJitter(t time.Duration) time.Duration {
+	if t <= 0 {
+		return time.Duration(0)
+	}
 	i := int64(t / 10)
 	j := rand.Int63n(2*i) - i
 	return time.Duration(j)

--- a/ui/static/js/fortio_chart.js
+++ b/ui/static/js/fortio_chart.js
@@ -117,8 +117,8 @@ function makeTitle (res) {
   }
   title.push('Response time histogram at ' + res.RequestedQPS + ' target qps (' +
         myRound(res.ActualQPS, 1) + ' actual) ' + res.NumThreads + ' connections for ' +
-        res.RequestedDuration + ' (actual time ' + myRound(res.ActualDuration / 1e9, 1) + 's), ' +
-        errStr)
+        res.RequestedDuration + ' (actual time ' + myRound(res.ActualDuration / 1e9, 1) + 's), req jitter: ' + 
+		res.RequestJitter + ", " + errStr)
   title.push(percStr)
   return title
 }

--- a/ui/static/js/fortio_chart.js
+++ b/ui/static/js/fortio_chart.js
@@ -117,8 +117,8 @@ function makeTitle (res) {
   }
   title.push('Response time histogram at ' + res.RequestedQPS + ' target qps (' +
         myRound(res.ActualQPS, 1) + ' actual) ' + res.NumThreads + ' connections for ' +
-        res.RequestedDuration + ' (actual time ' + myRound(res.ActualDuration / 1e9, 1) + 's), req jitter: ' + 
-		res.RequestJitter + ", " + errStr)
+        res.RequestedDuration + ' (actual time ' + myRound(res.ActualDuration / 1e9, 1) + 's), jitter: ' + 
+		res.Jitter + ", " + errStr)
   title.push(percStr)
   return title
 }

--- a/ui/templates/main.html
+++ b/ui/templates/main.html
@@ -43,7 +43,7 @@
     or run until interrupted:<input type="checkbox" name="t" onchange="toggleDuration(this)" />
     or run for exactly <input type="text" name="n" size="6" value="" /> calls. <br />
     Threads/Simultaneous connections: <input type="text" name="c" size="6" value="8" /> <br />
-    Request jitter:<input type="checkbox" name="reqjitter" /> <br />
+    Jitter:<input type="checkbox" name="jitter" /> <br />
     Percentiles: <input type="text" name="p" size="20" value="50, 75, 90, 99, 99.9" /> <br />
     Histogram Resolution: <input type="text" name="r" size="8" value="0.0001" /> <br />
     Headers: <br />

--- a/ui/templates/main.html
+++ b/ui/templates/main.html
@@ -43,6 +43,7 @@
     or run until interrupted:<input type="checkbox" name="t" onchange="toggleDuration(this)" />
     or run for exactly <input type="text" name="n" size="6" value="" /> calls. <br />
     Threads/Simultaneous connections: <input type="text" name="c" size="6" value="8" /> <br />
+    Request jitter:<input type="checkbox" name="reqjitter" /> <br />
     Percentiles: <input type="text" name="p" size="20" value="50, 75, 90, 99, 99.9" /> <br />
     Histogram Resolution: <input type="text" name="r" size="8" value="0.0001" /> <br />
     Headers: <br />

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -152,7 +152,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	percList, _ := stats.ParsePercentiles(r.FormValue("p"))   // nolint: gas
 	qps, _ := strconv.ParseFloat(r.FormValue("qps"), 64)      // nolint: gas
 	durStr := r.FormValue("t")
-	reqJitter := (r.FormValue("reqjitter") == "on")
+	jitter := (r.FormValue("jitter") == "on")
 	grpcSecure := (r.FormValue("grpc-secure") == "on")
 	grpcPing := (r.FormValue("ping") == "on")
 	grpcPingDelay, _ := time.ParseDuration(r.FormValue("grpc-ping-delay"))
@@ -193,7 +193,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		Percentiles: percList,
 		Labels:      labels,
 		Exactly:     n,
-		RequestJitter: reqJitter,
+		Jitter:      jitter,
 	}
 	if mode == run {
 		ro.Normalize()

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -152,6 +152,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	percList, _ := stats.ParsePercentiles(r.FormValue("p"))   // nolint: gas
 	qps, _ := strconv.ParseFloat(r.FormValue("qps"), 64)      // nolint: gas
 	durStr := r.FormValue("t")
+	reqJitter := (r.FormValue("reqjitter") == "on")
 	grpcSecure := (r.FormValue("grpc-secure") == "on")
 	grpcPing := (r.FormValue("ping") == "on")
 	grpcPingDelay, _ := time.ParseDuration(r.FormValue("grpc-ping-delay"))
@@ -192,6 +193,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		Percentiles: percList,
 		Labels:      labels,
 		Exactly:     n,
+		RequestJitter: reqJitter,
 	}
 	if mode == run {
 		ro.Normalize()


### PR DESCRIPTION
We have been using `fortio` to measure Istio's latency. One of the problems with its long-tail latency issue is the benchmark itself. When we specify `-c 100`, 100 goroutines are created to send off 100 requests all at the same time (using tcpdump, we saw these requests all got to the server side within 100us). So on the server side, it sees these mini-bursts of requests over and over again. Due to Envoy worker threads being single threaded, this creates a significant queuing delay. In the real world, bursts of requests do happen, but we should not artificially create thundering herd problem to make Istio (or whatever is being tested) to have latency problem that is worse than what it really is. 

A flag `--request-jitter` is added to add (+/-)10% jitter between requests of parallel clients. Here is the result measuring Istio latency with and without the flag:

* Without added jitter:
```
# ./fortio load -qps 1000 -c 100 -t 300s 10.97.103.115:8079
Fortio 1.3.2-pre running at 1000 queries per second, 4->4 procs, for 5m0s: 10.97.103.115:8079
16:33:26 I httprunner.go:82> Starting http test for 10.97.103.115:8079 with 100 threads at 1000.0 qps
16:33:26 W http_client.go:142> Assuming http:// on missing scheme for '10.97.103.115:8079'
Starting at 1000 qps with 100 thread(s) [gomax 4] for 5m0s : 3000 calls each (total 300000)
Ended after 5m0.013834356s : 300000 calls. qps=999.95
Sleep times : count 299900 avg 0.088003375 +/- 0.00315 min 0.059958014 max 0.098711726 sum 26392.2122
Aggregated Function Time : count 300000 avg 0.011201918 +/- 0.003032 min 0.001004862 max 0.038903617 sum 3360.57543
# range, mid point, percentile, count
>= 0.00100486 <= 0.002 , 0.00150243 , 0.01, 19
> 0.002 <= 0.003 , 0.0025 , 0.02, 33
> 0.003 <= 0.004 , 0.0035 , 0.04, 75
> 0.004 <= 0.005 , 0.0045 , 0.07, 96
> 0.005 <= 0.006 , 0.0055 , 0.27, 601
> 0.006 <= 0.007 , 0.0065 , 3.53, 9766
> 0.007 <= 0.008 , 0.0075 , 14.33, 32409
> 0.008 <= 0.009 , 0.0085 , 28.50, 42496
> 0.009 <= 0.01 , 0.0095 , 41.03, 37599
> 0.01 <= 0.011 , 0.0105 , 52.01, 32940
> 0.011 <= 0.012 , 0.0115 , 62.61, 31792
> 0.012 <= 0.014 , 0.013 , 81.53, 56771
> 0.014 <= 0.016 , 0.015 , 93.95, 37256
> 0.016 <= 0.018 , 0.017 , 97.99, 12126
> 0.018 <= 0.02 , 0.019 , 99.12, 3370
> 0.02 <= 0.025 , 0.0225 , 99.90, 2349
> 0.025 <= 0.03 , 0.0275 , 100.00, 300
> 0.03 <= 0.035 , 0.0325 , 100.00, 1
> 0.035 <= 0.0389036 , 0.0369518 , 100.00, 1
# target 50% 0.0108168
# target 75% 0.0133096
# target 90% 0.0153637
# target 99% 0.0197929
# target 99.9% 0.0250333
Sockets used: 100 (for perfect keepalive, would be 100)
Code 200 : 300000 (100.0 %)
Response Header Sizes : count 300000 avg 295.00439 +/- 0.06609 min 295 max 296 sum 88501316
Response Body/Total Sizes : count 300000 avg 295.00439 +/- 0.06609 min 295 max 296 sum 88501316
All done 300000 calls (plus 100 warmup) 11.202 ms avg, 1000.0 qps
```

* With the `--request-jitter` flag:
```
# ./fortio load -qps 1000 -c 100 -t 300s --request-jitter 10.97.103.115:8079
Fortio 1.3.2-pre running at 1000 queries per second, 4->4 procs, for 5m0s: 10.97.103.115:8079
16:28:15 I httprunner.go:82> Starting http test for 10.97.103.115:8079 with 100 threads at 1000.0 qps
16:28:15 W http_client.go:142> Assuming http:// on missing scheme for '10.97.103.115:8079'
Starting at 1000 qps with 100 thread(s) [gomax 4] for 5m0s : 3000 calls each (total 300000)
Ended after 5m0.010714621s : 300000 calls. qps=999.96
Sleep times : count 299900 avg 0.097020439 +/- 0.00854 min 0.054097274 max 0.119709755 sum 29096.4297
Aggregated Function Time : count 300000 avg 0.0027441949 +/- 0.002333 min 0.000662307 max 0.031994066 sum 823.258457
# range, mid point, percentile, count
>= 0.000662307 <= 0.001 , 0.000831154 , 7.27, 21823
> 0.001 <= 0.002 , 0.0015 , 54.81, 142595
> 0.002 <= 0.003 , 0.0025 , 73.09, 54853
> 0.003 <= 0.004 , 0.0035 , 80.92, 23490
> 0.004 <= 0.005 , 0.0045 , 86.02, 15301
> 0.005 <= 0.006 , 0.0055 , 90.61, 13770
> 0.006 <= 0.007 , 0.0065 , 93.94, 9987
> 0.007 <= 0.008 , 0.0075 , 96.14, 6611
> 0.008 <= 0.009 , 0.0085 , 97.51, 4090
> 0.009 <= 0.01 , 0.0095 , 98.32, 2426
> 0.01 <= 0.011 , 0.0105 , 98.80, 1450
> 0.011 <= 0.012 , 0.0115 , 99.12, 960
> 0.012 <= 0.014 , 0.013 , 99.55, 1281
> 0.014 <= 0.016 , 0.015 , 99.77, 676
> 0.016 <= 0.018 , 0.017 , 99.86, 266
> 0.018 <= 0.02 , 0.019 , 99.92, 168
> 0.02 <= 0.025 , 0.0225 , 99.98, 179
> 0.025 <= 0.03 , 0.0275 , 100.00, 62
> 0.03 <= 0.0319941 , 0.030997 , 100.00, 12
# target 50% 0.00189889
# target 75% 0.00324389
# target 90% 0.00586696
# target 99% 0.0116292
# target 99.9% 0.0194405
Sockets used: 100 (for perfect keepalive, would be 100)
Code 200 : 300000 (100.0 %)
Response Header Sizes : count 300000 avg 295.00006 +/- 0.007528 min 295 max 296 sum 88500017
Response Body/Total Sizes : count 300000 avg 295.00006 +/- 0.007528 min 295 max 296 sum 88500017
All done 300000 calls (plus 100 warmup) 2.744 ms avg, 1000.0 qps
```

The latency difference is pretty significant with or without jitter under the same test condition (1000 qps, 100 clients, 300 seconds). Avg latency went from 11.2ms to 2.7ms. Long-tail latency also improved significantly. This problem with request jitter has been discussed here as well: https://github.com/envoyproxy/envoy/issues/5536
