### PR TITLE
`-server-idle-timeout` and close=x as a % instead of just true/false for all echo requests, `-calc-qps` client side

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ url from the first request is used)
   -cacert Path
         Path to a custom CA certificate file to be used for the TLS client
 connections, if empty, use https:// prefix for standard internet/system CAs
+  -calc-qps
+        Calculate the qps based on number of requests (-n) and duration (-t)
   -cert Path
         Path to the certificate file to be used for client or server TLS
   -compression

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Most important flags for http load generation:
 | `-c connections` | Number of parallel simultaneous connections (and matching go routine) |
 | `-t duration` | How long to run the test  (for instance `-t 30m` for 30 minutes) or 0 to run until ^C, example (default 5s) |
 | `-n numcalls` | Run for exactly this number of calls instead of duration. Default (0) is to use duration (-t). |
+| `-payload str` or `-payload-file fname` | Switch to using POST with the given payload (see also `-payload-size` for random payload)|
+| `-uniform` | Spread the calls across threads |
 | `-r resolution` | Resolution of the histogram lowest buckets in seconds (default 0.001 i.e 1ms), use 1/10th of your expected typical latency |
 | `-H "header: value"` | Can be specified multiple times to add headers (including Host:) |
 | `-a`     |  Automatically save JSON result with filename based on labels and timestamp |
@@ -269,6 +271,8 @@ server mode
   -sequential-warmup
         http(s) runner warmup done in parallel instead of sequentially. When
 set, restores pre 1.21 behavior
+  -server-idle-timeout value
+        Default IdleTimeout for servers (default 30s)
   -static-dir path
         Deprecated/unused path.
   -stdclient
