### PR TITLE
rest/json run trigger api + more fixes/improvments

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ You can set a default value for all these by passing `-echo-server-default-param
   * Download/sync from an Amazon S3 or Google Cloud compatible bucket listings [XML URLs](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html)
 
 * API to trigger and cancel runs from the running server (like the form ui but more directly and with `async=on` option)
-  * `/fortio/rest/run` starts a run; the arguments are either from the command line or from POSTed JSON; `jsonPath` can be provided to look for in a subset of the json object, for instance `jsonPath=metadata` allows to use the flagger webhook meta data for fortio run parameters (see #493).
+  * `/fortio/rest/run` starts a run; the arguments are either from the command line or from POSTed JSON; `jsonPath` can be provided to look for in a subset of the json object, for instance `jsonPath=metadata` allows to use the flagger webhook meta data for fortio run parameters (see [#493](https://github.com/fortio/fortio/pull/493)).
   * `/fortio/rest/stop` stops all current run or by run id.
 
 The `report` mode is a readonly subset of the above directly on `/`.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It can run for a set duration, for a fixed number of calls, or until interrupted
 The name fortio comes from greek [φορτίο](https://fortio.org/fortio.mp3) which means load/burden.
 
 Fortio is a fast, small (3Mb docker image, minimal dependencies), reusable, embeddable go library as well as a command line tool and server process,
-the server includes a simple web UI and graphical representation of the results (both a single latency graph and a multiple results comparative min, max, avg, qps and percentiles graphs).
+the server includes a simple web UI and REST API to trigger run and see graphical representation of the results (both a single latency graph and a multiple results comparative min, max, avg, qps and percentiles graphs).
 
 Fortio also includes a set of server side features (similar to httpbin) to help debugging and testing: request echo back including headers, adding latency or error codes with a probability distribution, tcp echoing, tcp proxying, http fan out/scatter and gather proxy server, GRPC echo/health in addition to http, etc...
 
@@ -335,15 +335,15 @@ There is also the GRPC health and ping servers, as well as the http->https redir
 ```Shell
 $ fortio server &
 14:11:05 I fortio_main.go:171> Not using dynamic flag watching (use -config to set watch directory)
-Fortio 1.18.0 tcp-echo server listening on [::]:8078
-Fortio 1.18.0 grpc 'ping' server listening on [::]:8079
-Fortio 1.18.0 https redirector server listening on [::]:8081
-Fortio 1.18.0 echo server listening on [::]:8080
+Fortio X.Y.Z tcp-echo server listening on [::]:8078
+Fortio X.Y.Z grpc 'ping' server listening on [::]:8079
+Fortio X.Y.Z https redirector server listening on [::]:8081
+Fortio X.Y.Z echo server listening on [::]:8080
 Data directory is /Users/ldemailly/go/src/fortio.org/fortio
 UI started - visit:
 http://localhost:8080/fortio/
 (or any host/ip reachable on this server)
-14:11:05 I fortio_main.go:233> All fortio 1.18.0 release go1.16.9 servers started!
+14:11:05 I fortio_main.go:233> All fortio X.Y.Z release goM.m.p servers started!
 ```
 
 ### Change the port / binding address
@@ -356,8 +356,8 @@ $ fortio server -http-port 10.10.10.10:8088
 UI starting - visit:
 http://10.10.10.10:8088/fortio/
 Https redirector running on :8081
-Fortio 1.18.0 grpc ping server listening on port :8079
-Fortio 1.18.0 echo server listening on port 10.10.10.10:8088
+Fortio X.Y.Z grpc ping server listening on port :8079
+Fortio X.Y.Z echo server listening on port 10.10.10.10:8088
 ```
 
 ### Unix domain sockets
@@ -366,12 +366,12 @@ You can use unix domain socket for any server/client:
 
 ```Shell
 $ fortio server --http-port /tmp/fortio-uds-http &
-Fortio 1.18.0 grpc 'ping' server listening on [::]:8079
-Fortio 1.18.0 https redirector server listening on [::]:8081
-Fortio 1.18.0 echo server listening on /tmp/fortio-uds-http
+Fortio X.Y.Z grpc 'ping' server listening on [::]:8079
+Fortio X.Y.Z https redirector server listening on [::]:8081
+Fortio X.Y.Z echo server listening on /tmp/fortio-uds-http
 UI started - visit:
 fortio curl -unix-socket=/tmp/fortio-uds-http http://localhost/fortio/
-14:58:45 I fortio_main.go:217> All fortio 1.18.0 unknown go1.16.9 servers started!
+14:58:45 I fortio_main.go:217> All fortio X.Y.Z unknown goM.m.p servers started!
 $ fortio curl -unix-socket=/tmp/fortio-uds-http http://foo.bar/debug
 15:00:48 I http_client.go:428> Using unix domain socket /tmp/fortio-uds-http instead of foo.bar http
 HTTP/1.1 200 OK
@@ -379,14 +379,14 @@ Content-Type: text/plain; charset=UTF-8
 Date: Wed, 08 Aug 2018 22:00:48 GMT
 Content-Length: 231
 
-Φορτίο version 1.18.0 unknown go1.16.9 echo debug server up for 2m3.4s on ldemailly-macbookpro - request from
+Φορτίο version X.Y.Z unknown goM.m.p echo debug server up for 2m3.4s on ldemailly-macbookpro - request from
 
 GET /debug HTTP/1.1
 
 headers:
 
 Host: foo.bar
-User-Agent: fortio.org/fortio-1.18.0
+User-Agent: fortio.org/fortio-X.Y.Z
 
 body:
 ```
