### PR TITLE
Echo prefix after /debug/

### DIFF
--- a/fhttp/http_server.go
+++ b/fhttp/http_server.go
@@ -349,6 +349,7 @@ func Serve(port, debugPath string) (*http.ServeMux, net.Addr) {
 	}
 	if debugPath != "" {
 		mux.HandleFunc(debugPath, DebugHandler)
+		mux.HandleFunc(strings.TrimSuffix(debugPath, "/")+"/echo/", EchoHandler) // Fix #524
 	}
 	mux.HandleFunc("/", EchoHandler)
 	return mux, addr

--- a/fhttp/httprunner_test.go
+++ b/fhttp/httprunner_test.go
@@ -234,10 +234,10 @@ func TestServe(t *testing.T) {
 	_, addr := ServeTCP("0", "/debugx1")
 	port := addr.Port
 	log.Infof("On addr %s found port: %d", addr, port)
-	url := fmt.Sprintf("http://localhost:%d/debugx1?env=dump", port)
 	if port == 0 {
 		t.Errorf("outport: %d must be different", port)
 	}
+	url := fmt.Sprintf("http://localhost:%d/debugx1?env=dump", port)
 	time.Sleep(100 * time.Millisecond)
 	o := NewHTTPOptions(url)
 	o.AddAndValidateExtraHeader("X-Header: value1")
@@ -252,6 +252,17 @@ func TestServe(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "X-Header: value1,value2") {
 		t.Errorf("Multi header not found in %s", DebugSummary(data, 1024))
+	}
+	url2 := fmt.Sprintf("http://localhost:%d/debugx1/echo/foo", port)
+	o2 := NewHTTPOptions(url2)
+	o2.Payload = []byte("abcd")
+	c2, _ := NewClient(o2)
+	code2, data2, header := c2.Fetch()
+	if code2 != http.StatusOK {
+		t.Errorf("Unexpected non 200 ret code for debug url %s : %d", url, code)
+	}
+	if string(data2[header:]) != "abcd" {
+		t.Errorf("Unexpected that %s isn't an echo server, got %q", url2, string(data2))
 	}
 }
 

--- a/ui/templates/browse.html
+++ b/ui/templates/browse.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html><head><title>Φορτίο v{{.Version}}</title>
 <script src="{{.ChartJSPath}}"></script>
-<link rel="icon" href="../favicon.ico" />
+<link rel="icon" href="{{.Version}}/static/img/favicon.ico"/>
 <style>
 a:link {
   text-decoration: none;

--- a/ui/templates/main.html
+++ b/ui/templates/main.html
@@ -94,8 +94,11 @@
   </div>
 </form>
 <p><i>Or</i></p>
-<a href="{{.DebugPath}}">debug</a> and <a href="{{.DebugPath}}?env=dump">debug with env dump</a> and <a href="{{.DebugPath}}/pprof/">Internal PPROF</a>
+<a href="{{.DebugPath}}">debug</a> and <a href="{{.DebugPath}}?env=dump">debug with env dump</a>
+and <a href="{{.DebugPath}}/pprof/">Internal PPROF</a>
 and <a href="flags">Command line flags</a>
+and <a href="{{.DebugPath}}/echo/">Additional echo handler under {{.DebugPath}}/echo/</a> (supports all the
+query arguments mentioned on the <a href="https://github.com/fortio/fortio#server-urls-and-features">Echo url features</a> github doc)
 <p><i>Or</i></p>
 <form action="sync">
   <div>

--- a/ui/templates/main.html
+++ b/ui/templates/main.html
@@ -3,7 +3,7 @@
 <head><title>Φορτίο v{{.Version}}</title>
   <script src="{{.ChartJSPath}}"></script>
   <script src="{{.Version}}/static/js/fortio_chart.js"></script>
-  <link rel="icon" href="../favicon.ico"/>
+  <link rel="icon" href="{{.Version}}/static/img/favicon.ico"/>
   <link rel="stylesheet" href="{{.Version}}/static/css/fortio.css">
 </head>
 {{template "header" .}}

--- a/ui/templates/sync.html
+++ b/ui/templates/sync.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html><head><title>Φορτίο v{{.Version}}</title>
 <script src="{{.Version}}/static/js/fortio_chart.js"></script>
-<link rel="icon" href="../favicon.ico" />
+<link rel="icon" href="{{.Version}}/static/img/favicon.ico" />
 <link rel="stylesheet" href="{{.Version}}/static/css/fortio.css">
 <style>
 .checkmark {


### PR DESCRIPTION
Fixes #524 by adding an addition /echo/ after the debug path (so default is `/debug/echo/...`)

Allows to re - root the UI and debug and this echo all under same /fortio/ prefix for instance using `-echo-debug-path /fortio/debug/` and thus have `/fortio/debug/foo` be the debug output and `/fortio/debug/echo/bar?delay=200ms` be an echo with functionality from query args