### PR TITLE
added new flag, default true,  so the fetch2 endpoint copies all head…

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ docker run fortio/fortio load http://www.google.com/ # For a test run
 Or download one of the binary distributions, from the [releases](https://github.com/fortio/fortio/releases) assets page or for instance:
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.19.0/fortio-linux_x64-1.19.0.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.20.0/fortio-linux_x64-1.20.0.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.19.0/fortio_1.19.0_amd64.deb
-dpkg -i fortio_1.19.0_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.20.0/fortio_1.20.0_amd64.deb
+dpkg -i fortio_1.20.0_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.19.0/fortio-1.19.0-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.20.0/fortio-1.20.0-1.x86_64.rpm
 ```
 
 On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
@@ -61,7 +61,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.19.0/fortio_win_1.19.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.20.0/fortio_win_1.20.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -104,12 +104,13 @@ Full list of command line flags (`fortio help`):
 <details>
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
-Φορτίο 1.19.0 usage:
+Φορτίο 1.20.0 usage:
 where command is one of: load (load testing), server (starts ui, http-echo,
-redirect, proxies, tcp-echo and grpc ping servers), tcp-echo (only the tcp-echo
-server), report (report only UI server), redirect (only the redirect server),
-proxies (only the -M and -P configured proxies), grpcping (grpc client),
-or curl (single URL debug), or nc (single tcp or udp:// connection).
+ redirect, proxies, tcp-echo and grpc ping servers), tcp-echo (only the tcp-echo
+ server), report (report only UI server), redirect (only the redirect server),
+ proxies (only the -M and -P configured proxies), grpcping (grpc client),
+ or curl (single URL debug), or nc (single tcp or udp:// connection),
+ or version (prints the version).
 where target is a url (http load tests) or host:port (grpc health test).
 flags are:
   -H header
@@ -240,6 +241,9 @@ smaller than -maxpayloadsizekb. Setting this switches http to POST.
         grpc load test: use ping instead of health
   -profile file
         write .cpu and .mem profiles to file
+  -proxy-all-headers
+        Determines if only tracing or all headers (and cookies) are copied from
+request on the fetch2 ui/server endpoint (default true)
   -qps float
         Queries Per Seconds or 0 for no wait/max qps (default 8)
   -quiet

--- a/fhttp/http_server.go
+++ b/fhttp/http_server.go
@@ -46,7 +46,7 @@ var (
 	startTime time.Time
 	// EchoRequests is the number of request received. Only updated in Debug mode.
 	EchoRequests int64
-	// TODO find a way to only include this on binaries and not library mode. (#433)
+	// TODO find a way to only include this on binaries and not library mode (#433).
 	defaultEchoServerParams = dflag.DynString(flag.CommandLine, "echo-server-default-params", "",
 		"Default parameters/querystring to use if there isn't one provided explicitly. E.g \"status=404&delay=3s\"")
 	fetch2CopiesAllHeader = dflag.DynBool(flag.CommandLine, "proxy-all-headers", true,

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -71,14 +71,15 @@ func (f *httpMultiFlagList) Set(value string) error {
 
 // Usage to a writer.
 func usage(w io.Writer, msgs ...interface{}) {
-	_, _ = fmt.Fprintf(w, "Φορτίο %s usage:\n\t%s command [flags] target\n%s\n%s\n%s\n%s\n%s\n%s\n",
+	_, _ = fmt.Fprintf(w, "Φορτίο %s usage:\n\t%s command [flags] target\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n",
 		version.Short(),
 		os.Args[0],
 		"where command is one of: load (load testing), server (starts ui, http-echo,",
-		"redirect, proxies, tcp-echo and grpc ping servers), tcp-echo (only the tcp-echo",
-		"server), report (report only UI server), redirect (only the redirect server),",
-		"proxies (only the -M and -P configured proxies), grpcping (grpc client),",
-		"or curl (single URL debug), or nc (single tcp or udp:// connection).",
+		" redirect, proxies, tcp-echo and grpc ping servers), tcp-echo (only the tcp-echo",
+		" server), report (report only UI server), redirect (only the redirect server),",
+		" proxies (only the -M and -P configured proxies), grpcping (grpc client),",
+		" or curl (single URL debug), or nc (single tcp or udp:// connection),",
+		" or version (prints the version).",
 		"where target is a url (http load tests) or host:port (grpc health test).")
 	bincommon.FlagsUsage(w, msgs...)
 }


### PR DESCRIPTION
…ers (and thus cookies) when used, allows to test cookie based sticky routing