### PR TITLE
Fast client support for https/TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ set, restores pre 1.21 behavior
   -static-dir path
         Deprecated/unused path.
   -stdclient
-        Use the slower net/http standard client (works for TLS)
+        Use the slower net/http standard client (slower but supports h2)
   -sync URL
         index.tsv or s3/gcs bucket xml URL to fetch at startup for server modes.
   -sync-interval duration

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ docker run fortio/fortio load http://www.google.com/ # For a test run
 Or download one of the binary distributions, from the [releases](https://github.com/fortio/fortio/releases) assets page or for instance:
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.22.0/fortio-linux_x64-1.22.0.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.23.0/fortio-linux_x64-1.23.0.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.22.0/fortio_1.22.0_amd64.deb
-dpkg -i fortio_1.22.0_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.23.0/fortio_1.23.0_amd64.deb
+dpkg -i fortio_1.23.0_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.22.0/fortio-1.22.0-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.23.0/fortio-1.23.0-1.x86_64.rpm
 ```
 
 On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
@@ -61,7 +61,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.22.0/fortio_win_1.22.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.23.0/fortio_win_1.23.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -106,7 +106,7 @@ Full list of command line flags (`fortio help`):
 <details>
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
-Φορτίο 1.22.0 usage:
+Φορτίο 1.23.0 usage:
 where command is one of: load (load testing), server (starts ui, http-echo,
  redirect, proxies, tcp-echo and grpc ping servers), tcp-echo (only the tcp-echo
  server), report (report only UI server), redirect (only the redirect server),
@@ -675,7 +675,7 @@ and you get in result.json
   "ActualQPS": 38.44836361217263,
   "ActualDuration": 104035637,
   "NumThreads": 2,
-  "Version": "v1.22.0",
+  "Version": "X.Y.Z",
   "DurationHistogram": {
     "Count": 4,
     "Min": 0.00027292,

--- a/bincommon/commonflags.go
+++ b/bincommon/commonflags.go
@@ -62,7 +62,7 @@ var (
 	halfCloseFlag   = flag.Bool("halfclose", false,
 		"When not keepalive, whether to half close the connection (only for fast http)")
 	httpReqTimeoutFlag  = flag.Duration("timeout", fhttp.HTTPReqTimeOutDefaultValue, "Connection and read timeout value (for http)")
-	stdClientFlag       = flag.Bool("stdclient", false, "Use the slower net/http standard client (works for TLS)")
+	stdClientFlag       = flag.Bool("stdclient", false, "Use the slower net/http standard client (slower but supports h2)")
 	http10Flag          = flag.Bool("http1.0", false, "Use http1.0 (instead of http 1.1)")
 	httpsInsecureFlag   = flag.Bool("k", false, "Do not verify certs in https connections")
 	httpsInsecureFlagL  = flag.Bool("https-insecure", false, "Long form of the -k flag")

--- a/fhttp/http_client.go
+++ b/fhttp/http_client.go
@@ -637,7 +637,9 @@ func NewFastClient(o *HTTPOptions) (Fetcher, error) {
 	if customHostHeader {
 		host = o.hostOverride
 	}
-	tlsConfig.ServerName = host
+	if tlsConfig != nil {
+		tlsConfig.ServerName = host
+	}
 	var buf bytes.Buffer
 	buf.WriteString(method + " " + url.RequestURI() + " HTTP/" + proto + "\r\n")
 	if !bc.http10 || customHostHeader {

--- a/fhttp/http_client.go
+++ b/fhttp/http_client.go
@@ -470,7 +470,7 @@ func NewStdClient(o *HTTPOptions) (*Client, error) {
 	return &client, nil
 }
 
-// TLSClientConfig() creates a tls.Config based on input HTTPOptions.
+// TLSClientConfig creates a tls.Config based on input HTTPOptions.
 // ServerName is set later (once host is determined after URL parsing
 // and depending on hostOverride).
 func (h *HTTPOptions) TLSClientConfig() (*tls.Config, error) {

--- a/fhttp/http_client.go
+++ b/fhttp/http_client.go
@@ -470,33 +470,36 @@ func NewStdClient(o *HTTPOptions) (*Client, error) {
 	return &client, nil
 }
 
-func (o *HTTPOptions) TLSClientConfig() (*tls.Config, error) {
-	if !o.https {
+// TLSClientConfig() creates a tls.Config based on input HTTPOptions.
+// ServerName is set later (once host is determined after URL parsing
+// and depending on hostOverride).
+func (h *HTTPOptions) TLSClientConfig() (*tls.Config, error) {
+	if !h.https {
 		return nil, nil
 	}
 	var res *tls.Config
 
 	res = &tls.Config{MinVersion: tls.VersionTLS12}
-	if o.Insecure {
+	if h.Insecure {
 		log.LogVf("Using insecure https")
 		res.InsecureSkipVerify = true
 	}
-	if len(o.Cert) > 0 && len(o.Key) > 0 {
-		cert, err := tls.LoadX509KeyPair(o.Cert, o.Key)
+	if len(h.Cert) > 0 && len(h.Key) > 0 {
+		cert, err := tls.LoadX509KeyPair(h.Cert, h.Key)
 		if err != nil {
-			log.Errf("LoadX509KeyPair error for cert %v / key %v: %v", o.Cert, o.Key, err)
+			log.Errf("LoadX509KeyPair error for cert %v / key %v: %v", h.Cert, h.Key, err)
 			return nil, err
 		}
 		res.Certificates = []tls.Certificate{cert}
 	}
-	if len(o.CACert) > 0 {
+	if len(h.CACert) > 0 {
 		// Load CA cert
-		caCert, err := ioutil.ReadFile(o.CACert)
+		caCert, err := ioutil.ReadFile(h.CACert)
 		if err != nil {
-			log.Errf("Unable to read CA from %v: %v", o.CACert, err)
+			log.Errf("Unable to read CA from %v: %v", h.CACert, err)
 			return nil, err
 		}
-		log.LogVf("Using custom CA from %v", o.CACert)
+		log.LogVf("Using custom CA from %v", h.CACert)
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(caCert)
 		res.RootCAs = caCertPool

--- a/fhttp/http_client.go
+++ b/fhttp/http_client.go
@@ -142,10 +142,6 @@ func (h *HTTPOptions) URLSchemeCheck() {
 	}
 	if strings.HasPrefix(lcURL, hs) {
 		h.https = true
-		if !h.DisableFastClient {
-			log.Warnf("https requested, switching to standard go client")
-			h.DisableFastClient = true
-		}
 		return // url is good
 	}
 	if !strings.HasPrefix(lcURL, "http://") {
@@ -443,32 +439,9 @@ func NewStdClient(o *HTTPOptions) (*Client, error) {
 		},
 		TLSHandshakeTimeout: o.HTTPReqTimeOut,
 	}
-	if o.https { // nolint: nestif // fine for now
-		tr.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
-		if o.Insecure {
-			log.LogVf("Using insecure https")
-			tr.TLSClientConfig.InsecureSkipVerify = true
-		}
-		if len(o.Cert) > 0 && len(o.Key) > 0 {
-			cert, err := tls.LoadX509KeyPair(o.Cert, o.Key)
-			if err != nil {
-				log.Errf("LoadX509KeyPair error for cert %v / key %v: %v", o.Cert, o.Key, err)
-				return nil, err
-			}
-			tr.TLSClientConfig.Certificates = []tls.Certificate{cert}
-		}
-		if len(o.CACert) > 0 {
-			// Load CA cert
-			caCert, err := ioutil.ReadFile(o.CACert)
-			if err != nil {
-				log.Errf("Unable to read CA from %v: %v", o.CACert, err)
-				return nil, err
-			}
-			log.LogVf("Using custom CA from %v", o.CACert)
-			caCertPool := x509.NewCertPool()
-			caCertPool.AppendCertsFromPEM(caCert)
-			tr.TLSClientConfig.RootCAs = caCertPool
-		}
+	tr.TLSClientConfig, err = o.TLSClientConfig()
+	if err != nil {
+		return nil, err
 	}
 
 	client := Client{
@@ -495,6 +468,40 @@ func NewStdClient(o *HTTPOptions) (*Client, error) {
 		}
 	}
 	return &client, nil
+}
+
+func (o *HTTPOptions) TLSClientConfig() (*tls.Config, error) {
+	if !o.https {
+		return nil, nil
+	}
+	var res *tls.Config
+
+	res = &tls.Config{MinVersion: tls.VersionTLS12}
+	if o.Insecure {
+		log.LogVf("Using insecure https")
+		res.InsecureSkipVerify = true
+	}
+	if len(o.Cert) > 0 && len(o.Key) > 0 {
+		cert, err := tls.LoadX509KeyPair(o.Cert, o.Key)
+		if err != nil {
+			log.Errf("LoadX509KeyPair error for cert %v / key %v: %v", o.Cert, o.Key, err)
+			return nil, err
+		}
+		res.Certificates = []tls.Certificate{cert}
+	}
+	if len(o.CACert) > 0 {
+		// Load CA cert
+		caCert, err := ioutil.ReadFile(o.CACert)
+		if err != nil {
+			log.Errf("Unable to read CA from %v: %v", o.CACert, err)
+			return nil, err
+		}
+		log.LogVf("Using custom CA from %v", o.CACert)
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+		res.RootCAs = caCertPool
+	}
+	return res, nil
 }
 
 // FetchURL fetches the data at the given url using the standard client and default options.
@@ -540,6 +547,8 @@ type FastClient struct {
 	uuidMarkers  [][]byte
 	logErrors    bool
 	id           int
+	https        bool
+	tlsConfig    *tls.Config
 }
 
 // Close cleans up any resources used by FastClient.
@@ -587,14 +596,15 @@ func NewFastClient(o *HTTPOptions) (Fetcher, error) {
 		log.Errf("Bad url '%s' : %v", urlString, err)
 		return nil, err
 	}
-	if url.Scheme != "http" {
-		log.Errf("Only http is supported with the optimized client, use -stdclient for url %s", o.URL)
-		return nil, fmt.Errorf("only http for fast client")
+	tlsConfig, err := o.TLSClientConfig()
+	if err != nil {
+		return nil, err
 	}
 	// note: Host includes the port
 	bc := FastClient{
 		url: o.URL, host: url.Host, hostname: url.Hostname(), port: url.Port(),
 		http10: o.HTTP10, halfClose: o.AllowHalfClose, logErrors: o.LogErrors, id: o.ID,
+		https: o.https, tlsConfig: tlsConfig,
 	}
 	bc.buffer = make([]byte, BufferSizeKb*1024)
 	if bc.port == "" {
@@ -627,6 +637,7 @@ func NewFastClient(o *HTTPOptions) (Fetcher, error) {
 	if customHostHeader {
 		host = o.hostOverride
 	}
+	tlsConfig.ServerName = host
 	var buf bytes.Buffer
 	buf.WriteString(method + " " + url.RequestURI() + " HTTP/" + proto + "\r\n")
 	if !bc.http10 || customHostHeader {
@@ -670,10 +681,20 @@ func (c *FastClient) returnRes() (int, []byte, int) {
 // connect to destination.
 func (c *FastClient) connect() net.Conn {
 	c.socketCount++
-	socket, err := net.Dial(c.dest.Network(), c.dest.String())
-	if err != nil {
-		log.Errf("Unable to connect to %v : %v", c.dest, err)
-		return nil
+	var socket net.Conn
+	var err error
+	if c.https {
+		socket, err = tls.Dial(c.dest.Network(), c.dest.String(), c.tlsConfig)
+		if err != nil {
+			log.Errf("Unable to TLS connect to %v : %v", c.dest, err)
+			return nil
+		}
+	} else {
+		socket, err = net.Dial(c.dest.Network(), c.dest.String())
+		if err != nil {
+			log.Errf("Unable to connect to %v : %v", c.dest, err)
+			return nil
+		}
 	}
 	fnet.SetSocketBuffers(socket, len(c.buffer), len(c.req))
 	return socket

--- a/fhttp/http_test.go
+++ b/fhttp/http_test.go
@@ -114,26 +114,22 @@ func TestSchemeCheck(t *testing.T) {
 	tests := []struct {
 		input  string
 		output string
-		stdcli bool
 	}{
-		{"https://www.google.com/", "https://www.google.com/", true},
-		{"www.google.com", "http://www.google.com", false},
-		{"hTTps://foo.bar:123/ab/cd", "hTTps://foo.bar:123/ab/cd", true}, // not double http:
-		{"HTTP://foo.bar:124/ab/cd", "HTTP://foo.bar:124/ab/cd", false},  // not double http:
-		{"", "", false},                      // and error in the logs
-		{"x", "http://x", false},             // should not crash because url is shorter than prefix
-		{"http:/", "http://http:/", false},   // boundary
-		{"http://", "http://", false},        // boundary
-		{"https://", "https://", true},       // boundary
-		{"https:/", "http://https:/", false}, // boundary
+		{"https://www.google.com/", "https://www.google.com/"},
+		{"www.google.com", "http://www.google.com"},
+		{"hTTps://foo.bar:123/ab/cd", "hTTps://foo.bar:123/ab/cd"}, // not double http:
+		{"HTTP://foo.bar:124/ab/cd", "HTTP://foo.bar:124/ab/cd"},   // not double http:
+		{"", ""},                      // and error in the logs
+		{"x", "http://x"},             // should not crash because url is shorter than prefix
+		{"http:/", "http://http:/"},   // boundary
+		{"http://", "http://"},        // boundary
+		{"https://", "https://"},      // boundary
+		{"https:/", "http://https:/"}, // boundary
 	}
 	for _, tst := range tests {
 		o := NewHTTPOptions(tst.input)
 		if o.URL != tst.output {
 			t.Errorf("Got %v, expecting %v for url '%s'", o.URL, tst.output, tst.input)
-		}
-		if o.DisableFastClient != tst.stdcli {
-			t.Errorf("Got %v, expecting %v for stdclient for url '%s'", o.DisableFastClient, tst.stdcli, tst.input)
 		}
 	}
 }

--- a/fhttp/http_test.go
+++ b/fhttp/http_test.go
@@ -692,12 +692,7 @@ func TestDefaultPort(t *testing.T) {
 	cli.Close()
 	opts.URL = "https://fortio.org" // will be https port 443
 	opts.Insecure = true            // not needed as we have valid certs but to exercise that code
-	cli, err := NewFastClient(opts)
-	if cli != nil || err == nil {
-		// If https support was added, remove this whitebox/for coverage purpose assertion
-		t.Errorf("fast client isn't supposed to support https (yet), got %v", cli)
-	}
-	cli, err = NewClient(opts)
+	cli, err := NewClient(opts)
 	if cli == nil {
 		t.Fatalf("Couldn't get a client using NewClient on modified opts: %v", err)
 	}


### PR DESCRIPTION
Support TLS for fast client too; that way we get socket count and higher performance (http 1.x only though, for h2(c) you'd want to specify to use the `-stdclient`)

fixes #528