### PR TITLE
Added Merging Functionality

### DIFF
--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -51,8 +51,8 @@ type HTTPRunnerResults struct {
 
 // Merge two different HTTPRunnerResults
 func Merge(rr1 *HTTPRunnerResults,
-	       rr2 *HTTPRunnerResults,
-	       percList []float64) (*HTTPRunnerResults, error) {
+	rr2 *HTTPRunnerResults,
+	percList []float64) (*HTTPRunnerResults, error) {
 
 	ret := HTTPRunnerResults{}
 
@@ -61,17 +61,17 @@ func Merge(rr1 *HTTPRunnerResults,
 	}
 
 	ret.RunnerResults = *periodic.Merge(rr1.Result(),
-                                        rr2.Result(),
-                                        percList)
+		rr2.Result(),
+		percList)
 
 	for k, v := range rr2.RetCodes {
-    	_, ok := rr1.RetCodes[k]
+		_, ok := rr1.RetCodes[k]
 
-    	if ok {
-    		rr1.RetCodes[k] += rr2.RetCodes[k]
-    	} else {
-    		rr1.RetCodes[k] = v
-    	}
+		if ok {
+			rr1.RetCodes[k] += rr2.RetCodes[k]
+		} else {
+			rr1.RetCodes[k] = v
+		}
 	}
 
 	ret.RetCodes = rr1.RetCodes

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -278,7 +278,7 @@ func fortioMerge(args []string, percList []float64) {
 	for idx, fileName := range files {
 		bytes, err := ioutil.ReadFile(fileName)
 		if err != nil {
-			fmt.Println("Aborting because %v\n", err)
+			fmt.Printf("Aborting because %v\n", err)
 			os.Exit(1)
 		}
 
@@ -292,7 +292,7 @@ func fortioMerge(args []string, percList []float64) {
 
 		err = json.Unmarshal(bytes, data)
 		if err != nil {
-			fmt.Println("Aborting because %v\n", err)
+			fmt.Printf("Aborting because %v\n", err)
 			os.Exit(1)
 		}
 
@@ -306,7 +306,7 @@ func fortioMerge(args []string, percList []float64) {
 					data.(*fhttp.HTTPRunnerResults),
 					percList)
 				if err != nil {
-					fmt.Println("Aborting because %v\n", err)
+					fmt.Printf("Aborting because %v\n", err)
 					os.Exit(1)
 				}
 			}

--- a/periodic/periodic.go
+++ b/periodic/periodic.go
@@ -274,6 +274,7 @@ func (r *RunnerOptions) Abort() {
 	}
 }
 
+// Merge two different RunnerResults
 func Merge(rr1 *RunnerResults, rr2 *RunnerResults,
 	percList []float64) *RunnerResults {
 	ret := RunnerResults{}

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -316,6 +316,10 @@ func sumOfSquares(stdev float64, sum float64, count int64) float64 {
 	variance := math.Pow(stdev, 2)
 
 	ret := (variance * fC) + (sum * sum / fC)
+	if math.IsNaN(ret) {
+		return 0
+	}
+
 	return ret
 }
 
@@ -512,6 +516,10 @@ func (h *Histogram) copyHDataFrom(src *Histogram) {
 	}
 }
 
+/* Merge two different HistogramData's. The function calls Import on both
+HistogramData's which converts them into Histograms which are then merged
+using the already present Merge Function.
+*/
 func MergeHistData(hd1 *HistogramData, hd2 *HistogramData, percList []float64) *HistogramData {
 	h1 := hd1.Import()
 	h2 := hd2.Import()

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -330,17 +330,17 @@ func indexSlice(slice []int32, value int32) int {
 
 // Import translate the external representation of the histogram data in
 // an internally usable one.
-func (histData *HistogramData) Import() *Histogram {
-	res := NewHistogram(histData.Offset,
-		histData.Divider)
-	res.Counter.Count = histData.Count
-	res.Counter.Min = histData.Min
-	res.Counter.Max = histData.Max
-	res.Counter.Sum = histData.Sum
-	res.Counter.sumOfSquares = sumOfSquares(histData.StdDev, histData.Sum, histData.Count)
+func (e *HistogramData) Import() *Histogram {
+	res := NewHistogram(e.Offset,
+		e.Divider)
+	res.Counter.Count = e.Count
+	res.Counter.Min = e.Min
+	res.Counter.Max = e.Max
+	res.Counter.Sum = e.Sum
+	res.Counter.sumOfSquares = sumOfSquares(e.StdDev, e.Sum, e.Count)
 
-	for idx, bucket := range histData.Data {
-		if idx < len(histData.Data)-1 {
+	for idx, bucket := range e.Data {
+		if idx < len(e.Data)-1 {
 			e := bucket.Interval.End
 			val := int32((e - res.Offset) / res.Divider)
 			res.Hdata[indexSlice(histogramBucketValues, val)] = int32(bucket.Count)

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -516,10 +516,8 @@ func (h *Histogram) copyHDataFrom(src *Histogram) {
 	}
 }
 
-/* MergeHistData merges two different HistogramData's. The function calls Import on both
-HistogramData's which converts them into Histograms which are then merged
-using the already present Merge Function.
-*/
+// MergeHistData merges two different HistogramData's. 
+// The function calls Import on both HistogramData's.
 func MergeHistData(hd1 *HistogramData, hd2 *HistogramData, percList []float64) *HistogramData {
 	h1 := hd1.Import()
 	h2 := hd2.Import()

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -516,7 +516,7 @@ func (h *Histogram) copyHDataFrom(src *Histogram) {
 	}
 }
 
-/* Merge two different HistogramData's. The function calls Import on both
+/* MergeHistData merges two different HistogramData's. The function calls Import on both
 HistogramData's which converts them into Histograms which are then merged
 using the already present Merge Function.
 */

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -516,7 +516,7 @@ func (h *Histogram) copyHDataFrom(src *Histogram) {
 	}
 }
 
-// MergeHistData merges two different HistogramData's. 
+// MergeHistData merges two different HistogramData's.
 // The function calls Import on both HistogramData's.
 func MergeHistData(hd1 *HistogramData, hd2 *HistogramData, percList []float64) *HistogramData {
 	h1 := hd1.Import()

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -518,6 +518,7 @@ func (h *Histogram) copyHDataFrom(src *Histogram) {
 
 // MergeHistData merges two different HistogramData's.
 // The function calls Import on both HistogramData's.
+// It uses Histogram's Merge Function.
 func MergeHistData(hd1 *HistogramData, hd2 *HistogramData, percList []float64) *HistogramData {
 	h1 := hd1.Import()
 	h2 := hd2.Import()

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -209,8 +209,8 @@ func TestImportFunction3(t *testing.T) {
 const (
 	NumRandomHistogram = 10000
 	NumValues1         = 1
-	NumValues2         = 200
-	NumValues3         = 20000
+	NumValues2         = 20
+	NumValues3         = 2000
 )
 
 func TestImportFunction4(t *testing.T) {

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -206,6 +206,37 @@ func TestImportFunction3(t *testing.T) {
 	}
 }
 
+const (
+	NumRandomHistogram = 10000
+	NumValues          = 2000
+)
+
+func TestImportFunction4(t *testing.T) {
+	for i := 0; i < NumRandomHistogram; i++ {
+		h := NewHistogram(rand.Float64(), rand.Float64())
+
+		for j := 0; j < NumValues; j++ {
+			h.Record(rand.Float64())
+		}
+
+		h.Print(os.Stdout, "TestImportFunction4", []float64{20})
+
+		var tests = []struct {
+			actual   Histogram
+			expected Histogram
+			msg      string
+		}{
+			{*h, *h.Export().Import(), ""},
+		}
+
+		for _, test := range tests {
+			if !reflect.DeepEqual(test.actual, test.expected) {
+				t.Errorf("%+v, %+v, %+v", h, *h.Export(), *h.Export().Import())
+			}
+		}
+	}
+}
+
 func TestHistogram(t *testing.T) {
 	h := NewHistogram(0, 10)
 	h.Record(1)
@@ -390,6 +421,7 @@ func TestHistogramExport1(t *testing.T) {
 	CheckEquals(t, string(data), `{
  "Offset": 0,
  "Divider": 10,
+ "SumOfSquares": 1900224.5488999998,
  "Count": 5,
  "Min": -137.4,
  "Max": 1001.67,
@@ -444,10 +476,6 @@ func TestHistogramExport1(t *testing.T) {
  ]
 }`, "Json output")
 }
-
-const (
-	NumRandomHistogram = 2000
-)
 
 func TestHistogramExportRandom(t *testing.T) {
 	for i := 0; i < NumRandomHistogram; i++ {

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -208,18 +208,72 @@ func TestImportFunction3(t *testing.T) {
 
 const (
 	NumRandomHistogram = 10000
-	NumValues          = 2000
+	NumValues1         = 1
+	NumValues2         = 200
+	NumValues3         = 20000
 )
 
 func TestImportFunction4(t *testing.T) {
 	for i := 0; i < NumRandomHistogram; i++ {
 		h := NewHistogram(rand.Float64(), rand.Float64())
 
-		for j := 0; j < NumValues; j++ {
+		for j := 0; j < NumValues1; j++ {
 			h.Record(rand.Float64())
 		}
 
 		h.Print(os.Stdout, "TestImportFunction4", []float64{20})
+
+		var tests = []struct {
+			actual   Histogram
+			expected Histogram
+			msg      string
+		}{
+			{*h, *h.Export().Import(), ""},
+		}
+
+		for _, test := range tests {
+			if !reflect.DeepEqual(test.actual, test.expected) {
+				t.Errorf("%+v, %+v, %+v", h, *h.Export(), *h.Export().Import())
+			}
+		}
+	}
+}
+
+func TestImportFunction5(t *testing.T) {
+	for i := 0; i < NumRandomHistogram; i++ {
+		h := NewHistogram(rand.Float64(), rand.Float64())
+
+		for j := 0; j < NumValues2; j++ {
+			h.Record(rand.Float64())
+		}
+
+		h.Print(os.Stdout, "TestImportFunction5", []float64{20})
+
+		var tests = []struct {
+			actual   Histogram
+			expected Histogram
+			msg      string
+		}{
+			{*h, *h.Export().Import(), ""},
+		}
+
+		for _, test := range tests {
+			if !reflect.DeepEqual(test.actual, test.expected) {
+				t.Errorf("%+v, %+v, %+v", h, *h.Export(), *h.Export().Import())
+			}
+		}
+	}
+}
+
+func TestImportFunction6(t *testing.T) {
+	for i := 0; i < NumRandomHistogram; i++ {
+		h := NewHistogram(rand.Float64(), rand.Float64())
+
+		for j := 0; j < NumValues3; j++ {
+			h.Record(rand.Float64())
+		}
+
+		h.Print(os.Stdout, "TestImportFunction6", []float64{20})
 
 		var tests = []struct {
 			actual   Histogram
@@ -422,6 +476,7 @@ func TestHistogramExport1(t *testing.T) {
  "Offset": 0,
  "Divider": 10,
  "SumOfSquares": 1900224.5488999998,
+ "BucketMax": 1200,
  "Count": 5,
  "Min": -137.4,
  "Max": 1001.67,

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -318,6 +318,8 @@ func TestHistogramExport1(t *testing.T) {
 		t.Error(err)
 	}
 	CheckEquals(t, string(data), `{
+ "Offset": 0,
+ "Divider": 10,
  "Count": 5,
  "Min": -137.4,
  "Max": 1001.67,

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -136,6 +136,76 @@ func TestZeroDivider(t *testing.T) {
 	}
 }
 
+func TestImportFunction1(t *testing.T) {
+	h := NewHistogram(0, 0.0001)
+	h.Record(0.04)
+	h.Record(0.05)
+	h.Record(0.08)
+	h.Record(0.10)
+	h.Record(0.50)
+	h.Print(os.Stdout, "TestImportFunction1", []float64{50})
+
+	var tests = []struct {
+		actual   Histogram
+		expected Histogram
+		msg      string
+	}{
+		{*h, *h.Export().Import(), ""},
+	}
+
+	for _, test := range tests {
+		if !reflect.DeepEqual(test.actual, test.expected) {
+			t.Errorf("%s: got %+v, not as expected %+v", test.msg, test.actual, test.expected)
+		}
+	}
+}
+
+func TestImportFunction2(t *testing.T) {
+	h := NewHistogram(0, 0.1)
+	h.Print(os.Stdout, "TestImportFunction2", []float64{50})
+
+	var tests = []struct {
+		actual   Histogram
+		expected Histogram
+		msg      string
+	}{
+		{*h, *h.Export().Import(), ""},
+	}
+
+	for _, test := range tests {
+		if !reflect.DeepEqual(test.actual, test.expected) {
+			t.Errorf("%s: got %+v, not as expected %+v", test.msg, test.actual, test.expected)
+		}
+	}
+}
+
+func TestImportFunction3(t *testing.T) {
+	h := NewHistogram(0, 1)
+	h.Record(-1)
+	h.Record(-0.5)
+	h.RecordN(0, 3)
+	h.Record(1)
+	h.Record(2)
+	h.Record(3)
+	h.Record(4)
+	h.RecordN(5, 2)
+	h.Print(os.Stdout, "TestImportFunction3", []float64{50})
+
+	var tests = []struct {
+		actual   Histogram
+		expected Histogram
+		msg      string
+	}{
+		{*h, *h.Export().Import(), ""},
+	}
+
+	for _, test := range tests {
+		if !reflect.DeepEqual(test.actual, test.expected) {
+			t.Errorf("%s: got %+v, not as expected %+v", test.msg, test.actual, test.expected)
+		}
+	}
+}
+
 func TestHistogram(t *testing.T) {
 	h := NewHistogram(0, 10)
 	h.Record(1)


### PR DESCRIPTION
Addresses Issues (https://github.com/fortio/fortio/issues/99, https://github.com/fortio/fortio/issues/134). Adds the functionality to merge multiple fortio json outputs. 

Example: `fortio merge -json "MergedResults.json" -files Result1.json,Result2.json,Result3.json`

1. To enable the merging functionality I had to include the `Offset` and `Divider` variables in the json output to recover the original Histogram from the result.
2. To calculate the Duration I add up all the Durations in the individual files. It might be better to take the average.
