### PR TITLE
Add message in result to indicate if uniform pattern is being used

### DIFF
--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -176,6 +176,7 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 	totalCount := float64(total.DurationHistogram.Count)
 	_, _ = fmt.Fprintf(out, "Sockets used: %d (for perfect keepalive, would be %d)\n", total.SocketCount, r.Options().NumThreads)
 	_, _ = fmt.Fprintf(out, "Jitter: %t\n", total.Jitter)
+	_, _ = fmt.Fprintf(out, "Uniform: %t\n", total.Uniform)
 	for _, k := range keys {
 		_, _ = fmt.Fprintf(out, "Code %3d : %d (%.1f %%)\n", k, total.RetCodes[k], 100.*float64(total.RetCodes[k])/totalCount)
 	}


### PR DESCRIPTION
Show if the uniform traffic pattern is used in result. Example:
```
Sockets used: 4 (for perfect keepalive, would be 4)
Jitter: false
Uniform: false
```