### PR TITLE
help crash fix + DynBool

### DIFF
--- a/dflag/dynbool.go
+++ b/dflag/dynbool.go
@@ -1,0 +1,87 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+// See LICENSE for licensing terms.
+
+package flagz
+
+import (
+	"fmt"
+	"strconv"
+	"sync/atomic"
+
+	flag "github.com/spf13/pflag"
+)
+
+// DynBool creates a `Flag` that represents `bool` which is safe to change dynamically at runtime.
+func DynBool(flagSet *flag.FlagSet, name string, value bool, usage string) *DynBoolValue {
+	v := boolToInt(value)
+	dynValue := &DynBoolValue{ptr: &v}
+	flag := flagSet.VarPF(dynValue, name, "", usage)
+	flag.NoOptDefVal = "true"
+	MarkFlagDynamic(flag)
+	return dynValue
+}
+
+// DynBoolValue is a flag-related `int64` value wrapper.
+type DynBoolValue struct {
+	ptr       *uint32
+	validator func(bool) error
+	notifier  func(oldValue bool, newValue bool)
+}
+
+// Get retrieves the value in a thread-safe manner.
+func (d *DynBoolValue) Get() bool {
+	return atomic.LoadUint32(d.ptr) == 1
+}
+
+// Set updates the value from a string representation in a thread-safe manner.
+// This operation may return an error if the provided `input` doesn't parse, or the resulting value doesn't pass an
+// optional validator.
+// If a notifier is set on the value, it will be invoked in a separate go-routine.
+func (d *DynBoolValue) Set(input string) error {
+	val, err := strconv.ParseBool(input)
+	if err != nil {
+		return err
+	}
+	if d.validator != nil {
+		if err := d.validator(val); err != nil {
+			return err
+		}
+	}
+
+	oldVal := atomic.SwapUint32(d.ptr, boolToInt(val))
+	if d.notifier != nil {
+		go d.notifier(oldVal == 1, val)
+	}
+	return nil
+}
+
+// WithValidator adds a function that checks values before they're set.
+// Any error returned by the validator will lead to the value being rejected.
+// Validators are executed on the same go-routine as the call to `Set`.
+func (d *DynBoolValue) WithValidator(validator func(bool) error) {
+	d.validator = validator
+}
+
+// WithNotifier adds a function is called every time a new value is successfully set.
+// Each notifier is executed in a new go-routine.
+func (d *DynBoolValue) WithNotifier(notifier func(oldValue bool, newValue bool)) {
+	d.notifier = notifier
+}
+
+// Type is an indicator of what this flag represents.
+func (d *DynBoolValue) Type() string {
+	return "dyn_bool"
+}
+
+// String returns the canonical string representation of the type.
+func (d *DynBoolValue) String() string {
+	return fmt.Sprintf("%v", d.Get())
+}
+
+func boolToInt(b bool) uint32 {
+	if b {
+		return 1
+	} else {
+		return 0
+	}
+}

--- a/dflag/dynbool_test.go
+++ b/dflag/dynbool_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+// See LICENSE for licensing terms.
+
+package flagz
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	flag "github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDynBool_SetAndGet(t *testing.T) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	dynFlag := DynBool(set, "some_bool_1", true, "Use it or lose it")
+	assert.Equal(t, true, dynFlag.Get(), "value must be default after create")
+	err := set.Set("some_bool_1", "false")
+	assert.NoError(t, err, "setting value must succeed")
+	assert.Equal(t, false, dynFlag.Get(), "value must be set after update")
+}
+
+func TestDynBool_IsMarkedDynamic(t *testing.T) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	DynBool(set, "some_bool_1", true, "Use it or lose it")
+	assert.True(t, IsFlagDynamic(set.Lookup("some_bool_1")))
+}
+
+func TestDynBool_FiresValidators(t *testing.T) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	DynBool(set, "some_bool_1", true, "Use it or lose it").WithValidator(func(b bool) error {
+		if b {
+			return nil
+		}
+		return fmt.Errorf("not true!")
+	})
+	assert.Error(t, set.Set("some_bool_1", "false"), "error from validator when value does not satisfy validator")
+}
+
+func TestDynBool_FiresNotifier(t *testing.T) {
+	waitCh := make(chan bool, 1)
+	notifier := func(oldVal bool, newVal bool) {
+		assert.EqualValues(t, true, oldVal, "old value in notify must match previous value")
+		assert.EqualValues(t, false, newVal, "new value in notify must match set value")
+		waitCh <- true
+	}
+
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	DynBool(set, "some_bool_1", true, "Use it or lose it").WithNotifier(notifier)
+	set.Set("some_bool_1", "false")
+	select {
+	case <-time.After(5 * time.Millisecond):
+		assert.Fail(t, "failed to trigger notifier")
+	case <-waitCh:
+	}
+}
+
+func Benchmark_Bool_Dyn_Get(b *testing.B) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	value := DynBool(set, "some_bool_1", true, "Use it or lose it")
+	set.Set("some_bool_1", "false")
+	for i := 0; i < b.N; i++ {
+		x := value.Get()
+		x = !x
+	}
+}
+
+func Benchmark_Bool_Normal_Get(b *testing.B) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	valPtr := set.Bool("some_bool_1", true, "Use it or lose it")
+	set.Set("some_bool_1", "false")
+	for i := 0; i < b.N; i++ {
+		x := *valPtr
+		x = !x
+	}
+}

--- a/dflag/dynbool_test.go
+++ b/dflag/dynbool_test.go
@@ -1,14 +1,14 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 // See LICENSE for licensing terms.
 
