### PR TITLE
echo debug path normalization needed depending on whether debug path ends with / or not

### DIFF
--- a/fhttp/http_server.go
+++ b/fhttp/http_server.go
@@ -339,6 +339,11 @@ func CacheOn(w http.ResponseWriter) {
 	w.Header().Set("Cache-Control", "max-age=365000000, immutable")
 }
 
+// EchoDebugPath returns the additional echo handler path behind debugPath (ie /debug -> /debug/echo/).
+func EchoDebugPath(debugPath string) string {
+	return strings.TrimSuffix(debugPath, "/") + "/echo/"
+}
+
 // Serve starts a debug / echo http server on the given port.
 // Returns the mux and addr where the listening socket is bound.
 // The .Port can be retrieved from it when requesting the 0 port as
@@ -351,7 +356,7 @@ func Serve(port, debugPath string) (*http.ServeMux, net.Addr) {
 	}
 	if debugPath != "" {
 		mux.HandleFunc(debugPath, DebugHandler)
-		mux.HandleFunc(strings.TrimSuffix(debugPath, "/")+"/echo/", EchoHandler) // Fix #524
+		mux.HandleFunc(EchoDebugPath(debugPath), EchoHandler) // Fix #524
 	}
 	mux.HandleFunc("/", EchoHandler)
 	return mux, addr

--- a/ui/templates/main.html
+++ b/ui/templates/main.html
@@ -95,9 +95,9 @@
 </form>
 <p><i>Or</i></p>
 <a href="{{.DebugPath}}">debug</a> and <a href="{{.DebugPath}}?env=dump">debug with env dump</a>
-and <a href="{{.DebugPath}}/pprof/">Internal PPROF</a>
+and <a href="/debug/pprof/">Internal PPROF</a>
 and <a href="flags">Command line flags</a>
-and <a href="{{.DebugPath}}/echo/">Additional echo handler under {{.DebugPath}}/echo/</a> (supports all the
+and <a href="{{.EchoDebugPath}}">Additional echo handler under {{.EchoDebugPath}}</a> (supports all the
 query arguments mentioned on the <a href="https://github.com/fortio/fortio#server-urls-and-features">Echo url features</a> github doc)
 <p><i>Or</i></p>
 <form action="sync">

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -65,7 +65,8 @@ var (
 	uiPath      string // absolute (base)
 	logoPath    string // relative
 	chartJSPath string // relative
-	debugPath   string // mostly relative
+	debugPath   string // absolute
+	echoPath    string // absolute
 	fetchPath   string // this one is absolute
 	// Used to construct default URL to self.
 	urlHostPort string
@@ -239,6 +240,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			Version                     string
 			LogoPath                    string
 			DebugPath                   string
+			EchoDebugPath               string
 			ChartJSPath                 string
 			StartTime                   string
 			TargetURL                   string
@@ -250,7 +252,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			DoStop                      bool
 			DoLoad                      bool
 		}{
-			r, defaultHeaders, version.Short(), logoPath, debugPath, chartJSPath,
+			r, defaultHeaders, version.Short(), logoPath, debugPath, echoPath, chartJSPath,
 			startTime.Format(time.ANSIC), url, labels, runid,
 			fhttp.RoundDuration(time.Since(startTime)), durSeconds, urlHostPort, mode == stop, mode == run,
 		})
@@ -895,7 +897,8 @@ func Serve(baseurl, port, debugpath, uipath, datadir string, percentileList []fl
 		log.Warnf("Adding missing trailing / to UI path '%s'", uiPath)
 		uiPath += "/"
 	}
-	debugPath = ".." + debugpath // TODO: calculate actual path if not same number of directories
+	debugPath = debugpath
+	echoPath = fhttp.EchoDebugPath(debugpath)
 	mux.HandleFunc(uiPath, Handler)
 	fetchPath = uiPath + fetchURI
 	// For backward compatibility with http:// only fetcher


### PR DESCRIPTION
echo debug path normalization needed depending on whether debug path ends with / or not. 

also fix pprof link which is hardcoded to /debug/pprof/


Fixes #535