### PR TITLE
Allow customizing the min/max on the count axis

### DIFF
--- a/ui/static/js/fortio_chart.js
+++ b/ui/static/js/fortio_chart.js
@@ -370,8 +370,10 @@ function getUpdateForm () {
   const xMin = form.xmin.value.trim()
   const xMax = form.xmax.value.trim()
   const xIsLogarithmic = form.xlog.checked
+  const yMin = form.ymin.value.trim()
+  const yMax = form.ymax.value.trim()
   const yIsLogarithmic = form.ylog.checked
-  return { xMin, xMax, xIsLogarithmic, yIsLogarithmic }
+  return { xMin, xMax, xIsLogarithmic, yMin, yMax, yIsLogarithmic }
 }
 
 function getSelectedResults () {
@@ -397,6 +399,8 @@ function updateQueryString () {
   params.set('xMin', form.xMin)
   params.set('xMax', form.xMax)
   params.set('xLog', form.xIsLogarithmic)
+  params.set('yMin', form.yMin)
+  params.set('yMax', form.yMax)
   params.set('yLog', form.yIsLogarithmic)
   const selectedResults = getSelectedResults()
   params.delete('sel')
@@ -412,6 +416,7 @@ function updateChartOptions (chart) {
   const form = getUpdateForm()
   const scales = chart.config.options.scales
   const newXMin = parseFloat(form.xMin)
+  const newYMin = parseFloat(form.yMin)
   const newXAxis = form.xIsLogarithmic ? logXAxe : linearXAxe
   const newYAxis = form.yIsLogarithmic ? logYAxe : linearYAxe
   chart.config.options.scales = {
@@ -422,9 +427,15 @@ function updateChartOptions (chart) {
   const newNewXAxis = chart.config.options.scales.xAxes[0]
   newNewXAxis.ticks.min = form.xMin === '' ? undefined : newXMin
   const formXMax = form.xMax
-  newNewXAxis.ticks.max = formXMax === '' || formXMax === 'max'
-    ? undefined
-    : parseFloat(formXMax)
+  newNewXAxis.ticks.max = formXMax === '' || formXMax === 'max' ?
+      undefined :
+      parseFloat(formXMax)
+  const newNewYAxis = chart.config.options.scales.yAxes[1]
+  newNewYAxis.ticks.min = form.yMin === '' ? undefined : newYMin
+  const formYMax = form.yMax
+  newNewYAxis.ticks.max = formYMax === '' || formYMax === 'max' ?
+      undefined :
+      parseFloat(formYMax)
   chart.update()
 }
 

--- a/ui/templates/browse.html
+++ b/ui/templates/browse.html
@@ -131,7 +131,9 @@ Select or multi select to graph...
 Time axis min <input type="text" name="xmin" value="{{.ChartOptions.XMin}}" size="5" /> ms,
 max <input type="text" name="xmax" value="{{.ChartOptions.XMax}}" size="5" /> ms,
 logarithmic: <input name="xlog" type="checkbox" onclick="updateChart()" {{if .ChartOptions.XIsLog}} checked {{end}} /> -
-Count axis logarithmic: <input name="ylog" type="checkbox" onclick="updateChart()" {{if .ChartOptions.YIsLog}} checked {{end}} />
+Count axis min <input type="text" name="ymin" value="{{.ChartOptions.YMin}}" size="5" /> ms,
+max <input type="text" name="ymax" value="{{.ChartOptions.YMax}}" size="5" /> ms,
+logarithmic: <input name="ylog" type="checkbox" onclick="updateChart()" {{if .ChartOptions.YIsLog}} checked {{end}} />
 </form>
 </div>
 {{if .DoSearch}}

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -464,6 +464,8 @@ func DataList() (dataList []string) {
 type ChartOptions struct {
 	XMin   string
 	XMax   string
+	YMin   string
+	YMax   string
 	XIsLog bool
 	YIsLog bool
 }
@@ -488,6 +490,8 @@ func BrowseHandler(w http.ResponseWriter, r *http.Request) {
 	xMax := r.FormValue("xMax")
 	// Ignore error, xLog == nil is the same as xLog being unspecified.
 	xLog, _ := strconv.ParseBool(r.FormValue("xLog"))
+	yMin := r.FormValue("yMin")
+	yMax := r.FormValue("yMax")
 	yLog, _ := strconv.ParseBool(r.FormValue("yLog"))
 	dataList := DataList()
 	selectedValues := r.URL.Query()["sel"]
@@ -502,6 +506,8 @@ func BrowseHandler(w http.ResponseWriter, r *http.Request) {
 		XMin:   xMin,
 		XMax:   xMax,
 		XIsLog: xLog,
+		YMin:   yMin,
+		YMax:   yMax,
 		YIsLog: yLog,
 	}
 	err := browseTemplate.Execute(w, &struct {


### PR DESCRIPTION
This replicates the behavior for the x axis, and allows the graph browse
UI to adjust the min/max values for the count axis.