-package flagz
+package dflag
 
 import (
+	"flag"
 	"fmt"
 	"testing"
 	"time"
 
-	flag "github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/dflag/dynduration.go
+++ b/dflag/dynduration.go
@@ -29,6 +29,9 @@ type DynDurationValue struct {
 
 // Get retrieves the value in a thread-safe manner.
 func (d *DynDurationValue) Get() time.Duration {
+	if d.ptr == nil {
+		return (time.Duration)(0)
+	}
 	return (time.Duration)(atomic.LoadInt64(d.ptr))
 }
 

--- a/dflag/dynfloat64.go
+++ b/dflag/dynfloat64.go
@@ -30,6 +30,9 @@ type DynFloat64Value struct {
 
 // Get retrieves the value in a thread-safe manner.
 func (d *DynFloat64Value) Get() float64 {
+	if d.ptr == nil {
+		return 0.0
+	}
 	p := (*float64)(atomic.LoadPointer(&d.ptr))
 	return *p
 }

--- a/dflag/dynint64.go
+++ b/dflag/dynint64.go
@@ -29,6 +29,9 @@ type DynInt64Value struct {
 
 // Get retrieves the value in a thread-safe manner.
 func (d *DynInt64Value) Get() int64 {
+	if d.ptr == nil {
+		return 0
+	}
 	return atomic.LoadInt64(d.ptr)
 }
 

--- a/dflag/dynjson.go
+++ b/dflag/dynjson.go
@@ -48,6 +48,9 @@ func (d *DynJSONValue) IsJSON() bool {
 
 // Get retrieves the value in its original JSON struct type in a thread-safe manner.
 func (d *DynJSONValue) Get() interface{} {
+	if d.ptr == nil {
+		return ""
+	}
 	return d.unsafeToStoredType(atomic.LoadPointer(&d.ptr))
 }
 

--- a/dflag/dynstring.go
+++ b/dflag/dynstring.go
@@ -29,6 +29,9 @@ type DynStringValue struct {
 
 // Get retrieves the value in a thread-safe manner.
 func (d *DynStringValue) Get() string {
+	if d.ptr == nil {
+		return ""
+	}
 	ptr := atomic.LoadPointer(&d.ptr)
 	return *(*string)(ptr)
 }

--- a/dflag/dynstringset.go
+++ b/dflag/dynstringset.go
@@ -32,6 +32,9 @@ type DynStringSetValue struct {
 
 // Get retrieves the value in a thread-safe manner.
 func (d *DynStringSetValue) Get() map[string]struct{} {
+	if d.ptr == nil {
+		return make(map[string]struct{})
+	}
 	p := (*map[string]struct{})(atomic.LoadPointer(&d.ptr))
 	return *p
 }

--- a/dflag/dynstringslice.go
+++ b/dflag/dynstringslice.go
@@ -31,6 +31,9 @@ type DynStringSliceValue struct {
 
 // Get retrieves the value in a thread-safe manner.
 func (d *DynStringSliceValue) Get() []string {
+	if d.ptr == nil {
+		return []string{}
+	}
 	p := (*[]string)(atomic.LoadPointer(&d.ptr))
 	return *p
 }

--- a/dflag/examples/server_kube/http.go
+++ b/dflag/examples/server_kube/http.go
@@ -28,6 +28,9 @@ var (
 	dynStr = dflag.DynString(flag.CommandLine, "example_my_dynamic_string", "initial_value", "Something interesting here.")
 	dynInt = dflag.DynInt64(flag.CommandLine, "example_my_dynamic_int", 1337, "Something integery here.")
 
+	dynBool1 = dflag.DynBool(flag.CommandLine, "example_bool1", false, "Something true... or false. Starting false.")
+	dynBool2 = dflag.DynBool(flag.CommandLine, "example_bool2", true, "Something true... or false. Starting true.")
+
 	// This is an example of a dynamically-modifiable JSON flag of an arbitrary type.
 	dynJSON = dflag.DynJSON(
 		flag.CommandLine,
@@ -42,7 +45,6 @@ var (
 )
 
 func main() {
-
 	flag.Parse()
 	u, err := configmap.Setup(flag.CommandLine, *dirPathWatch)
 	if err != nil {

--- a/dflag/nildptr_test.go
+++ b/dflag/nildptr_test.go
@@ -1,0 +1,32 @@
+// Copyright 2020 Laurent Demailly. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+// Tests the fix for #375
+// panic: runtime error: invalid memory address or nil pointer dereference
+// through flag.isZeroValue() -> dyn .Get()
+
+package dflag
+
+import (
+	"testing"
+	"time"
+
+	"flag"
+)
+
+type foo struct {
+}
+
+func TestDynFlagPrintDefaultsNotCrashing(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.PanicOnError)
+	DynBool(fs, "b", false, "b")
+	DynDuration(fs, "d", 0*time.Second, "d")
+	DynFloat64(fs, "f", 0, "f")
+	DynInt64(fs, "i", 0, "i")
+	DynJSON(fs, "j", &foo{}, "j")
+	DynString(fs, "s", "", "s")
+	DynStringSet(fs, "sset", []string{}, "sset")
+	DynStringSlice(fs, "sslice", []string{}, "sslice")
+	fs.PrintDefaults() // no crash/panic == test passes
+	// TODO potentially, check the output and the zero valued versus not help string difference
+}


### PR DESCRIPTION

- fix crash in -help / PrintDefaults (fixes #375) 
- added working version of DynBool including way to use them without values
(originally from https://github.com/Helcaraxan/go-flagz/tree/go-mod-compatible )