### PR TITLE
Now both the fastclient (like before) and the std client will log http errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2
 defaultEnv: &defaultEnv
     docker:
       # specify the version
-      - image: docker.io/fortio/fortio.build:v34
+      - image: docker.io/fortio/fortio.build:v35
     working_directory: /go/src/fortio.org/fortio
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v34 as build
+FROM docker.io/fortio/fortio.build:v35 as build
 WORKDIR /go/src/fortio.org
 COPY . fortio
 # We moved a lot of the logic into the Makefile so it can be reused in brew

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -8,7 +8,7 @@ RUN apt-get -y update && \
 # Install FPM
 RUN gem install --no-document fpm
 # From fortio 1.4 onward we dropped go 1.8 compatibility
-RUN curl -f https://dl.google.com/go/go1.16.5.linux-amd64.tar.gz | tar xfz - -C /usr/local
+RUN curl -f https://dl.google.com/go/go1.16.9.linux-amd64.tar.gz | tar xfz - -C /usr/local
 ENV GOPATH /go
 RUN mkdir -p $GOPATH/bin
 ENV PATH /usr/local/go/bin:$PATH:$GOPATH/bin

--- a/Dockerfile.echosrv
+++ b/Dockerfile.echosrv
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v34 as build
+FROM docker.io/fortio/fortio.build:v35 as build
 WORKDIR /go/src/fortio.org
 COPY . fortio
 RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_TARGET=fortio.org/fortio/echosrv OFFICIAL_BIN=../echosrv.bin

--- a/Dockerfile.fcurl
+++ b/Dockerfile.fcurl
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v34 as build
+FROM docker.io/fortio/fortio.build:v35 as build
 WORKDIR /go/src/fortio.org
 COPY . fortio
 # fcurl should not need vendor/no dependencies

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,5 @@
 # Getting the source tree ready for running tests (sut)
-FROM docker.io/fortio/fortio.build:v34
+FROM docker.io/fortio/fortio.build:v35
 WORKDIR /go/src/fortio.org
 COPY . fortio
 RUN make -C fortio dependencies

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 IMAGES=echosrv fcurl # plus the combo image / Dockerfile without ext.
 
 DOCKER_PREFIX := docker.io/fortio/fortio
