### PR TITLE
also trim spaces for boolean dynamic flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2
 defaultEnv: &defaultEnv
     docker:
       # specify the version
-      - image: docker.io/fortio/fortio.build:v29
+      - image: docker.io/fortio/fortio.build:v30
     working_directory: /go/src/fortio.org/fortio
 
 jobs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -353,6 +353,10 @@ linters:
     - testpackage
     - wrapcheck
     - exhaustivestruct
+# TODO consider putting these back
+    - paralleltest
+    - thelper
+    - forbidigo
 #    - maligned
 #    - prealloc
   enable-all: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v29 as build
+FROM docker.io/fortio/fortio.build:v30 as build
 WORKDIR /go/src/fortio.org
 COPY . fortio
 # We moved a lot of the logic into the Makefile so it can be reused in brew

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -8,7 +8,7 @@ RUN apt-get -y update && \
 # Install FPM
 RUN gem install --no-document fpm
 # From fortio 1.4 onward we dropped go 1.8 compatibility
-RUN curl -f https://dl.google.com/go/go1.15.5.linux-amd64.tar.gz | tar xfz - -C /usr/local
+RUN curl -f https://dl.google.com/go/go1.15.6.linux-amd64.tar.gz | tar xfz - -C /usr/local
 ENV GOPATH /go
 RUN mkdir -p $GOPATH/bin
 ENV PATH /usr/local/go/bin:$PATH:$GOPATH/bin

--- a/Dockerfile.echosrv
+++ b/Dockerfile.echosrv
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v29 as build
+FROM docker.io/fortio/fortio.build:v30 as build
 WORKDIR /go/src/fortio.org
 COPY . fortio
 RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_TARGET=fortio.org/fortio/echosrv OFFICIAL_BIN=../echosrv.bin

--- a/Dockerfile.fcurl
+++ b/Dockerfile.fcurl
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v29 as build
+FROM docker.io/fortio/fortio.build:v30 as build
 WORKDIR /go/src/fortio.org
 COPY . fortio
 # fcurl should not need vendor/no dependencies

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,5 @@
 # Getting the source tree ready for running tests (sut)
-FROM docker.io/fortio/fortio.build:v29
+FROM docker.io/fortio/fortio.build:v30
 WORKDIR /go/src/fortio.org
 COPY . fortio
 RUN make -C fortio dependencies

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 IMAGES=echosrv fcurl # plus the combo image / Dockerfile without ext.
 
 DOCKER_PREFIX := docker.io/fortio/fortio
