### PR TITLE
fix for -quiet not quiet'ing the configmap log.

### DIFF
--- a/Webtest.sh
+++ b/Webtest.sh
@@ -45,6 +45,14 @@ CURL="docker exec $DOCKERNAME $FORTIO_BIN_PATH curl -loglevel $LOGLEVEL"
 # Check https works (certs are in the image) - also tests autoswitch to std client for https
 $CURL https://www.google.com/robots.txt > /dev/null
 
+# Check that quiet is quiet. Issue #385.
+QUIETCURLTEST="docker exec $DOCKERNAME $FORTIO_BIN_PATH curl -quiet www.google.com"
+if [ `$QUIETCURLTEST 2>&1 1> /dev/null | wc -l` -ne 0 ]; then
+  echo "Error, -quiet still outputs logs"
+  $QUIETCURLTEST 2>&1 1> /dev/null
+  exit 1
+fi
+
 # Check we can connect, and run a http QPS test against ourselves through fetch
 $CURL "${BASE_FORTIO}fetch/localhost:8080$FORTIO_UI_PREFIX?url=http://localhost:8080/debug&load=Start&qps=-1&json=on" | grep ActualQPS
 # Check we can do it twice despite ulimit - check we get all 200s (exactly 80 of them (default is 8 connections->16 fds + a few))

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -156,6 +156,9 @@ func main() {
 	command := os.Args[1]
 	os.Args = append([]string{os.Args[0]}, os.Args[2:]...)
 	flag.Parse()
+	if *bincommon.QuietFlag {
+		log.SetLogLevelQuiet(log.Error)
+	}
 	confDir := *bincommon.ConfigDirectoryFlag
 	if confDir != "" {
 		if _, err := configmap.Setup(flag.CommandLine, confDir); err != nil {
@@ -165,9 +168,6 @@ func main() {
 		log.Infof("Not using dynamic flag watching (use -config to set watch directory)")
 	}
 	fnet.ChangeMaxPayloadSize(*newMaxPayloadSizeKb * fnet.KILOBYTE)
-	if *bincommon.QuietFlag {
-		log.SetLogLevelQuiet(log.Error)
-	}
 	percList, err := stats.ParsePercentiles(*percentilesFlag)
 	if err != nil {
 		usageErr("Unable to extract percentiles from -p: ", err)


### PR DESCRIPTION
Fixes #385 
