### PR TITLE
Fix UI custom header bug and support payloads in the UI

### DIFF
--- a/ui/templates/main.html
+++ b/ui/templates/main.html
@@ -55,6 +55,7 @@
     <input type="text" name="H" size=40 value="" /> <br />
     <button type="button" onclick="addCustomHeader()">+</button>
     <br />
+    Payload:<br /> <textarea name="payload" rows="5" cols="80"></textarea><br />
     Load using:<br />
     http: <input type="radio" name="runner" value="http" checked/>
     (https insecure:<input type="checkbox" name="https-insecure" />,

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -214,6 +214,23 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	httpopts.DisableFastClient = stdClient
 	httpopts.Insecure = httpsInsecure
 	httpopts.Resolve = resolve
+	firstHeader := true
+	for _, header := range r.Form["H"] {
+		if len(header) == 0 {
+			continue
+		}
+		log.LogVf("adding header %v", header)
+		if firstHeader {
+			// If there is at least 1 non empty H passed, reset the header list
+			httpopts.ResetHeaders()
+			firstHeader = false
+		}
+		err := httpopts.AddAndValidateExtraHeader(header)
+		if err != nil {
+			log.Errf("Error adding custom headers: %v", err)
+		}
+	}
+
 	if !JSONOnly {
 		// Normal html mode
 		if mainTemplate == nil {
@@ -279,22 +296,6 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		}
 	case run:
 		// mode == run case:
-		firstHeader := true
-		for _, header := range r.Form["H"] {
-			if len(header) == 0 {
-				continue
-			}
-			log.LogVf("adding header %v", header)
-			if firstHeader {
-				// If there is at least 1 non empty H passed, reset the header list
-				httpopts.ResetHeaders()
-				firstHeader = false
-			}
-			err := httpopts.AddAndValidateExtraHeader(header)
-			if err != nil {
-				log.Errf("Error adding custom headers: %v", err)
-			}
-		}
 		fhttp.OnBehalfOf(httpopts, r)
 		if !JSONOnly {
 			flusher.Flush()

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -164,6 +164,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	stdClient := (r.FormValue("stdclient") == "on")
 	httpsInsecure := (r.FormValue("https-insecure") == "on")
 	resolve := r.FormValue("resolve")
+	payload := r.FormValue("payload")
 	var dur time.Duration
 	if durStr == "on" || ((len(r.Form["t"]) > 1) && r.Form["t"][1] == "on") {
 		dur = -1
@@ -214,6 +215,10 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	httpopts.DisableFastClient = stdClient
 	httpopts.Insecure = httpsInsecure
 	httpopts.Resolve = resolve
+	if payload != "" {
+		log.Debugf("Using payload: %s", payload)
+		httpopts.Payload = []byte(payload)
+	}
 	firstHeader := true
 	for _, header := range r.Form["H"] {
 		if len(header) == 0 {


### PR DESCRIPTION
### More about the UI custom header bug
Custom header parsing must be performed before headers are consumed.
Certain custom headers, like Content-Type, were inadvertently being ignored since `HTTPOptions.AllHeaders()` was being called to populate the template variables in the `!JSONOnly` block.

### Screenshot of UI with payload field
<img width="864" alt="Screen Shot 2020-09-25 at 7 02 17 PM" src="https://user-images.githubusercontent.com/896205/94327715-bc0b7700-ff61-11ea-9767-7388cda79ca7.png">