-BUILD_IMAGE_TAG := v29
+BUILD_IMAGE_TAG := v30
 BUILD_IMAGE := $(DOCKER_PREFIX).build:$(BUILD_IMAGE_TAG)
 
 TAG:=$(USER)$(shell date +%y%m%d_%H%M%S)

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ docker run fortio/fortio load http://www.google.com/ # For a test run
 Or download one of the binary distributions, from the [releases](https://github.com/fortio/fortio/releases) assets page or for instance:
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.11.4/fortio-linux_x64-1.11.4.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.11.5/fortio-linux_x64-1.11.5.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.11.4/fortio_1.11.4-1_amd64.deb
-dpkg -i fortio_1.11.4-1_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.11.5/fortio_1.11.5-1_amd64.deb
+dpkg -i fortio_1.11.5-1_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.11.4/fortio-1.11.4-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.11.5/fortio-1.11.5-1.x86_64.rpm
 ```
 
 On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
@@ -61,7 +61,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.11.4/fortio_win_1.11.4.zip and extract all to some location then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.11.5/fortio_win_1.11.5.zip and extract all to some location then using the Windows Command Prompt:
 ```
 cd fortio
 fortio.exe server
@@ -105,7 +105,7 @@ Full list of command line flags (`fortio help`):
 <details>
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
-Φορτίο 1.11.4 usage:
+Φορτίο 1.11.5 usage:
         fortio command [flags] target
 where command is one of: load (load testing), server (starts ui, http-echo,
 redirect, proxies, tcp-echo and grpc ping servers), tcp-echo (only the tcp-echo
@@ -284,15 +284,15 @@ See also the FAQ entry about [fortio flags for best results](https://github.com/
 ```Shell
 $ fortio server &
 14:11:05 I fortio_main.go:171> Not using dynamic flag watching (use -config to set watch directory)
-Fortio 1.11.4 tcp-echo server listening on [::]:8078
-Fortio 1.11.4 grpc 'ping' server listening on [::]:8079
-Fortio 1.11.4 https redirector server listening on [::]:8081
-Fortio 1.11.4 echo server listening on [::]:8080
+Fortio 1.11.5 tcp-echo server listening on [::]:8078
+Fortio 1.11.5 grpc 'ping' server listening on [::]:8079
+Fortio 1.11.5 https redirector server listening on [::]:8081
+Fortio 1.11.5 echo server listening on [::]:8080
 Data directory is /Users/ldemailly/go/src/fortio.org/fortio
 UI started - visit:
 http://localhost:8080/fortio/
 (or any host/ip reachable on this server)
-14:11:05 I fortio_main.go:233> All fortio 1.11.4 release go1.15.2 servers started!
+14:11:05 I fortio_main.go:233> All fortio 1.11.5 release go1.15.2 servers started!
 ```
 
 ### Change the port / binding address
@@ -305,8 +305,8 @@ $ fortio server -http-port 10.10.10.10:8088
 UI starting - visit:
 http://10.10.10.10:8088/fortio/
 Https redirector running on :8081
-Fortio 1.11.4 grpc ping server listening on port :8079
-Fortio 1.11.4 echo server listening on port 10.10.10.10:8088
+Fortio 1.11.5 grpc ping server listening on port :8079
+Fortio 1.11.5 echo server listening on port 10.10.10.10:8088
 ```
 
 ### Unix domain sockets
@@ -315,12 +315,12 @@ You can use unix domain socket for any server/client:
 
 ```Shell
 $ fortio server --http-port /tmp/fortio-uds-http &
-Fortio 1.11.4 grpc 'ping' server listening on [::]:8079
-Fortio 1.11.4 https redirector server listening on [::]:8081
-Fortio 1.11.4 echo server listening on /tmp/fortio-uds-http
+Fortio 1.11.5 grpc 'ping' server listening on [::]:8079
+Fortio 1.11.5 https redirector server listening on [::]:8081
+Fortio 1.11.5 echo server listening on /tmp/fortio-uds-http
 UI started - visit:
 fortio curl -unix-socket=/tmp/fortio-uds-http http://localhost/fortio/
-14:58:45 I fortio_main.go:217> All fortio 1.11.4 unknown go1.10.3 servers started!
+14:58:45 I fortio_main.go:217> All fortio 1.11.5 unknown go1.10.3 servers started!
 $ fortio curl -unix-socket=/tmp/fortio-uds-http http://foo.bar/debug
 15:00:48 I http_client.go:428> Using unix domain socket /tmp/fortio-uds-http instead of foo.bar http
 HTTP/1.1 200 OK
@@ -328,14 +328,14 @@ Content-Type: text/plain; charset=UTF-8
 Date: Wed, 08 Aug 2018 22:00:48 GMT
 Content-Length: 231
 
-Φορτίο version 1.11.4 unknown go1.10.3 echo debug server up for 2m3.4s on ldemailly-macbookpro - request from
+Φορτίο version 1.11.5 unknown go1.10.3 echo debug server up for 2m3.4s on ldemailly-macbookpro - request from
 
 GET /debug HTTP/1.1
 
 headers:
 
 Host: foo.bar
-User-Agent: fortio.org/fortio-1.11.4
+User-Agent: fortio.org/fortio-1.11.5
 
 body:
 ```
@@ -344,10 +344,10 @@ body:
 Start the echo-server alone and run a load (use `tcp://` prefix for the load test to be for tcp echo server)
 ```Shell
 $ fortio echo-server &
-Fortio 1.11.4 tcp-echo server listening on [::]:8078
-19:45:30 I fortio_main.go:238> All fortio 1.11.4 release go1.15.2 servers started!
+Fortio 1.11.5 tcp-echo server listening on [::]:8078
+19:45:30 I fortio_main.go:238> All fortio 1.11.5 release go1.15.2 servers started!
 $ fortio load -qps -1 -n 100000 tcp://localhost:8078
-Fortio 1.11.4 running at -1 queries per second, 16->16 procs, for 100000 calls: tcp://localhost:8078
+Fortio 1.11.5 running at -1 queries per second, 16->16 procs, for 100000 calls: tcp://localhost:8078
 20:01:31 I tcprunner.go:218> Starting tcp test for tcp://localhost:8078 with 4 threads at -1.0 qps
 Starting at max qps with 4 thread(s) [gomax 16] for exactly 100000 calls (25000 per thread + 0)
 20:01:32 I periodic.go:558> T003 ended after 1.240585427s : 25000 calls. qps=20151.77629520873
@@ -418,8 +418,8 @@ $ fortio server -cert /path/to/fortio/server.crt -key /path/to/fortio/server.key
 UI starting - visit:
 http://localhost:8080/fortio/
 Https redirector running on :8081
-Fortio 1.11.4 grpc ping server listening on port :8079
-Fortio 1.11.4 echo server listening on port localhost:8080
+Fortio 1.11.5 grpc ping server listening on port :8079
+Fortio 1.11.5 echo server listening on port localhost:8080
 Using server certificate /path/to/fortio/server.crt to construct TLS credentials
 Using server key /path/to/fortio/server.key to construct TLS credentials
 ```
@@ -464,7 +464,7 @@ Load (low default qps/threading) test:
 
 ```Shell
 $ fortio load http://www.google.com
-Fortio 1.11.4 running at 8 queries per second, 8->8 procs, for 5s: http://www.google.com
+Fortio 1.11.5 running at 8 queries per second, 8->8 procs, for 5s: http://www.google.com
 19:10:33 I httprunner.go:84> Starting http test for http://www.google.com with 4 threads at 8.0 qps
 Starting at 8 qps with 4 thread(s) [gomax 8] for 5s : 10 calls each (total 40)
 19:10:39 I periodic.go:314> T002 ended after 5.056753279s : 10 calls. qps=1.9775534712220633
@@ -495,7 +495,7 @@ Uses `-s` to use multiple (h2/grpc) streams per connection (`-c`), request to hi
 
 ```bash
 $ fortio load -a -grpc -ping -grpc-ping-delay 0.25s -payload "01234567890" -c 2 -s 4 https://fortio-stage.istio.io
-Fortio 1.11.4 running at 8 queries per second, 8->8 procs, for 5s: https://fortio-stage.istio.io
+Fortio 1.11.5 running at 8 queries per second, 8->8 procs, for 5s: https://fortio-stage.istio.io
 16:32:56 I grpcrunner.go:139> Starting GRPC Ping Delay=250ms PayloadLength=11 test for https://fortio-stage.istio.io with 4*2 threads at 8.0 qps
 16:32:56 I grpcrunner.go:261> stripping https scheme. grpc destination: fortio-stage.istio.io. grpc port: 443
 16:32:57 I grpcrunner.go:261> stripping https scheme. grpc destination: fortio-stage.istio.io. grpc port: 443
@@ -600,14 +600,14 @@ Content-Type: text/plain; charset=UTF-8
 Date: Mon, 08 Jan 2018 22:26:26 GMT
 Content-Length: 230
 
-Φορτίο version 1.11.4 echo debug server up for 39s on ldemailly-macbookpro - request from [::1]:65055
+Φορτίο version 1.11.5 echo debug server up for 39s on ldemailly-macbookpro - request from [::1]:65055
 
 GET /debug HTTP/1.1
 
 headers:
 
 Host: localhost:8080
-User-Agent: fortio.org/fortio-1.11.4
+User-Agent: fortio.org/fortio-1.11.5
 Foo: Bar
 
 body:
@@ -632,7 +632,7 @@ Example listen on 1 extra port and every request sent to that 1 port is forward 
 # in one window or &
 $ fortio server -M "5554 http://localhost:8080 http://localhost:8080"
 [...]
-Fortio 1.11.4 Multi on 5554 server listening on [::]:5554
+Fortio 1.11.5 Multi on 5554 server listening on [::]:5554
 10:09:56 I http_forwarder.go:152> Multi-server on [::]:5554 running with &{Targets:[{Destination:http://localhost:8080 MirrorOrigin:true} {Destination:http://localhost:8080 MirrorOrigin:true}] Name:Multi on [::]:5554 client:0xc0001ccc00}
 ```
 Call the debug endpoint on both
@@ -644,7 +644,7 @@ Date: Wed, 07 Oct 2020 17:11:06 GMT
 Content-Length: 684
 Content-Type: text/plain; charset=utf-8
 
-Φορτίο version 1.11.4 unknown go1.15.2 echo debug server up for 1m9.3s on C02C77BHMD6R - request from [::1]:51020
+Φορτίο version 1.11.5 unknown go1.15.2 echo debug server up for 1m9.3s on C02C77BHMD6R - request from [::1]:51020
 
 POST /debug HTTP/1.1
 
@@ -653,14 +653,14 @@ headers:
 Host: localhost:8080
 Accept-Encoding: gzip
 Content-Type: application/octet-stream
-User-Agent: fortio.org/fortio-1.11.4
+User-Agent: fortio.org/fortio-1.11.5
 X-Fortio-Multi-Id: 1
 X-On-Behalf-Of: [::1]:51019
 
 body:
 
 a test
-Φορτίο version 1.11.4 unknown go1.15.2 echo debug server up for 1m9.3s on C02C77BHMD6R - request from [::1]:51020
+Φορτίο version 1.11.5 unknown go1.15.2 echo debug server up for 1m9.3s on C02C77BHMD6R - request from [::1]:51020
 
 POST /debug HTTP/1.1
 
@@ -669,7 +669,7 @@ headers:
 Host: localhost:8080
 Accept-Encoding: gzip
 Content-Type: application/octet-stream
-User-Agent: fortio.org/fortio-1.11.4
+User-Agent: fortio.org/fortio-1.11.5
 X-Fortio-Multi-Id: 2
 X-On-Behalf-Of: [::1]:51019
 
@@ -690,15 +690,15 @@ Example: open 2 additional listening ports and forward all requests received on 
 
 ```Shell
 $ fortio server -P "8888 [::1]:8080" -P "[::1]:8889 [::1]:8080" 
-Fortio 1.11.4 grpc 'ping' server listening on [::]:8079
-Fortio 1.11.4 https redirector server listening on [::]:8081
-Fortio 1.11.4 echo server listening on [::]:8080
+Fortio 1.11.5 grpc 'ping' server listening on [::]:8079
+Fortio 1.11.5 https redirector server listening on [::]:8081
+Fortio 1.11.5 echo server listening on [::]:8080
 Data directory is /home/dl
 UI started - visit:
 http://localhost:8080/fortio/
 (or any host/ip reachable on this server)
-Fortio 1.11.4 proxy for [::1]:8080 server listening on [::]:8888
-Fortio 1.11.4 proxy for [::1]:8080 server listening on [::1]:8889
+Fortio 1.11.5 proxy for [::1]:8080 server listening on [::]:8888
+Fortio 1.11.5 proxy for [::1]:8080 server listening on [::1]:8889
 ```
 
 ## Server URLs and features

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -112,7 +112,7 @@ docker exec $DOCKERNAME $FORTIO_BIN_PATH grpcping localhost
 PPROF_URL="$BASE_URL/debug/pprof/heap?debug=1"
 $CURL $PPROF_URL | grep -i TotalAlloc # should find this in memory profile
 # creating dummy container to hold a volume for test certs due to remote docker bind mount limitation.
-docker create -v $TEST_CERT_VOL --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v29 /bin/true # cleaned up by name
+docker create -v $TEST_CERT_VOL --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v30 /bin/true # cleaned up by name
 # copying cert files into the certs volume of the dummy container
 for f in ca.crt server.crt server.key; do docker cp $PWD/cert-tmp/$f $DOCKERSECVOLNAME:$TEST_CERT_VOL/$f; done
 # start server in secure grpc mode. uses non-default ports to avoid conflicts with fortio_server container.

--- a/dflag/dynbool.go
+++ b/dflag/dynbool.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync/atomic"
 )
 
@@ -45,7 +46,7 @@ func (d *DynBoolValue) Get() bool {
 // optional validator.
 // If a notifier is set on the value, it will be invoked in a separate go-routine.
 func (d *DynBoolValue) Set(input string) error {
-	val, err := strconv.ParseBool(input)
+	val, err := strconv.ParseBool(strings.TrimSpace(input))
 	if err != nil {
 		return err
 	}

--- a/dflag/dynbool_test.go
+++ b/dflag/dynbool_test.go
@@ -19,6 +19,9 @@ func TestDynBool_SetAndGet(t *testing.T) {
 	err := set.Set("some_bool_1", "false")
 	assert.NoError(t, err, "setting value must succeed")
 	assert.Equal(t, false, dynFlag.Get(), "value must be set after update")
+	err = set.Set("some_bool_1", "true\n")
+	assert.NoError(t, err, "setting value with extra whitespace should work")
+	assert.Equal(t, true, dynFlag.Get(), "value must be set after update")
 }
 
 func TestDynBool_IsMarkedDynamic(t *testing.T) {

--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -76,7 +76,6 @@ type HTTPRunnerOptions struct {
 }
 
 // RunHTTPTest runs an http test and returns the aggregated stats.
-// nolint: funlen
 func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 	o.RunType = "HTTP"
 	log.Infof("Starting http test for %s with %d threads at %.1f qps", o.URL, o.NumThreads, o.QPS)

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -1,5 +1,5 @@
 # Concatenated after ../Dockerfile to create the tgz
-FROM docker.io/fortio/fortio.build:v29 as stage
+FROM docker.io/fortio/fortio.build:v30 as stage
 WORKDIR /stage
 COPY --from=release /usr/bin/fortio usr/bin/fortio
 COPY --from=release /usr/share/fortio usr/share/fortio

--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	major = 1
 	minor = 11
-	patch = 4
+	patch = 5
 
 	debug = false // turn on to debug init()
 )


### PR DESCRIPTION
also trim spaces for boolean dynamic flags. happens with configmap directories