### PR TITLE
Add offset to the histogram of the response time

### DIFF
--- a/fortio_main.go
+++ b/fortio_main.go
@@ -104,7 +104,7 @@ var (
 	durationFlag    = flag.Duration("t", defaults.Duration, "How long to run the test or 0 to run until ^C")
 	percentilesFlag = flag.String("p", "50,75,90,99,99.9", "List of pXX to calculate")
 	resolutionFlag  = flag.Float64("r", defaults.Resolution, "Resolution of the histogram lowest buckets in seconds")
-	offsetFlag      = flag.Float64("o", defaults.Offset, "Offset of the histogram data in seconds")
+	offsetFlag      = flag.Duration("o", defaults.Offset, "Offset duration of the histogram data")
 	goMaxProcsFlag  = flag.Int("gomaxprocs", 0, "Setting for runtime.GOMAXPROCS, <1 doesn't change the default")
 	profileFlag     = flag.String("profile", "", "write .cpu and .mem profiles to `file`")
 	grpcFlag        = flag.Bool("grpc", false, "Use GRPC (health check by default, add -ping for ping) for load testing")

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -104,6 +104,7 @@ var (
 	durationFlag    = flag.Duration("t", defaults.Duration, "How long to run the test or 0 to run until ^C")
 	percentilesFlag = flag.String("p", "50,75,90,99,99.9", "List of pXX to calculate")
 	resolutionFlag  = flag.Float64("r", defaults.Resolution, "Resolution of the histogram lowest buckets in seconds")
+	offsetFlag      = flag.Float64("o", defaults.Offset, "Offset of the histogram data in seconds")
 	goMaxProcsFlag  = flag.Int("gomaxprocs", 0, "Setting for runtime.GOMAXPROCS, <1 doesn't change the default")
 	profileFlag     = flag.String("profile", "", "write .cpu and .mem profiles to `file`")
 	grpcFlag        = flag.Bool("grpc", false, "Use GRPC (health check by default, add -ping for ping) for load testing")
@@ -387,6 +388,7 @@ func fortioLoad(justCurl bool, percList []float64) {
 		Exactly:     *exactlyFlag,
 		Jitter:      *jitterFlag,
 		RunID:       *bincommon.RunIDFlag,
+		Offset:      *offsetFlag,
 	}
 	var res periodic.HasRunnerResult
 	var err error

--- a/periodic/periodic.go
+++ b/periodic/periodic.go
@@ -134,8 +134,8 @@ type RunnerOptions struct {
 	Jitter bool
 	// Optional run id; used by the server to identify runs.
 	RunID int64
-	// Optional Offect; to offset the histogram function duration
-	Offset float64
+	// Optional Offect Duration; to offset the histogram function duration
+	Offset time.Duration
 }
 
 // RunnerResults encapsulates the actual QPS observed and duration histogram.
@@ -408,7 +408,8 @@ func (r *periodicRunner) Run() RunnerResults {
 	}
 	start := time.Now()
 	// Histogram  and stats for Function duration - millisecond precision
-	functionDuration := stats.NewHistogram(r.Offset, r.Resolution)
+	offsetSec := float64(r.Offset) / float64(time.Second)
+	functionDuration := stats.NewHistogram(offsetSec, r.Resolution)
 	// Histogram and stats for Sleep time (negative offset to capture <0 sleep in their own bucket):
 	sleepTime := stats.NewHistogram(-0.001, 0.001)
 	if r.NumThreads <= 1 {

--- a/periodic/periodic.go
+++ b/periodic/periodic.go
@@ -134,6 +134,8 @@ type RunnerOptions struct {
 	Jitter bool
 	// Optional run id; used by the server to identify runs.
 	RunID int64
+	// Optional Offect; to offset the histogram function duration
+	Offset float64
 }
 
 // RunnerResults encapsulates the actual QPS observed and duration histogram.
@@ -406,7 +408,7 @@ func (r *periodicRunner) Run() RunnerResults {
 	}
 	start := time.Now()
 	// Histogram  and stats for Function duration - millisecond precision
-	functionDuration := stats.NewHistogram(0, r.Resolution)
+	functionDuration := stats.NewHistogram(r.Offset, r.Resolution)
 	// Histogram and stats for Sleep time (negative offset to capture <0 sleep in their own bucket):
 	sleepTime := stats.NewHistogram(-0.001, 0.001)
 	if r.NumThreads <= 1 {

--- a/periodic/periodic.go
+++ b/periodic/periodic.go
@@ -408,8 +408,7 @@ func (r *periodicRunner) Run() RunnerResults {
 	}
 	start := time.Now()
 	// Histogram  and stats for Function duration - millisecond precision
-	offsetSec := float64(r.Offset) / float64(time.Second)
-	functionDuration := stats.NewHistogram(offsetSec, r.Resolution)
+	functionDuration := stats.NewHistogram(r.Offset.Seconds(), r.Resolution)
 	// Histogram and stats for Sleep time (negative offset to capture <0 sleep in their own bucket):
 	sleepTime := stats.NewHistogram(-0.001, 0.001)
 	if r.NumThreads <= 1 {


### PR DESCRIPTION
It is to add offsset to the histogram of the response time.

Currently we run the fortio on a service with predefined latency, say, 200ms, 500ms, 1s to simulate production behavior.  Fortio does not give accurate response time as the histogram of the response time is always starting from 0.   

In this PR, a new flag is added.  it is
-o :  offset to histogram of the response time
e.g.  if the latency of the service is 200ms,  i.e. sleep 200ms in the service.  the command for the fortio is : '
  
fortio load -o 0.2s    ......

