### PR TITLE
Fix getJitter panic: invalid argument to Int63n

### DIFF
--- a/periodic/periodic.go
+++ b/periodic/periodic.go
@@ -560,7 +560,7 @@ func formatDate(d *time.Time) string {
 
 // getJitter returns a jitter time that is (+/-)10% of the duration t if t is >0
 func getJitter(t time.Duration) time.Duration {
-	i := int64(float64(t)/10. + 0.5) // round to nearest instead of truncate
+	i := int64(float64(t)/10. + 0.5) // nolint: gomnd // rounding to nearest instead of truncate
 	if i <= 0 {
 		return time.Duration(0)
 	}

--- a/periodic/periodic.go
+++ b/periodic/periodic.go
@@ -560,10 +560,10 @@ func formatDate(d *time.Time) string {
 
 // getJitter returns a jitter time that is (+/-)10% of the duration t if t is >0
 func getJitter(t time.Duration) time.Duration {
-	if t <= 0 {
+	i := int64(float64(t)/10. + 0.5) // round to nearest instead of truncate
+	if i <= 0 {
 		return time.Duration(0)
 	}
-	i := int64(t / 10)
 	j := rand.Int63n(2*i) - i
 	return time.Duration(j)
 }

--- a/periodic/periodic_test.go
+++ b/periodic/periodic_test.go
@@ -370,3 +370,10 @@ func Test2Watchers(t *testing.T) {
 	}
 	gAbortMutex.Unlock()
 }
+
+func TestGetJitter(t *testing.T) {
+	d := getJitter(4)
+	if d != time.Duration(0) {
+		t.Errorf("getJitter < 5 got %v instead of expected 0", d)
+	}
+}


### PR DESCRIPTION
Here is the error log when we run the istio perf benchmark test:

```
2dac87db_qps_3000_c_16_1024_v2-stats-wasmbothsidecars_perf.data
kubectl --namespace twopods-istio exec fortioclient-69f64854bb-t7gfm  -- fortio load  -jitter=True -c 16 -qps 3000 -t 240s -a -r 0.00005   -httpbufferkb=128 -labels 2dac87db_qps_3000_c_16_1024_v2-stats-wasm_both http://fortioserver:8080/echo?size=1024
Defaulting container name to captured.
Use 'kubectl describe pod/fortioclient-69f64854bb-t7gfm -n twopods-istio' to see all of the containers in this pod.
Fortio 1.3.2-pre running at 3000 queries per second, 32->32 procs, for 4m0s: http://fortioserver:8080/echo?size=1024
13:22:30 I httprunner.go:82> Starting http test for http://fortioserver:8080/echo?size=1024 with 16 threads at 3000.0 qps
Starting at 3000 qps with 16 thread(s) [gomax 32] for 4m0s : 45000 calls each (total 720000)
panic: invalid argument to Int63n

goroutine 133 [running]:
math/rand.(*Rand).Int63n(0xc0000c6150, 0x0, 0x758cda975)
	/go1.11/go/src/math/rand/rand.go:111 +0x10d
math/rand.Int63n(0x0, 0xd73840)
	/go1.11/go/src/math/rand/rand.go:319 +0x37
fortio.org/fortio/periodic.getJitter(0x5, 0x2a8b4e6)
	/go/src/fortio.org/fortio/periodic/periodic.go:565 +0x66
fortio.org/fortio/periodic.runOne(0x2, 0xc00025a060, 0xc000394be0, 0xc000394c30, 0xafc8, 0xbfc47065a37708f9, 0x2a8b4e6, 0xd73840, 0xc0001d4500)
	/go/src/fortio.org/fortio/periodic/periodic.go:519 +0x96b
fortio.org/fortio/periodic.(*periodicRunner).Run.func1(0xc00025a060, 0xafc8, 0xbfc47065a37708f9, 0x2a8b4e6, 0xd73840, 0xc0001d4500, 0xc0002ec334, 0x2, 0xc000394be0, 0xc000394c30)
	/go/src/fortio.org/fortio/periodic/periodic.go:415 +0x8b
created by fortio.org/fortio/periodic.(*periodicRunner).Run
	/go/src/fortio.org/fortio/periodic/periodic.go:414 +0x4f1
command terminated with exit code 2
```

The root cause for this is that according to Golang math/rand source code: https://golang.org/src/math/rand/rand.go (line111) if the seed number is <= 0 it will panic.

Therefore, I set the minimum `i` value here to be int64(1) [duration type] when `i` <=0.

cc @ldemailly @mandarjog 