@@ -395,10 +395,10 @@ body:
 Start the echo-server alone and run a load (use `tcp://` prefix for the load test to be for tcp echo server)
 ```Shell
 $ fortio tcp-echo &
-Fortio 1.18.0 tcp-echo TCP server listening on [::]:8078
-19:45:30 I fortio_main.go:238> All fortio 1.18.0 release go1.16.9 servers started!
+Fortio X.Y.Z tcp-echo TCP server listening on [::]:8078
+19:45:30 I fortio_main.go:238> All fortio X.Y.Z release goM.m.p servers started!
 $ fortio load -qps -1 -n 100000 tcp://localhost:8078
-Fortio 1.18.0 running at -1 queries per second, 16->16 procs, for 100000 calls: tcp://localhost:8078
+Fortio X.Y.Z running at -1 queries per second, 16->16 procs, for 100000 calls: tcp://localhost:8078
 20:01:31 I tcprunner.go:218> Starting tcp test for tcp://localhost:8078 with 4 threads at -1.0 qps
 Starting at max qps with 4 thread(s) [gomax 16] for exactly 100000 calls (25000 per thread + 0)
 20:01:32 I periodic.go:558> T003 ended after 1.240585427s : 25000 calls. qps=20151.77629520873
@@ -424,11 +424,11 @@ All done 100000 calls (plus 0 warmup) 0.049 ms avg, 80495.0 qps
 Start the udp-echo server alone and run a load (use `tcp://` prefix for the load test to be for tcp echo server)
 ```
 $ fortio udp-echo &
-Fortio 1.18.0 udp-echo UDP server listening on [::]:8078
+Fortio X.Y.Z udp-echo UDP server listening on [::]:8078
 21:54:52 I fortio_main.go:273> Note: not using dynamic flag watching (use -config to set watch directory)
-21:54:52 I fortio_main.go:281> All fortio 1.18.0 release go1.16.9 servers started!
+21:54:52 I fortio_main.go:281> All fortio X.Y.Z release goM.m.p servers started!
 $ fortio load -qps -1 -n 100000 udp://localhost:8078/
-Fortio 1.18.0 running at -1 queries per second, 16->16 procs, for 100000 calls: udp://localhost:8078/
+Fortio X.Y.Z running at -1 queries per second, 16->16 procs, for 100000 calls: udp://localhost:8078/
 21:56:48 I udprunner.go:222> Starting udp test for udp://localhost:8078/ with 4 threads at -1.0 qps
 Starting at max qps with 4 thread(s) [gomax 16] for exactly 100000 calls (25000 per thread + 0)
 21:56:49 I periodic.go:558> T003 ended after 969.635695ms : 25000 calls. qps=25782.879208051432
@@ -510,8 +510,8 @@ $ fortio server -cert /path/to/fortio/server.crt -key /path/to/fortio/server.key
 UI starting - visit:
 http://localhost:8080/fortio/
 Https redirector running on :8081
-Fortio 1.18.0 grpc ping server listening on port :8079
-Fortio 1.18.0 echo server listening on port localhost:8080
+Fortio X.Y.Z grpc ping server listening on port :8079
+Fortio X.Y.Z echo server listening on port localhost:8080
 Using server certificate /path/to/fortio/server.crt to construct TLS credentials
 Using server key /path/to/fortio/server.key to construct TLS credentials
 ```
@@ -556,7 +556,7 @@ Load (low default qps/threading) test:
 
 ```Shell
 $ fortio load http://www.google.com
-Fortio 1.18.0 running at 8 queries per second, 8->8 procs, for 5s: http://www.google.com
+Fortio X.Y.Z running at 8 queries per second, 8->8 procs, for 5s: http://www.google.com
 19:10:33 I httprunner.go:84> Starting http test for http://www.google.com with 4 threads at 8.0 qps
 Starting at 8 qps with 4 thread(s) [gomax 8] for 5s : 10 calls each (total 40)
 19:10:39 I periodic.go:314> T002 ended after 5.056753279s : 10 calls. qps=1.9775534712220633
@@ -587,7 +587,7 @@ Uses `-s` to use multiple (h2/grpc) streams per connection (`-c`), request to hi
 
 ```bash
 $ fortio load -a -grpc -ping -grpc-ping-delay 0.25s -payload "01234567890" -c 2 -s 4 https://fortio-stage.istio.io
-Fortio 1.18.0 running at 8 queries per second, 8->8 procs, for 5s: https://fortio-stage.istio.io
+Fortio X.Y.Z running at 8 queries per second, 8->8 procs, for 5s: https://fortio-stage.istio.io
 16:32:56 I grpcrunner.go:139> Starting GRPC Ping Delay=250ms PayloadLength=11 test for https://fortio-stage.istio.io with 4*2 threads at 8.0 qps
 16:32:56 I grpcrunner.go:261> stripping https scheme. grpc destination: fortio-stage.istio.io. grpc port: 443
 16:32:57 I grpcrunner.go:261> stripping https scheme. grpc destination: fortio-stage.istio.io. grpc port: 443
@@ -692,14 +692,14 @@ Content-Type: text/plain; charset=UTF-8
 Date: Mon, 08 Jan 2018 22:26:26 GMT
 Content-Length: 230
 
-Φορτίο version 1.18.0 echo debug server up for 39s on ldemailly-macbookpro - request from [::1]:65055
+Φορτίο version X.Y.Z echo debug server up for 39s on ldemailly-macbookpro - request from [::1]:65055
 
 GET /debug HTTP/1.1
 
 headers:
 
 Host: localhost:8080
-User-Agent: fortio.org/fortio-1.18.0
+User-Agent: fortio.org/fortio-X.Y.Z
 Foo: Bar
 
 body:
@@ -724,7 +724,7 @@ Example listen on 1 extra port and every request sent to that 1 port is forward 
 # in one window or &
 $ fortio server -M "5554 http://localhost:8080 http://localhost:8080"
 [...]
