### PR TITLE
Fix the empty body content error

### DIFF
--- a/fhttp/http_client.go
+++ b/fhttp/http_client.go
@@ -371,7 +371,10 @@ func (c *Client) Fetch() (int, []byte, int) {
 		bodyBytes := []byte(body)
 		c.req.ContentLength = int64(len(bodyBytes))
 		c.req.Body = ioutil.NopCloser(bytes.NewReader(bodyBytes))
+	} else if c.body != "" {
+		c.req.Body = ioutil.NopCloser(bytes.NewReader([]byte(c.body)))
 	}
+
 	resp, err := c.client.Do(c.req)
 	if err != nil {
 		log.Errf("[%d] Unable to send %s request for %s : %v", c.id, c.req.Method, c.url, err)

--- a/fhttp/http_test.go
+++ b/fhttp/http_test.go
@@ -528,7 +528,7 @@ func TestPayloadWithEchoBack(t *testing.T) {
 	}
 }
 
-// Test Post request with std client and the socket close after answering
+// Test Post request with std client and the socket close after answering.
 func TestPayloadWithStdClientAndClosedSocket(t *testing.T) {
 	m, a := DynamicHTTPServer(false)
 	m.HandleFunc("/", EchoHandler)

--- a/fhttp/http_test.go
+++ b/fhttp/http_test.go
@@ -528,6 +528,31 @@ func TestPayloadWithEchoBack(t *testing.T) {
 	}
 }
 
+// Test Post request with std client and the socket close after answering
+func TestPayloadWithStdClientAndClosedSocket(t *testing.T) {
+	m, a := DynamicHTTPServer(false)
+	m.HandleFunc("/", EchoHandler)
+
+	url := fmt.Sprintf("http://localhost:%d/?close=true", a.Port)
+	payload := []byte("{\"test\" : \"test\"}")
+	opts := NewHTTPOptions(url)
+	opts.DisableFastClient = true
+	opts.Payload = payload
+	cli, _ := NewClient(opts)
+
+	for i := 0; i < 3; i++ {
+		code, body, header := cli.Fetch()
+
+		if code != 200 {
+			t.Errorf("Unexpected http status code, expected 200, got %d", code)
+		}
+
+		if !bytes.Equal(body[header:], payload) {
+			t.Errorf("Got %s, expected %q from echo", DebugSummary(body, 512), payload)
+		}
+	}
+}
+
 // Many of the earlier http tests are through httprunner but new tests should go here
 
 func TestUnixDomainHttp(t *testing.T) {

--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -176,6 +176,7 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 	totalCount := float64(total.DurationHistogram.Count)
 	_, _ = fmt.Fprintf(out, "Sockets used: %d (for perfect keepalive, would be %d)\n", total.SocketCount, r.Options().NumThreads)
 	_, _ = fmt.Fprintf(out, "Jitter: %t\n", total.Jitter)
+	_, _ = fmt.Fprintf(out, "Uniform: %t\n", total.Uniform)
 	for _, k := range keys {
 		_, _ = fmt.Fprintf(out, "Code %3d : %d (%.1f %%)\n", k, total.RetCodes[k], 100.*float64(total.RetCodes[k])/totalCount)
 	}


### PR DESCRIPTION
**Problem**
When we send multiple POST requests, we notice the error 
```
11:19:01 E http_client.go:379> [0] Unable to send POST request for `link` : Post `link`: http: ContentLength=259 with Body length 0
```
**Root Cause**
When the first request is sent, the request body is read to the end of file. So the following request body's starting index is already at end of file, which cause the body length to be 0.

**Solution**
Reset the request body's starting index before sending the request. No need to recreate the request everytime. Inspired by this [post](https://stackoverflow.com/a/47348886)

Fixes #520