### PR TITLE
fix missing html escaping. also have the example server able to no have the set url

### DIFF
--- a/dflag/endpoint/endpoint.go
+++ b/dflag/endpoint/endpoint.go
@@ -8,9 +8,9 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"html/template"
 	"net/http"
 	"strings"
-	"text/template"
 
 	"fortio.org/fortio/dflag"
 	"fortio.org/fortio/fhttp"

--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	major = 1
 	minor = 6
-	patch = 0
+	patch = 1
 
 	debug = false // turn on to debug init()
 )


### PR DESCRIPTION
- fixes #373 
- disable set url using -has_set=false