-Fortio 1.18.0 Multi on 5554 server listening on [::]:5554
+Fortio X.Y.Z Multi on 5554 server listening on [::]:5554
 10:09:56 I http_forwarder.go:152> Multi-server on [::]:5554 running with &{Targets:[{Destination:http://localhost:8080 MirrorOrigin:true} {Destination:http://localhost:8080 MirrorOrigin:true}] Name:Multi on [::]:5554 client:0xc0001ccc00}
 ```
 Call the debug endpoint on both
@@ -736,7 +736,7 @@ Date: Wed, 07 Oct 2020 17:11:06 GMT
 Content-Length: 684
 Content-Type: text/plain; charset=utf-8
 
-Φορτίο version 1.18.0 unknown go1.16.9 echo debug server up for 1m9.3s on C02C77BHMD6R - request from [::1]:51020
+Φορτίο version X.Y.Z unknown goM.m.p echo debug server up for 1m9.3s on C02C77BHMD6R - request from [::1]:51020
 
 POST /debug HTTP/1.1
 
@@ -745,14 +745,14 @@ headers:
 Host: localhost:8080
 Accept-Encoding: gzip
 Content-Type: application/octet-stream
-User-Agent: fortio.org/fortio-1.18.0
+User-Agent: fortio.org/fortio-X.Y.Z
 X-Fortio-Multi-Id: 1
 X-On-Behalf-Of: [::1]:51019
 
 body:
 
 a test
-Φορτίο version 1.18.0 unknown go1.16.9 echo debug server up for 1m9.3s on C02C77BHMD6R - request from [::1]:51020
+Φορτίο version X.Y.Z unknown goM.m.p echo debug server up for 1m9.3s on C02C77BHMD6R - request from [::1]:51020
 
 POST /debug HTTP/1.1
 
@@ -761,7 +761,7 @@ headers:
 Host: localhost:8080
 Accept-Encoding: gzip
 Content-Type: application/octet-stream
-User-Agent: fortio.org/fortio-1.18.0
+User-Agent: fortio.org/fortio-X.Y.Z
 X-Fortio-Multi-Id: 2
 X-On-Behalf-Of: [::1]:51019
 
@@ -782,15 +782,15 @@ Example: open 2 additional listening ports and forward all requests received on 
 
 ```Shell
 $ fortio server -P "8888 [::1]:8080" -P "[::1]:8889 [::1]:8080"
-Fortio 1.18.0 grpc 'ping' server listening on [::]:8079
-Fortio 1.18.0 https redirector server listening on [::]:8081
-Fortio 1.18.0 echo server listening on [::]:8080
+Fortio X.Y.Z grpc 'ping' server listening on [::]:8079
+Fortio X.Y.Z https redirector server listening on [::]:8081
+Fortio X.Y.Z echo server listening on [::]:8080
 Data directory is /home/dl
 UI started - visit:
 http://localhost:8080/fortio/
 (or any host/ip reachable on this server)
-Fortio 1.18.0 proxy for [::1]:8080 server listening on [::]:8888
-Fortio 1.18.0 proxy for [::1]:8080 server listening on [::1]:8889
+Fortio X.Y.Z proxy for [::1]:8080 server listening on [::]:8888
+Fortio X.Y.Z proxy for [::1]:8080 server listening on [::1]:8889
 ```
 
 ## Implementation details

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ docker run fortio/fortio load http://www.google.com/ # For a test run
 Or download one of the binary distributions, from the [releases](https://github.com/fortio/fortio/releases) assets page or for instance:
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.17.1/fortio-linux_x64-1.17.1.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.18.0/fortio-linux_x64-1.18.0.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.17.1/fortio_1.17.1_amd64.deb
-dpkg -i fortio_1.17.1-1_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.18.0/fortio_1.18.0_amd64.deb
+dpkg -i fortio_1.18.0-1_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.17.1/fortio-1.17.1-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.18.0/fortio-1.18.0-1.x86_64.rpm
 ```
 
 On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
@@ -61,7 +61,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.17.1/fortio_win_1.17.1.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.18.0/fortio_win_1.18.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -104,7 +104,7 @@ Full list of command line flags (`fortio help`):
 <details>
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
-Φορτίο 1.17.1 usage:
+Φορτίο 1.18.0 usage:
         fortio command [flags] target
 where command is one of: load (load testing), server (starts ui, http-echo,
 redirect, proxies, tcp-echo and grpc ping servers), tcp-echo (only the tcp-echo
@@ -251,6 +251,9 @@ properly). Can be in the form of host:port, ip:port, port or "disabled" to
 disable the feature. (default "8081")
   -resolve string
         Resolve CN of cert to this IP, so that we can call https://cn directly
+  -runid int
+        Optional RunID to add to json result and auto save filename, to match
+server mode
   -s int
         Number of streams per grpc connection (default 1)
   -static-dir path
@@ -317,6 +320,10 @@ You can set a default value for all these by passing `-echo-server-default-param
   * Download/sync peer to peer JSON results files from other Fortio servers (using their `index.tsv` URLs)
   * Download/sync from an Amazon S3 or Google Cloud compatible bucket listings [XML URLs](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html)
 
+* API to trigger and cancel runs from the running server (like the form ui but more directly and with `async=on` option)
+  * `/fortio/rest/run` starts a run
+  * `/fortio/rest/stop` stops all current run or by run id.
+
 The `report` mode is a readonly subset of the above directly on `/`.
 
 There is also the GRPC health and ping servers, as well as the http->https redirector.
@@ -328,15 +335,15 @@ There is also the GRPC health and ping servers, as well as the http->https redir
 ```Shell
 $ fortio server &
 14:11:05 I fortio_main.go:171> Not using dynamic flag watching (use -config to set watch directory)
-Fortio 1.17.1 tcp-echo server listening on [::]:8078
-Fortio 1.17.1 grpc 'ping' server listening on [::]:8079
-Fortio 1.17.1 https redirector server listening on [::]:8081
-Fortio 1.17.1 echo server listening on [::]:8080
+Fortio 1.18.0 tcp-echo server listening on [::]:8078
+Fortio 1.18.0 grpc 'ping' server listening on [::]:8079
+Fortio 1.18.0 https redirector server listening on [::]:8081
+Fortio 1.18.0 echo server listening on [::]:8080
 Data directory is /Users/ldemailly/go/src/fortio.org/fortio
 UI started - visit:
 http://localhost:8080/fortio/
 (or any host/ip reachable on this server)
-14:11:05 I fortio_main.go:233> All fortio 1.17.1 release go1.16.9 servers started!
+14:11:05 I fortio_main.go:233> All fortio 1.18.0 release go1.16.9 servers started!
 ```
 
 ### Change the port / binding address
@@ -349,8 +356,8 @@ $ fortio server -http-port 10.10.10.10:8088
 UI starting - visit:
 http://10.10.10.10:8088/fortio/
 Https redirector running on :8081
-Fortio 1.17.1 grpc ping server listening on port :8079
-Fortio 1.17.1 echo server listening on port 10.10.10.10:8088
+Fortio 1.18.0 grpc ping server listening on port :8079
+Fortio 1.18.0 echo server listening on port 10.10.10.10:8088
 ```
 
 ### Unix domain sockets
@@ -359,12 +366,12 @@ You can use unix domain socket for any server/client:
 
 ```Shell
 $ fortio server --http-port /tmp/fortio-uds-http &
-Fortio 1.17.1 grpc 'ping' server listening on [::]:8079
-Fortio 1.17.1 https redirector server listening on [::]:8081
-Fortio 1.17.1 echo server listening on /tmp/fortio-uds-http
+Fortio 1.18.0 grpc 'ping' server listening on [::]:8079
+Fortio 1.18.0 https redirector server listening on [::]:8081
+Fortio 1.18.0 echo server listening on /tmp/fortio-uds-http
 UI started - visit:
 fortio curl -unix-socket=/tmp/fortio-uds-http http://localhost/fortio/
-14:58:45 I fortio_main.go:217> All fortio 1.17.1 unknown go1.16.9 servers started!
+14:58:45 I fortio_main.go:217> All fortio 1.18.0 unknown go1.16.9 servers started!
 $ fortio curl -unix-socket=/tmp/fortio-uds-http http://foo.bar/debug
 15:00:48 I http_client.go:428> Using unix domain socket /tmp/fortio-uds-http instead of foo.bar http
 HTTP/1.1 200 OK
@@ -372,14 +379,14 @@ Content-Type: text/plain; charset=UTF-8
 Date: Wed, 08 Aug 2018 22:00:48 GMT
 Content-Length: 231
 
-Φορτίο version 1.17.1 unknown go1.16.9 echo debug server up for 2m3.4s on ldemailly-macbookpro - request from
+Φορτίο version 1.18.0 unknown go1.16.9 echo debug server up for 2m3.4s on ldemailly-macbookpro - request from
 
 GET /debug HTTP/1.1
 
 headers:
 
 Host: foo.bar
-User-Agent: fortio.org/fortio-1.17.1
+User-Agent: fortio.org/fortio-1.18.0
 
 body:
 ```
@@ -388,10 +395,10 @@ body:
 Start the echo-server alone and run a load (use `tcp://` prefix for the load test to be for tcp echo server)
 ```Shell
 $ fortio tcp-echo &
-Fortio 1.17.1 tcp-echo TCP server listening on [::]:8078
-19:45:30 I fortio_main.go:238> All fortio 1.17.1 release go1.16.9 servers started!
+Fortio 1.18.0 tcp-echo TCP server listening on [::]:8078
+19:45:30 I fortio_main.go:238> All fortio 1.18.0 release go1.16.9 servers started!
 $ fortio load -qps -1 -n 100000 tcp://localhost:8078
-Fortio 1.17.1 running at -1 queries per second, 16->16 procs, for 100000 calls: tcp://localhost:8078
+Fortio 1.18.0 running at -1 queries per second, 16->16 procs, for 100000 calls: tcp://localhost:8078
 20:01:31 I tcprunner.go:218> Starting tcp test for tcp://localhost:8078 with 4 threads at -1.0 qps
 Starting at max qps with 4 thread(s) [gomax 16] for exactly 100000 calls (25000 per thread + 0)
 20:01:32 I periodic.go:558> T003 ended after 1.240585427s : 25000 calls. qps=20151.77629520873
@@ -417,11 +424,11 @@ All done 100000 calls (plus 0 warmup) 0.049 ms avg, 80495.0 qps
 Start the udp-echo server alone and run a load (use `tcp://` prefix for the load test to be for tcp echo server)
 ```
 $ fortio udp-echo &
-Fortio 1.17.1 udp-echo UDP server listening on [::]:8078
+Fortio 1.18.0 udp-echo UDP server listening on [::]:8078
 21:54:52 I fortio_main.go:273> Note: not using dynamic flag watching (use -config to set watch directory)
-21:54:52 I fortio_main.go:281> All fortio 1.17.1 release go1.16.9 servers started!
+21:54:52 I fortio_main.go:281> All fortio 1.18.0 release go1.16.9 servers started!
 $ fortio load -qps -1 -n 100000 udp://localhost:8078/
-Fortio 1.17.1 running at -1 queries per second, 16->16 procs, for 100000 calls: udp://localhost:8078/
+Fortio 1.18.0 running at -1 queries per second, 16->16 procs, for 100000 calls: udp://localhost:8078/
 21:56:48 I udprunner.go:222> Starting udp test for udp://localhost:8078/ with 4 threads at -1.0 qps
 Starting at max qps with 4 thread(s) [gomax 16] for exactly 100000 calls (25000 per thread + 0)
 21:56:49 I periodic.go:558> T003 ended after 969.635695ms : 25000 calls. qps=25782.879208051432
@@ -503,8 +510,8 @@ $ fortio server -cert /path/to/fortio/server.crt -key /path/to/fortio/server.key
 UI starting - visit:
 http://localhost:8080/fortio/
 Https redirector running on :8081
-Fortio 1.17.1 grpc ping server listening on port :8079
-Fortio 1.17.1 echo server listening on port localhost:8080
+Fortio 1.18.0 grpc ping server listening on port :8079
+Fortio 1.18.0 echo server listening on port localhost:8080
 Using server certificate /path/to/fortio/server.crt to construct TLS credentials
 Using server key /path/to/fortio/server.key to construct TLS credentials
 ```
@@ -549,7 +556,7 @@ Load (low default qps/threading) test:
 
 ```Shell
 $ fortio load http://www.google.com
-Fortio 1.17.1 running at 8 queries per second, 8->8 procs, for 5s: http://www.google.com
+Fortio 1.18.0 running at 8 queries per second, 8->8 procs, for 5s: http://www.google.com
 19:10:33 I httprunner.go:84> Starting http test for http://www.google.com with 4 threads at 8.0 qps
 Starting at 8 qps with 4 thread(s) [gomax 8] for 5s : 10 calls each (total 40)
 19:10:39 I periodic.go:314> T002 ended after 5.056753279s : 10 calls. qps=1.9775534712220633
@@ -580,7 +587,7 @@ Uses `-s` to use multiple (h2/grpc) streams per connection (`-c`), request to hi
 
 ```bash
 $ fortio load -a -grpc -ping -grpc-ping-delay 0.25s -payload "01234567890" -c 2 -s 4 https://fortio-stage.istio.io
-Fortio 1.17.1 running at 8 queries per second, 8->8 procs, for 5s: https://fortio-stage.istio.io
+Fortio 1.18.0 running at 8 queries per second, 8->8 procs, for 5s: https://fortio-stage.istio.io
 16:32:56 I grpcrunner.go:139> Starting GRPC Ping Delay=250ms PayloadLength=11 test for https://fortio-stage.istio.io with 4*2 threads at 8.0 qps
 16:32:56 I grpcrunner.go:261> stripping https scheme. grpc destination: fortio-stage.istio.io. grpc port: 443
 16:32:57 I grpcrunner.go:261> stripping https scheme. grpc destination: fortio-stage.istio.io. grpc port: 443
@@ -685,14 +692,14 @@ Content-Type: text/plain; charset=UTF-8
 Date: Mon, 08 Jan 2018 22:26:26 GMT
 Content-Length: 230
 
-Φορτίο version 1.17.1 echo debug server up for 39s on ldemailly-macbookpro - request from [::1]:65055
+Φορτίο version 1.18.0 echo debug server up for 39s on ldemailly-macbookpro - request from [::1]:65055
 
 GET /debug HTTP/1.1
 
 headers:
 
 Host: localhost:8080
-User-Agent: fortio.org/fortio-1.17.1
+User-Agent: fortio.org/fortio-1.18.0
 Foo: Bar
 
 body:
@@ -717,7 +724,7 @@ Example listen on 1 extra port and every request sent to that 1 port is forward 
 # in one window or &
 $ fortio server -M "5554 http://localhost:8080 http://localhost:8080"
 [...]
-Fortio 1.17.1 Multi on 5554 server listening on [::]:5554
+Fortio 1.18.0 Multi on 5554 server listening on [::]:5554
 10:09:56 I http_forwarder.go:152> Multi-server on [::]:5554 running with &{Targets:[{Destination:http://localhost:8080 MirrorOrigin:true} {Destination:http://localhost:8080 MirrorOrigin:true}] Name:Multi on [::]:5554 client:0xc0001ccc00}
 ```
 Call the debug endpoint on both
@@ -729,7 +736,7 @@ Date: Wed, 07 Oct 2020 17:11:06 GMT
 Content-Length: 684
 Content-Type: text/plain; charset=utf-8
 
-Φορτίο version 1.17.1 unknown go1.16.9 echo debug server up for 1m9.3s on C02C77BHMD6R - request from [::1]:51020
+Φορτίο version 1.18.0 unknown go1.16.9 echo debug server up for 1m9.3s on C02C77BHMD6R - request from [::1]:51020
 
 POST /debug HTTP/1.1
 
@@ -738,14 +745,14 @@ headers:
 Host: localhost:8080
 Accept-Encoding: gzip
 Content-Type: application/octet-stream
-User-Agent: fortio.org/fortio-1.17.1
+User-Agent: fortio.org/fortio-1.18.0
 X-Fortio-Multi-Id: 1
 X-On-Behalf-Of: [::1]:51019
 
 body:
 
 a test
-Φορτίο version 1.17.1 unknown go1.16.9 echo debug server up for 1m9.3s on C02C77BHMD6R - request from [::1]:51020
+Φορτίο version 1.18.0 unknown go1.16.9 echo debug server up for 1m9.3s on C02C77BHMD6R - request from [::1]:51020
 
 POST /debug HTTP/1.1
 
@@ -754,7 +761,7 @@ headers:
 Host: localhost:8080
 Accept-Encoding: gzip
 Content-Type: application/octet-stream
-User-Agent: fortio.org/fortio-1.17.1
+User-Agent: fortio.org/fortio-1.18.0
 X-Fortio-Multi-Id: 2
 X-On-Behalf-Of: [::1]:51019
 
@@ -775,15 +782,15 @@ Example: open 2 additional listening ports and forward all requests received on 
 
 ```Shell
 $ fortio server -P "8888 [::1]:8080" -P "[::1]:8889 [::1]:8080"
-Fortio 1.17.1 grpc 'ping' server listening on [::]:8079
-Fortio 1.17.1 https redirector server listening on [::]:8081
-Fortio 1.17.1 echo server listening on [::]:8080
+Fortio 1.18.0 grpc 'ping' server listening on [::]:8079
+Fortio 1.18.0 https redirector server listening on [::]:8081
+Fortio 1.18.0 echo server listening on [::]:8080
 Data directory is /home/dl
 UI started - visit:
 http://localhost:8080/fortio/
 (or any host/ip reachable on this server)
-Fortio 1.17.1 proxy for [::1]:8080 server listening on [::]:8888
-Fortio 1.17.1 proxy for [::1]:8080 server listening on [::1]:8889
+Fortio 1.18.0 proxy for [::1]:8080 server listening on [::]:8888
+Fortio 1.18.0 proxy for [::1]:8080 server listening on [::1]:8889
 ```
 
 ## Implementation details

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ You can set a default value for all these by passing `-echo-server-default-param
   * Download/sync from an Amazon S3 or Google Cloud compatible bucket listings [XML URLs](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html)
 
 * API to trigger and cancel runs from the running server (like the form ui but more directly and with `async=on` option)
-  * `/fortio/rest/run` starts a run
+  * `/fortio/rest/run` starts a run; the arguments are either from the command line or from POSTed JSON; `jsonPath` can be provided to look for in a subset of the json object, for instance `jsonPath=metadata` allows to use the flagger webhook meta data for fortio run parameters (see #493).
   * `/fortio/rest/stop` stops all current run or by run id.
 
 The `report` mode is a readonly subset of the above directly on `/`.

--- a/bincommon/commonflags.go
+++ b/bincommon/commonflags.go
@@ -98,6 +98,8 @@ var (
 			"if empty, use https:// prefix for standard internet/system CAs")
 	// LogErrorsFlag determines if the non ok http error codes get logged as they occur or not.
 	LogErrorsFlag = flag.Bool("log-errors", true, "Log http non 2xx/418 error codes as they occur")
+	// RunIDFlag is optional RunID to be present in json results (and default json result filename if not 0).
+	RunIDFlag = flag.Int64("runid", 0, "Optional RunID to add to json result and auto save filename, to match server mode")
 )
 
 // SharedMain is the common part of main from fortio_main and fcurl.

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -386,6 +386,7 @@ func fortioLoad(justCurl bool, percList []float64) {
 		Labels:      labels,
 		Exactly:     *exactlyFlag,
 		Jitter:      *jitterFlag,
+		RunID:       *bincommon.RunIDFlag,
 	}
 	var res periodic.HasRunnerResult
 	var err error

--- a/release/updateFlags.sh
+++ b/release/updateFlags.sh
@@ -15,4 +15,4 @@
 #
 # Extract fortio's help and rewrap it to 80 cols
 # TODO: do like fmt does to keep leading identation
-fortio help | expand | fold -s | sed -e "s/ $//"
+go run . help | expand | fold -s | sed -e "s/ $//" -e "s/</\&lt;/"

--- a/ui/restHandler.go
+++ b/ui/restHandler.go
@@ -19,18 +19,20 @@ import (
 	"fortio.org/fortio/udprunner"
 )
 
+// ErrorReply is returned on errors.
 type ErrorReply struct {
 	Error     string
 	Exception error
 }
 
+// Error writes serialized ErrorReply to the writer.
 func Error(w http.ResponseWriter, msg ErrorReply) {
 	w.WriteHeader(http.StatusBadRequest)
 	b, _ := json.Marshal(msg)
 	_, _ = w.Write(b)
 }
 
-// RESTHandler is api version of UI submit handler
+// RESTRunHandler is api version of UI submit handler
 func RESTRunHandler(w http.ResponseWriter, r *http.Request) {
 	fhttp.LogRequest(r, "REST Run Api call")
 	DoSave := (r.FormValue("save") == "on")
@@ -93,6 +95,7 @@ func RESTRunHandler(w http.ResponseWriter, r *http.Request) {
 	runid := id
 	runs[runid] = &ro
 	uiRunMapMutex.Unlock()
+	ro.RunID = runid
 	log.Infof("New run id %d", runid)
 	httpopts := &fhttp.HTTPOptions{}
 	httpopts.HTTPReqTimeOut = timeout // to be normalized in init 0 replaced by default value
@@ -120,6 +123,7 @@ func RESTRunHandler(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(fmt.Sprintf("{\"started\": %d}", runid)))
 		// detach?
 	}
+
 	//	go func() {
 	var res periodic.HasRunnerResult
 	var err error

--- a/ui/restHandler.go
+++ b/ui/restHandler.go
@@ -42,15 +42,15 @@ func Error(w http.ResponseWriter, msg ErrorReply) {
 // . is all the json
 // .foo.bar.blah will extract that part of the tree.
 func GetConfigAtPath(path string, data []byte) (map[string]interface{}, error) {
-	var f interface{}
-	if err := json.Unmarshal(data, &f); err != nil {
+	// that's what Unmarshal does anyway if you pass interface{} var, skips a cast even for dynamic/unknown json
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
 		return nil, err
 	}
-	m := f.(map[string]interface{})
 	return getConfigAtPath(path, m)
 }
 
-// recurse on the requested path
+// recurse on the requested path.
 func getConfigAtPath(path string, m map[string]interface{}) (map[string]interface{}, error) {
 	path = strings.TrimLeft(path, ".")
 	if path == "" {
@@ -96,7 +96,7 @@ func FormValue(r *http.Request, json map[string]interface{}, key string) string 
 }
 
 // RESTRunHandler is api version of UI submit handler.
-func RESTRunHandler(w http.ResponseWriter, r *http.Request) {
+func RESTRunHandler(w http.ResponseWriter, r *http.Request) { // nolint: funlen
 	fhttp.LogRequest(r, "REST Run Api call")
 	data, err := ioutil.ReadAll(r.Body) // must be done before calling FormValue
 	if err != nil {
@@ -207,7 +207,8 @@ func RESTRunHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // Run executes the run (can be called async or not, writer is nil for async mode).
-func Run(w http.ResponseWriter, r *http.Request, jd map[string]interface{}, runner, url string, ro periodic.RunnerOptions, httpopts *fhttp.HTTPOptions) {
+func Run(w http.ResponseWriter, r *http.Request, jd map[string]interface{},
+	runner, url string, ro periodic.RunnerOptions, httpopts *fhttp.HTTPOptions) {
 	//	go func() {
 	var res periodic.HasRunnerResult
 	var err error

--- a/ui/restHandler.go
+++ b/ui/restHandler.go
@@ -74,6 +74,8 @@ func getConfigAtPath(path string, m map[string]interface{}) (map[string]interfac
 	return getConfigAtPath(rest, mm)
 }
 
+// FormValue gets the value from the query arguments/url parameter or from the
+// provided map (json data).
 func FormValue(r *http.Request, json map[string]interface{}, key string) string {
 	// query args have priority
 	res := r.FormValue(key)
@@ -282,18 +284,22 @@ func Run(w http.ResponseWriter, r *http.Request, jd map[string]interface{},
 	}
 }
 
+// RESTStatusHandler will print the state of the runs.
 func RESTStatusHandler(w http.ResponseWriter, r *http.Request) {
 	fhttp.LogRequest(r, "REST Status Api call")
 	w.WriteHeader(http.StatusServiceUnavailable)
 	w.Write([]byte("{\"error\":\"status not yet implemented\"}"))
 }
 
+// RESTStopHandler is the api to stop a given run by runid or all the runs if unspecified/0.
 func RESTStopHandler(w http.ResponseWriter, r *http.Request) {
 	fhttp.LogRequest(r, "REST Stop Api call")
-	i := StopByRunID(0) // TODO: get from input
+	runid, _ := strconv.ParseInt(r.FormValue("runid"), 10, 64)
+	i := StopByRunID(runid)
 	w.Write([]byte(fmt.Sprintf("{\"stopped\": %d}", i)))
 }
 
+// StopByRunID stops all the runs if passed 0 or the runid provided.
 func StopByRunID(runid int64) int {
 	uiRunMapMutex.Lock()
 	if runid <= 0 { // Stop all

--- a/ui/restHandler.go
+++ b/ui/restHandler.go
@@ -132,7 +132,7 @@ func Run(w http.ResponseWriter, r *http.Request, runner, url string, ro periodic
 	//	go func() {
 	var res periodic.HasRunnerResult
 	var err error
-	if runner == modegrpc {
+	if runner == modegrpc { // nolint: nestif
 		grpcSecure := (r.FormValue("grpc-secure") == "on")
 		grpcPing := (r.FormValue("ping") == "on")
 		grpcPingDelay, _ := time.ParseDuration(r.FormValue("grpc-ping-delay"))

--- a/ui/restHandler.go
+++ b/ui/restHandler.go
@@ -107,7 +107,7 @@ func RESTRunHandler(w http.ResponseWriter, r *http.Request) { // nolint: funlen
 	log.Infof("REST body: %s", fhttp.DebugSummary(data, 250))
 	jsonPath := r.FormValue("jsonPath")
 	var jd map[string]interface{}
-	if jsonPath != "" {
+	if len(data) > 0 {
 		// Json input and deserialize options from that path, eg. for flagger:
 		// jsonPath=metadata
 		jd, err = GetConfigAtPath(jsonPath, data)

--- a/ui/restHandler.go
+++ b/ui/restHandler.go
@@ -1,0 +1,226 @@
+package ui // import "fortio.org/fortio/ui"
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"fortio.org/fortio/fgrpc"
+	"fortio.org/fortio/fhttp"
+	"fortio.org/fortio/log"
+	"fortio.org/fortio/periodic"
+	"fortio.org/fortio/stats"
+	"fortio.org/fortio/tcprunner"
+	"fortio.org/fortio/udprunner"
+)
+
+type ErrorReply struct {
+	Error     string
+	Exception error
+}
+
+func Error(w http.ResponseWriter, msg ErrorReply) {
+	w.WriteHeader(http.StatusBadRequest)
+	b, _ := json.Marshal(msg)
+	_, _ = w.Write(b)
+}
+
+// RESTHandler is api version of UI submit handler
+func RESTRunHandler(w http.ResponseWriter, r *http.Request) {
+	fhttp.LogRequest(r, "REST Run Api call")
+	DoSave := (r.FormValue("save") == "on")
+	url := r.FormValue("url")
+	runner := r.FormValue("runner")
+	if runner == "" {
+		runner = "http"
+	}
+	log.Infof("Starting API run %s load request from %v for %s", runner, r.RemoteAddr, url)
+	async := (r.FormValue("async") == "on")
+	payload := r.FormValue("payload")
+	labels := r.FormValue("labels")
+	resolution, _ := strconv.ParseFloat(r.FormValue("r"), 64)
+	percList, _ := stats.ParsePercentiles(r.FormValue("p"))
+	qps, _ := strconv.ParseFloat(r.FormValue("qps"), 64)
+	durStr := r.FormValue("t")
+	jitter := (r.FormValue("jitter") == "on")
+	grpcSecure := (r.FormValue("grpc-secure") == "on")
+	grpcPing := (r.FormValue("ping") == "on")
+	grpcPingDelay, _ := time.ParseDuration(r.FormValue("grpc-ping-delay"))
+	stdClient := (r.FormValue("stdclient") == "on")
+	httpsInsecure := (r.FormValue("https-insecure") == "on")
+	resolve := r.FormValue("resolve")
+	timeoutStr := strings.TrimSpace(r.FormValue("timeout"))
+	timeout, _ := time.ParseDuration(timeoutStr) // will be 0 if empty, which is handled by runner and opts
+	var dur time.Duration
+	if durStr == "on" || ((len(r.Form["t"]) > 1) && r.Form["t"][1] == "on") {
+		dur = -1
+	} else {
+		var err error
+		dur, err = time.ParseDuration(durStr)
+		if err != nil {
+			log.Errf("Error parsing duration '%s': %v", durStr, err)
+		}
+	}
+	c, _ := strconv.Atoi(r.FormValue("c"))
+	out := io.Writer(os.Stderr)
+	if len(percList) == 0 && !strings.Contains(r.URL.RawQuery, "p=") {
+		percList = defaultPercentileList
+	}
+	n, _ := strconv.ParseInt(r.FormValue("n"), 10, 64)
+	if strings.TrimSpace(url) == "" {
+		Error(w, ErrorReply{"URL is required", nil})
+		return
+	}
+	ro := periodic.RunnerOptions{
+		QPS:         qps,
+		Duration:    dur,
+		Out:         out,
+		NumThreads:  c,
+		Resolution:  resolution,
+		Percentiles: percList,
+		Labels:      labels,
+		Exactly:     n,
+		Jitter:      jitter,
+	}
+	ro.Normalize()
+	uiRunMapMutex.Lock()
+	id++ // start at 1 as 0 means interrupt all
+	runid := id
+	runs[runid] = &ro
+	uiRunMapMutex.Unlock()
+	log.Infof("New run id %d", runid)
+	httpopts := &fhttp.HTTPOptions{}
+	httpopts.HTTPReqTimeOut = timeout // to be normalized in init 0 replaced by default value
+	httpopts = httpopts.Init(url)
+	httpopts.ResetHeaders()
+	httpopts.DisableFastClient = stdClient
+	httpopts.Insecure = httpsInsecure
+	httpopts.Resolve = resolve
+	if len(payload) > 0 {
+		httpopts.Payload = []byte(payload)
+	}
+	// mode == run case:
+	for _, header := range r.Form["H"] {
+		if len(header) == 0 {
+			continue
+		}
+		log.LogVf("adding header %v", header)
+		err := httpopts.AddAndValidateExtraHeader(header)
+		if err != nil {
+			log.Errf("Error adding custom headers: %v", err)
+		}
+	}
+	fhttp.OnBehalfOf(httpopts, r)
+	if async {
+		w.Write([]byte(fmt.Sprintf("{\"started\": %d}", runid)))
+		// detach?
+	}
+	//	go func() {
+	var res periodic.HasRunnerResult
+	var err error
+	if runner == modegrpc {
+		o := fgrpc.GRPCRunnerOptions{
+			RunnerOptions: ro,
+			Destination:   url,
+			UsePing:       grpcPing,
+			Delay:         grpcPingDelay,
+			Insecure:      httpsInsecure,
+		}
+		if grpcSecure {
+			o.Destination = fhttp.AddHTTPS(url)
+		}
+		// TODO: ReqTimeout: timeout
+		res, err = fgrpc.RunGRPCTest(&o)
+	} else if strings.HasPrefix(url, tcprunner.TCPURLPrefix) {
+		// TODO: copy pasta from fortio_main
+		o := tcprunner.RunnerOptions{
+			RunnerOptions: ro,
+		}
+		o.ReqTimeout = timeout
+		o.Destination = url
+		o.Payload = httpopts.Payload
+		res, err = tcprunner.RunTCPTest(&o)
+	} else if strings.HasPrefix(url, udprunner.UDPURLPrefix) {
+		// TODO: copy pasta from fortio_main
+		o := udprunner.RunnerOptions{
+			RunnerOptions: ro,
+		}
+		o.ReqTimeout = timeout
+		o.Destination = url
+		o.Payload = httpopts.Payload
+		res, err = udprunner.RunUDPTest(&o)
+	} else {
+		o := fhttp.HTTPRunnerOptions{
+			HTTPOptions:        *httpopts,
+			RunnerOptions:      ro,
+			AllowInitialErrors: true,
+		}
+		res, err = fhttp.RunHTTPTest(&o)
+	}
+	if err != nil {
+		log.Errf("Init error for %s mode with url %s and options %+v : %v", runner, url, ro, err)
+		Error(w, ErrorReply{"Aborting because of error", err})
+		return
+	}
+	json, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		log.Fatalf("Unable to json serialize result: %v", err)
+	}
+	id := res.Result().ID()
+	if DoSave {
+		SaveJSON(id, json)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, err = w.Write(json)
+	if err != nil {
+		log.Errf("Unable to write json output for %v: %v", r.RemoteAddr, err)
+	}
+	uiRunMapMutex.Lock()
+	delete(runs, runid)
+	uiRunMapMutex.Unlock()
+	//	}()
+}
+
+func RESTStatusHandler(w http.ResponseWriter, r *http.Request) {
+	fhttp.LogRequest(r, "REST Status Api call")
+	w.WriteHeader(http.StatusServiceUnavailable)
+	w.Write([]byte("{\"error\":\"status not yet implemented\"}"))
+}
+
+func RESTStopHandler(w http.ResponseWriter, r *http.Request) {
+	fhttp.LogRequest(r, "REST Stop Api call")
+	i := StopByRunID(0) // TODO: get from input
+	w.Write([]byte(fmt.Sprintf("{\"stopped\": %d}", i)))
+}
+
+func StopByRunID(runid int64) int {
+	uiRunMapMutex.Lock()
+	if runid <= 0 { // Stop all
+		i := 0
+		for k, v := range runs {
+			v.Abort()
+			delete(runs, k)
+			i++
+		}
+		uiRunMapMutex.Unlock()
+		log.Infof("Interrupted all %d runs", i)
+		return i
+	}
+	// else: Stop one
+	v, found := runs[runid]
+	if found {
+		delete(runs, runid)
+		uiRunMapMutex.Unlock()
+		v.Abort()
+		log.Infof("Interrupted run id %d", runid)
+		return 1
+	}
+	log.Infof("Runid %d not found to interrupt", runid)
+	uiRunMapMutex.Unlock()
+	return 0
+}

--- a/ui/static/js/fortio_chart.js
+++ b/ui/static/js/fortio_chart.js
@@ -87,13 +87,19 @@ function formatDate (dStr) {
 
 function makeTitle (res) {
   const title = []
-  if (res.Labels !== '') {
-    if (res.URL) { // http results
-      title.push(res.Labels + ' - ' + res.URL + ' - ' + formatDate(res.StartTime))
-    } else { // grpc results
-      title.push(res.Labels + ' - ' + res.Destination + ' - ' + formatDate(res.StartTime))
-    }
+  let firstLine = ''
+  if ((typeof res.RunID !== 'undefined')  &&  (res.RunID!== 0)) {
+    firstLine = '(' + res.RunID + ') '
   }
+  if (res.Labels !== '') {
+    firstLine += res.Labels + ' - '
+  }
+  if (res.URL) { // http results
+    firstLine+= res.URL
+  } else { // grpc/tcp results
+    firstLine+= res.Destination
+  }
+  title.push(firstLine+ ' - ' + formatDate(res.StartTime))
   let percStr = 'min ' + myRound(1000.0 * res.DurationHistogram.Min, 3) + ' ms, average ' + myRound(1000.0 * res.DurationHistogram.Avg, 3) + ' ms'
   if (res.DurationHistogram.Percentiles) {
     for (let i = 0; i < res.DurationHistogram.Percentiles.length; i++) {

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -201,6 +201,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		runs[runid] = &ro
 		uiRunMapMutex.Unlock()
 		log.Infof("New run id %d", runid)
+		ro.RunID = id
 	}
 	httpopts := &fhttp.HTTPOptions{}
 	httpopts.HTTPReqTimeOut = timeout // to be normalized in init 0 replaced by default value


### PR DESCRIPTION
new endpoints:
- `fortio/rest/run` similar to fetching fortio/ without needing `load=Start` to start a run
  - plus `async` query arg or json value "`on`" will make the run asynchronous (returns just the runid of the run instead of waiting for the result)
  - plus read all the run configuration from either query args or jsonPath posted info (so for a large payload; must be put in json vs POST query args in `/fortio/` endpoint)
  - compatible with [flagger](https://github.com/fluxcd/flagger) and other webhooks
e.g
```
curl -v -d '{"metadata": {"url":"localhost:8080", "c":"1", "n":"1", "async":"on", "save":"on"}}' \
     "localhost:8080/fortio/rest/run?jsonPath=.metadata"
```
makes a 1 connection 1 query run for localhost:8080 url asynchronously and saves results

or minimally:
```
curl -s -d '{"url":"localhost:8080"}' "localhost:8080/fortio/rest/run" | jq
```
- `fortio/rest/stop` stops all runs or by id

Also:
- added RunID in options and result, use it in filename generation when non 0 (server run ids auto increment)
- fixed bug where destination/url in ui wouldn't show unless labels were present
- show the runid there as (runid) prefix in UI

Fixes #492 