-BUILD_IMAGE_TAG := v34
+BUILD_IMAGE_TAG := v35
 BUILD_IMAGE := $(DOCKER_PREFIX).build:$(BUILD_IMAGE_TAG)
 
 TAG:=$(USER)$(shell date +%y%m%d_%H%M%S)

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ docker run fortio/fortio load http://www.google.com/ # For a test run
 Or download one of the binary distributions, from the [releases](https://github.com/fortio/fortio/releases) assets page or for instance:
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.17.0/fortio-linux_x64-1.17.0.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.17.1/fortio-linux_x64-1.17.1.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.17.0/fortio_1.17.0_amd64.deb
-dpkg -i fortio_1.17.0-1_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.17.1/fortio_1.17.1_amd64.deb
+dpkg -i fortio_1.17.1-1_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.17.0/fortio-1.17.0-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.17.1/fortio-1.17.1-1.x86_64.rpm
 ```
 
 On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
@@ -61,7 +61,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.17.0/fortio_win_1.17.0.zip and extract all to some location then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.17.1/fortio_win_1.17.1.zip and extract all to some location then using the Windows Command Prompt:
 ```
 cd fortio
 fortio.exe server
@@ -105,7 +105,7 @@ Full list of command line flags (`fortio help`):
 <details>
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
-Φορτίο 1.17.0 usage:
+Φορτίο 1.17.1 usage:
         fortio command [flags] target
 where command is one of: load (load testing), server (starts ui, http-echo,
 redirect, proxies, tcp-echo and grpc ping servers), tcp-echo (only the tcp-echo
@@ -201,6 +201,8 @@ output, unless -a is used)
   -labels string
         Additional config data/labels to add to the resulting JSON, defaults to
 target URL and hostname
+  -log-errors
+        Log http non 2xx/418 error codes as they occur (default true)
   -logcaller
         Logs filename and line number of callers to log (default true)
   -loglevel value
@@ -294,15 +296,15 @@ See also the FAQ entry about [fortio flags for best results](https://github.com/
 ```Shell
 $ fortio server &
 14:11:05 I fortio_main.go:171> Not using dynamic flag watching (use -config to set watch directory)
-Fortio 1.17.0 tcp-echo server listening on [::]:8078
-Fortio 1.17.0 grpc 'ping' server listening on [::]:8079
-Fortio 1.17.0 https redirector server listening on [::]:8081
-Fortio 1.17.0 echo server listening on [::]:8080
+Fortio 1.17.1 tcp-echo server listening on [::]:8078
+Fortio 1.17.1 grpc 'ping' server listening on [::]:8079
+Fortio 1.17.1 https redirector server listening on [::]:8081
+Fortio 1.17.1 echo server listening on [::]:8080
 Data directory is /Users/ldemailly/go/src/fortio.org/fortio
 UI started - visit:
 http://localhost:8080/fortio/
 (or any host/ip reachable on this server)
-14:11:05 I fortio_main.go:233> All fortio 1.17.0 release go1.16.5 servers started!
+14:11:05 I fortio_main.go:233> All fortio 1.17.1 release go1.16.9 servers started!
 ```
 
 ### Change the port / binding address
@@ -315,8 +317,8 @@ $ fortio server -http-port 10.10.10.10:8088
 UI starting - visit:
 http://10.10.10.10:8088/fortio/
 Https redirector running on :8081
-Fortio 1.17.0 grpc ping server listening on port :8079
-Fortio 1.17.0 echo server listening on port 10.10.10.10:8088
+Fortio 1.17.1 grpc ping server listening on port :8079
+Fortio 1.17.1 echo server listening on port 10.10.10.10:8088
 ```
 
 ### Unix domain sockets
@@ -325,12 +327,12 @@ You can use unix domain socket for any server/client:
 
 ```Shell
 $ fortio server --http-port /tmp/fortio-uds-http &
-Fortio 1.17.0 grpc 'ping' server listening on [::]:8079
-Fortio 1.17.0 https redirector server listening on [::]:8081
-Fortio 1.17.0 echo server listening on /tmp/fortio-uds-http
+Fortio 1.17.1 grpc 'ping' server listening on [::]:8079
+Fortio 1.17.1 https redirector server listening on [::]:8081
+Fortio 1.17.1 echo server listening on /tmp/fortio-uds-http
 UI started - visit:
 fortio curl -unix-socket=/tmp/fortio-uds-http http://localhost/fortio/
-14:58:45 I fortio_main.go:217> All fortio 1.17.0 unknown go1.16.5 servers started!
+14:58:45 I fortio_main.go:217> All fortio 1.17.1 unknown go1.16.9 servers started!
 $ fortio curl -unix-socket=/tmp/fortio-uds-http http://foo.bar/debug
 15:00:48 I http_client.go:428> Using unix domain socket /tmp/fortio-uds-http instead of foo.bar http
 HTTP/1.1 200 OK
@@ -338,14 +340,14 @@ Content-Type: text/plain; charset=UTF-8
 Date: Wed, 08 Aug 2018 22:00:48 GMT
 Content-Length: 231
 
-Φορτίο version 1.17.0 unknown go1.16.5 echo debug server up for 2m3.4s on ldemailly-macbookpro - request from
+Φορτίο version 1.17.1 unknown go1.16.9 echo debug server up for 2m3.4s on ldemailly-macbookpro - request from
 
 GET /debug HTTP/1.1
 
 headers:
 
 Host: foo.bar
-User-Agent: fortio.org/fortio-1.17.0
+User-Agent: fortio.org/fortio-1.17.1
 
 body:
 ```
@@ -354,10 +356,10 @@ body:
 Start the echo-server alone and run a load (use `tcp://` prefix for the load test to be for tcp echo server)
 ```Shell
 $ fortio tcp-echo &
-Fortio 1.17.0 tcp-echo TCP server listening on [::]:8078
-19:45:30 I fortio_main.go:238> All fortio 1.17.0 release go1.16.5 servers started!
+Fortio 1.17.1 tcp-echo TCP server listening on [::]:8078
+19:45:30 I fortio_main.go:238> All fortio 1.17.1 release go1.16.9 servers started!
 $ fortio load -qps -1 -n 100000 tcp://localhost:8078
-Fortio 1.17.0 running at -1 queries per second, 16->16 procs, for 100000 calls: tcp://localhost:8078
+Fortio 1.17.1 running at -1 queries per second, 16->16 procs, for 100000 calls: tcp://localhost:8078
 20:01:31 I tcprunner.go:218> Starting tcp test for tcp://localhost:8078 with 4 threads at -1.0 qps
 Starting at max qps with 4 thread(s) [gomax 16] for exactly 100000 calls (25000 per thread + 0)
 20:01:32 I periodic.go:558> T003 ended after 1.240585427s : 25000 calls. qps=20151.77629520873
@@ -383,11 +385,11 @@ All done 100000 calls (plus 0 warmup) 0.049 ms avg, 80495.0 qps
 Start the udp-echo server alone and run a load (use `tcp://` prefix for the load test to be for tcp echo server)
 ```
 $ fortio udp-echo &
-Fortio 1.17.0 udp-echo UDP server listening on [::]:8078
+Fortio 1.17.1 udp-echo UDP server listening on [::]:8078
 21:54:52 I fortio_main.go:273> Note: not using dynamic flag watching (use -config to set watch directory)
-21:54:52 I fortio_main.go:281> All fortio 1.17.0 release go1.16.5 servers started!
+21:54:52 I fortio_main.go:281> All fortio 1.17.1 release go1.16.9 servers started!
 $ fortio load -qps -1 -n 100000 udp://localhost:8078/
-Fortio 1.17.0 running at -1 queries per second, 16->16 procs, for 100000 calls: udp://localhost:8078/
+Fortio 1.17.1 running at -1 queries per second, 16->16 procs, for 100000 calls: udp://localhost:8078/
 21:56:48 I udprunner.go:222> Starting udp test for udp://localhost:8078/ with 4 threads at -1.0 qps
 Starting at max qps with 4 thread(s) [gomax 16] for exactly 100000 calls (25000 per thread + 0)
 21:56:49 I periodic.go:558> T003 ended after 969.635695ms : 25000 calls. qps=25782.879208051432
@@ -469,8 +471,8 @@ $ fortio server -cert /path/to/fortio/server.crt -key /path/to/fortio/server.key
 UI starting - visit:
 http://localhost:8080/fortio/
 Https redirector running on :8081
-Fortio 1.17.0 grpc ping server listening on port :8079
-Fortio 1.17.0 echo server listening on port localhost:8080
+Fortio 1.17.1 grpc ping server listening on port :8079
+Fortio 1.17.1 echo server listening on port localhost:8080
 Using server certificate /path/to/fortio/server.crt to construct TLS credentials
 Using server key /path/to/fortio/server.key to construct TLS credentials
 ```
@@ -515,7 +517,7 @@ Load (low default qps/threading) test:
 
 ```Shell
 $ fortio load http://www.google.com
-Fortio 1.17.0 running at 8 queries per second, 8->8 procs, for 5s: http://www.google.com
+Fortio 1.17.1 running at 8 queries per second, 8->8 procs, for 5s: http://www.google.com
 19:10:33 I httprunner.go:84> Starting http test for http://www.google.com with 4 threads at 8.0 qps
 Starting at 8 qps with 4 thread(s) [gomax 8] for 5s : 10 calls each (total 40)
 19:10:39 I periodic.go:314> T002 ended after 5.056753279s : 10 calls. qps=1.9775534712220633
@@ -546,7 +548,7 @@ Uses `-s` to use multiple (h2/grpc) streams per connection (`-c`), request to hi
 
 ```bash
 $ fortio load -a -grpc -ping -grpc-ping-delay 0.25s -payload "01234567890" -c 2 -s 4 https://fortio-stage.istio.io
-Fortio 1.17.0 running at 8 queries per second, 8->8 procs, for 5s: https://fortio-stage.istio.io
+Fortio 1.17.1 running at 8 queries per second, 8->8 procs, for 5s: https://fortio-stage.istio.io
 16:32:56 I grpcrunner.go:139> Starting GRPC Ping Delay=250ms PayloadLength=11 test for https://fortio-stage.istio.io with 4*2 threads at 8.0 qps
 16:32:56 I grpcrunner.go:261> stripping https scheme. grpc destination: fortio-stage.istio.io. grpc port: 443
 16:32:57 I grpcrunner.go:261> stripping https scheme. grpc destination: fortio-stage.istio.io. grpc port: 443
@@ -651,14 +653,14 @@ Content-Type: text/plain; charset=UTF-8
 Date: Mon, 08 Jan 2018 22:26:26 GMT
 Content-Length: 230
 
-Φορτίο version 1.17.0 echo debug server up for 39s on ldemailly-macbookpro - request from [::1]:65055
+Φορτίο version 1.17.1 echo debug server up for 39s on ldemailly-macbookpro - request from [::1]:65055
 
 GET /debug HTTP/1.1
 
 headers:
 
 Host: localhost:8080
-User-Agent: fortio.org/fortio-1.17.0
+User-Agent: fortio.org/fortio-1.17.1
 Foo: Bar
 
 body:
@@ -683,7 +685,7 @@ Example listen on 1 extra port and every request sent to that 1 port is forward 
 # in one window or &
 $ fortio server -M "5554 http://localhost:8080 http://localhost:8080"
 [...]
-Fortio 1.17.0 Multi on 5554 server listening on [::]:5554
+Fortio 1.17.1 Multi on 5554 server listening on [::]:5554
 10:09:56 I http_forwarder.go:152> Multi-server on [::]:5554 running with &{Targets:[{Destination:http://localhost:8080 MirrorOrigin:true} {Destination:http://localhost:8080 MirrorOrigin:true}] Name:Multi on [::]:5554 client:0xc0001ccc00}
 ```
 Call the debug endpoint on both
@@ -695,7 +697,7 @@ Date: Wed, 07 Oct 2020 17:11:06 GMT
 Content-Length: 684
 Content-Type: text/plain; charset=utf-8
 
-Φορτίο version 1.17.0 unknown go1.16.5 echo debug server up for 1m9.3s on C02C77BHMD6R - request from [::1]:51020
+Φορτίο version 1.17.1 unknown go1.16.9 echo debug server up for 1m9.3s on C02C77BHMD6R - request from [::1]:51020
 
 POST /debug HTTP/1.1
 
@@ -704,14 +706,14 @@ headers:
 Host: localhost:8080
 Accept-Encoding: gzip
 Content-Type: application/octet-stream
-User-Agent: fortio.org/fortio-1.17.0
+User-Agent: fortio.org/fortio-1.17.1
 X-Fortio-Multi-Id: 1
 X-On-Behalf-Of: [::1]:51019
 
 body:
 
 a test
-Φορτίο version 1.17.0 unknown go1.16.5 echo debug server up for 1m9.3s on C02C77BHMD6R - request from [::1]:51020
+Φορτίο version 1.17.1 unknown go1.16.9 echo debug server up for 1m9.3s on C02C77BHMD6R - request from [::1]:51020
 
 POST /debug HTTP/1.1
 
@@ -720,7 +722,7 @@ headers:
 Host: localhost:8080
 Accept-Encoding: gzip
 Content-Type: application/octet-stream
-User-Agent: fortio.org/fortio-1.17.0
+User-Agent: fortio.org/fortio-1.17.1
 X-Fortio-Multi-Id: 2
 X-On-Behalf-Of: [::1]:51019
 
@@ -741,15 +743,15 @@ Example: open 2 additional listening ports and forward all requests received on 
 
 ```Shell
 $ fortio server -P "8888 [::1]:8080" -P "[::1]:8889 [::1]:8080"
-Fortio 1.17.0 grpc 'ping' server listening on [::]:8079
-Fortio 1.17.0 https redirector server listening on [::]:8081
-Fortio 1.17.0 echo server listening on [::]:8080
+Fortio 1.17.1 grpc 'ping' server listening on [::]:8079
+Fortio 1.17.1 https redirector server listening on [::]:8081
+Fortio 1.17.1 echo server listening on [::]:8080
 Data directory is /home/dl
 UI started - visit:
 http://localhost:8080/fortio/
 (or any host/ip reachable on this server)
-Fortio 1.17.0 proxy for [::1]:8080 server listening on [::]:8888
-Fortio 1.17.0 proxy for [::1]:8080 server listening on [::1]:8889
+Fortio 1.17.1 proxy for [::1]:8080 server listening on [::]:8888
+Fortio 1.17.1 proxy for [::1]:8080 server listening on [::1]:8889
 ```
 
 ## Server URLs and features

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -113,7 +113,7 @@ docker exec $DOCKERNAME $FORTIO_BIN_PATH grpcping localhost
 PPROF_URL="$BASE_URL/debug/pprof/heap?debug=1"
 $CURL $PPROF_URL | grep -i TotalAlloc # should find this in memory profile
 # creating dummy container to hold a volume for test certs due to remote docker bind mount limitation.
-docker create -v $TEST_CERT_VOL --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v34 /bin/true # cleaned up by name
+docker create -v $TEST_CERT_VOL --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v35 /bin/true # cleaned up by name
 # copying cert files into the certs volume of the dummy container
 for f in ca.crt server.crt server.key; do docker cp $PWD/cert-tmp/$f $DOCKERSECVOLNAME:$TEST_CERT_VOL/$f; done
 # start server in secure grpc mode. uses non-default ports to avoid conflicts with fortio_server container.

--- a/bincommon/commonflags.go
+++ b/bincommon/commonflags.go
@@ -96,6 +96,7 @@ var (
 	CACertFlag = flag.String("cacert", "",
 		"`Path` to a custom CA certificate file to be used for the TLS client connections, "+
 			"if empty, use https:// prefix for standard internet/system CAs")
+	// LogErrorsFlag determines if the non ok http error codes get logged as they occur or not.
 	LogErrorsFlag = flag.Bool("log-errors", true, "Log http non 2xx/418 error codes as they occur")
 )
 

--- a/bincommon/commonflags.go
+++ b/bincommon/commonflags.go
@@ -96,6 +96,7 @@ var (
 	CACertFlag = flag.String("cacert", "",
 		"`Path` to a custom CA certificate file to be used for the TLS client connections, "+
 			"if empty, use https:// prefix for standard internet/system CAs")
+	LogErrorsFlag = flag.Bool("log-errors", true, "Log http non 2xx/418 error codes as they occur")
 )
 
 // SharedMain is the common part of main from fortio_main and fcurl.
@@ -178,5 +179,6 @@ func SharedHTTPOptions() *fhttp.HTTPOptions {
 	httpOpts.CACert = *CACertFlag
 	httpOpts.Cert = *CertFlag
 	httpOpts.Key = *KeyFlag
+	httpOpts.LogErrors = *LogErrorsFlag
 	return &httpOpts
 }

--- a/fhttp/http_client.go
+++ b/fhttp/http_client.go
@@ -191,7 +191,7 @@ type HTTPOptions struct {
 
 	UnixDomainSocket string // Path of unix domain socket to use instead of host:port from URL
 	LogErrors        bool   // whether to log non 2xx code as they occur or not
-	Id               int    // id to use for logging (thread id when used as a runner)
+	ID               int    // id to use for logging (thread id when used as a runner)
 }
 
 // ResetHeaders resets all the headers, including the User-Agent: one (and the Host: logical special header).
@@ -304,7 +304,7 @@ func newHTTPRequest(o *HTTPOptions) (*http.Request, error) {
 
 // Client object for making repeated requests of the same URL using the same
 // http client (net/http).
-// TODO: refactor common parts with FastClient
+// TODO: refactor common parts with FastClient.
 type Client struct {
 	url                  string
 	path                 string // original path of the request's url
@@ -481,7 +481,7 @@ func NewStdClient(o *HTTPOptions) (*Client, error) {
 			Transport: &tr,
 		},
 		transport: &tr,
-		id:        o.Id,
+		id:        o.ID,
 		logErrors: o.LogErrors,
 	}
 	if !o.FollowRedirects {
@@ -590,7 +590,7 @@ func NewFastClient(o *HTTPOptions) (Fetcher, error) {
 	// note: Host includes the port
 	bc := FastClient{
 		url: o.URL, host: url.Host, hostname: url.Hostname(), port: url.Port(),
-		http10: o.HTTP10, halfClose: o.AllowHalfClose, logErrors: o.LogErrors, id: o.Id,
+		http10: o.HTTP10, halfClose: o.AllowHalfClose, logErrors: o.LogErrors, id: o.ID,
 	}
 	bc.buffer = make([]byte, BufferSizeKb*1024)
 	if bc.port == "" {

--- a/fhttp/http_loglevel_test.go
+++ b/fhttp/http_loglevel_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !race
 // +build !race
 
 package fhttp

--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -96,7 +96,7 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 	for i := 0; i < numThreads; i++ {
 		r.Options().Runners[i] = &httpstate[i]
 		// Temp mutate the option so each client gets a logging id
-		o.HTTPOptions.Id = i
+		o.HTTPOptions.ID = i
 		// Create a client (and transport) and connect once for each 'thread'
 		var err error
 		httpstate[i].client, err = NewClient(&o.HTTPOptions)

--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -95,6 +95,8 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 	httpstate := make([]HTTPRunnerResults, numThreads)
 	for i := 0; i < numThreads; i++ {
 		r.Options().Runners[i] = &httpstate[i]
+		// Temp mutate the option so each client gets a logging id
+		o.HTTPOptions.Id = i
 		// Create a client (and transport) and connect once for each 'thread'
 		var err error
 		httpstate[i].client, err = NewClient(&o.HTTPOptions)

--- a/periodic/periodic_loglevel_test.go
+++ b/periodic/periodic_loglevel_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !race
 // +build !race
 
 package periodic

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -1,5 +1,5 @@
 # Concatenated after ../Dockerfile to create the tgz
-FROM docker.io/fortio/fortio.build:v34 as stage
+FROM docker.io/fortio/fortio.build:v35 as stage
 WORKDIR /stage
 COPY --from=release /usr/bin/fortio usr/bin/fortio
 #COPY --from=release /usr/share/fortio usr/share/fortio


### PR DESCRIPTION
Now both the fastclient (like before) and the std client will log non #490
ok http error codes (codes not 2xx or not 418) as they occur. 
You can also turn off these warnings using -log-errors=false

Also log an id 0-n number of runners/connection for these messages (this is a log change
fast client logs look like
```
16:35:41 W http_client.go:806> [0] Non ok http code 503 (HTTP/1.1 503)
```
and std client:
```
16:35:25 W http_client.go:401> [0] Non ok http code 503
```


Fixes #489

Also use latest go 1.16 (1.16.9) in  rev'ed up build image