@@ -319,7 +323,7 @@ Fortio `server` has the following feature for the http listening on 8080 (all pa
 | delay     | duration to delay the response by. Can be a single value or a comma separated list of probabilities, e.g `delay=150us:10,2ms:5,0.5s:1` for 10% of chance of a 150 us delay, 5% of a 2ms delay and 1% of a 1/2 second delay |
 | status    | http status to return instead of 200. Can be a single value or a comma separated list of probabilities, e.g `status=404:10,503:5,429:1` for 10% of chance of a 404 status, 5% of a 503 status and 1% of a 429 status |
 | size      | size of the payload to reply instead of echoing input. Also works as probabilities list. `size=1024:10,512:5` 10% of response will be 1k and 5% will be 512 bytes payload and the rest defaults to echoing back. |
-| close     | close the socket after answering e.g `close=true` |
+| close     | close the socket after answering e.g `close=true` to close after all requests or `close=5.3` to close after approximately 5.3% of requests|
 | header    | header(s) to add to the reply e.g. `&header=Foo:Bar&header=X:Y` |
 
 You can set a default value for all these by passing `-echo-server-default-params` to the server command line, for instance:

--- a/fhttp/http_server.go
+++ b/fhttp/http_server.go
@@ -98,8 +98,7 @@ func EchoHandler(w http.ResponseWriter, r *http.Request) {
 		rqNum := atomic.AddInt64(&EchoRequests, 1)
 		log.Debugf("Request # %v", rqNum)
 	}
-	doClose := generateClose(r.FormValue("close"))
-	if doClose {
+	if generateClose(r.FormValue("close")) {
 		log.Debugf("Adding Connection:close / will close socket")
 		w.Header().Set("Connection", "close")
 	}

--- a/fhttp/http_server.go
+++ b/fhttp/http_server.go
@@ -51,6 +51,7 @@ var (
 		"Default parameters/querystring to use if there isn't one provided explicitly. E.g \"status=404&delay=3s\"")
 	fetch2CopiesAllHeader = dflag.DynBool(flag.CommandLine, "proxy-all-headers", true,
 		"Determines if only tracing or all headers (and cookies) are copied from request on the fetch2 ui/server endpoint")
+	serverIdleTimeout = dflag.DynDuration(flag.CommandLine, "server-idle-timeout", 30*time.Second, "Default IdleTimeout for servers")
 )
 
 // EchoHandler is an http server handler echoing back the input.
@@ -97,7 +98,8 @@ func EchoHandler(w http.ResponseWriter, r *http.Request) {
 		rqNum := atomic.AddInt64(&EchoRequests, 1)
 		log.Debugf("Request # %v", rqNum)
 	}
-	if r.FormValue("close") != "" {
+	doClose := generateClose(r.FormValue("close"))
+	if doClose {
 		log.Debugf("Adding Connection:close / will close socket")
 		w.Header().Set("Connection", "close")
 	}
@@ -167,7 +169,8 @@ func HTTPServer(name string, port string) (*http.ServeMux, net.Addr) {
 	m := http.NewServeMux()
 	h2s := &http2.Server{}
 	s := &http.Server{
-		Handler: h2c.NewHandler(m, h2s),
+		IdleTimeout: serverIdleTimeout.Get(),
+		Handler:     h2c.NewHandler(m, h2s),
 	}
 	listener, addr := fnet.Listen(name, port)
 	if listener == nil {

--- a/fhttp/http_test.go
+++ b/fhttp/http_test.go
@@ -497,6 +497,27 @@ func TestGenerateSize(t *testing.T) {
 	}
 }
 
+func TestGenerateClose(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		// not numbers
+		{"true", true},
+		{"false", false},
+		{"x", true},
+		// Numbers
+		{"0", false},
+		{"0.0", false},
+		{"99.9999999", true}, // well, in theory this should fail once in a blue moon
+		{"100", true},
+	}
+	for _, tst := range tests {
+		if actual := generateClose(tst.input); actual != tst.expected {
+			t.Errorf("Got %v, expected %v for generateClose(%q)", actual, tst.expected, tst.input)
+		}
+	}
+}
 func TestPayloadWithEchoBack(t *testing.T) {
 	tests := []struct {
 		payload           []byte

--- a/fhttp/http_test.go
+++ b/fhttp/http_test.go
@@ -518,6 +518,7 @@ func TestGenerateClose(t *testing.T) {
 		}
 	}
 }
+
 func TestPayloadWithEchoBack(t *testing.T) {
 	tests := []struct {
 		payload           []byte

--- a/fhttp/http_utils.go
+++ b/fhttp/http_utils.go
@@ -398,6 +398,28 @@ func generateDelay(delay string) time.Duration {
 	return 0
 }
 
+// generateClose from string, format: close=true for 100% close
+// close=true:10 or close=10 for 10% socket close
+func generateClose(closeStr string) bool {
+	if closeStr == "" || closeStr == "false" {
+		return false
+	}
+	if closeStr == "true" { // avoid throwing error for pre 1.22 syntax
+		return true
+	}
+	p, err := strconv.ParseFloat(closeStr, 32)
+	if err != nil {
+		log.Debugf("error %v parsing close=%q treating as true", err, closeStr)
+		return true
+	}
+	res := 100. * rand.Float32() // nolint: gosec // we want fast not crypto
+	log.Debugf("close=%f rolled %f", p, res)
+	if res <= float32(p) {
+		return true
+	}
+	return false
+}
+
 // RoundDuration rounds to 10th of second.
 func RoundDuration(d time.Duration) time.Duration {
 	return d.Round(100 * time.Millisecond)

--- a/fhttp/http_utils.go
+++ b/fhttp/http_utils.go
@@ -399,7 +399,7 @@ func generateDelay(delay string) time.Duration {
 }
 
 // generateClose from string, format: close=true for 100% close
-// close=true:10 or close=10 for 10% socket close
+// close=true:10 or close=10 for 10% socket close.
 func generateClose(closeStr string) bool {
 	if closeStr == "" || closeStr == "false" {
 		return false

--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -77,7 +77,7 @@ type HTTPRunnerOptions struct {
 }
 
 // RunHTTPTest runs an http test and returns the aggregated stats.
-// nolint: funlen, gocognit
+// nolint: funlen, gocognit, gocyclo
 func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 	o.RunType = "HTTP"
 	warmupMode := "parallel"

--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -192,9 +192,10 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 	r.Options().ReleaseRunners()
 	sort.Ints(keys)
 	totalCount := float64(total.DurationHistogram.Count)
-	_, _ = fmt.Fprintf(out, "Sockets used: %d (for perfect keepalive, would be %d)\n", total.SocketCount, r.Options().NumThreads)
-	_, _ = fmt.Fprintf(out, "Jitter: %t\n", total.Jitter)
-	_, _ = fmt.Fprintf(out, "Uniform: %t\n", total.Uniform)
+	if !o.DisableFastClient {
+		_, _ = fmt.Fprintf(out, "Sockets used: %d (for perfect keepalive, would be %d)\n", total.SocketCount, r.Options().NumThreads)
+	}
+	_, _ = fmt.Fprintf(out, "Uniform: %t, Jitter: %t\n", total.Uniform, total.Jitter)
 	for _, k := range keys {
 		_, _ = fmt.Fprintf(out, "Code %3d : %d (%.1f %%)\n", k, total.RetCodes[k], 100.*float64(total.RetCodes[k])/totalCount)
 	}

--- a/fhttp/httprunner_test.go
+++ b/fhttp/httprunner_test.go
@@ -187,7 +187,7 @@ func TestHTTPRunnerClientRace(t *testing.T) {
 func TestClosingAndSocketCount(t *testing.T) {
 	mux, addr := DynamicHTTPServer(false)
 	mux.HandleFunc("/echo42/", EchoHandler)
-	URL := fmt.Sprintf("http://localhost:%d/echo42/?close=1", addr.Port)
+	URL := fmt.Sprintf("http://localhost:%d/echo42/?close=true", addr.Port)
 	opts := HTTPRunnerOptions{}
 	opts.Init(URL)
 	opts.QPS = 10


### PR DESCRIPTION
2 new server features: 

- ability to set  `-server-idle-timeout`
- for the echo server the `close=` param now can take a % to roll whether to close

1 new client/load feature:
- calculate the target qps to get the `-n` requests in `-t` time using `-calc-qps` (convenience function to for instance spread calls across idle timeouts...)

1 cosmetic improvement in end of run output (#517):
```
Sockets used: 0 (for perfect keepalive, would be 1)
Jitter: false
Uniform: true
```
Replaced by
```
Uniform: true, Jitter: true
```
for uniform client (skips the 0 socket output)