### PR TITLE
Multiarch enablement on Dockerfile and Dockerfile.build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,12 @@ jobs:
     <<: *defaultEnv
     steps:
       - setup_remote_docker:
-          version: 17.11.0-ce
+          version: 20.10.11
       - checkout
-      - run: make release-test
+      - run: |
+          docker context create release-tests
+          docker buildx create release-tests --use
+          make release-test BUILDX_PLATFORMS=linux/amd64
   linters:
     <<: *defaultEnv
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2
 defaultEnv: &defaultEnv
     docker:
       # specify the version
-      - image: docker.io/fortio/fortio.build:v38
+      - image: docker.io/fortio/fortio.build:v39
     working_directory: /go/src/fortio.org/fortio
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
     <<: *defaultEnv
     steps:
       - setup_remote_docker:
-          version: 20.10.11
+          version: 20.10.12
       - checkout
       - run: |
           docker context create release-tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,16 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+
       - name: Log in to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -39,6 +49,7 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           tags: fortio/fortio:${{ steps.build.outputs.VERSION }}, fortio/fortio:latest
 
@@ -52,54 +63,9 @@ jobs:
           release_name: Fortio ${{ steps.build.outputs.VERSION }}
           draft: true
 
-      - name: Upload release artifact 1
-        id: upload-release-asset1
-        uses: actions/upload-release-asset@v1
+      - name: Upload release artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: release/fortio_${{ steps.build.outputs.VERSION }}.orig.tar.gz
-          asset_name: fortio_${{ steps.build.outputs.VERSION }}.orig.tar.gz
-          asset_content_type: application/x-compressed-tar
-# Todo find a way to upload all in 1... it's silly to have to do 1 by 1
-      - name: Upload release artifact 2
-        id: upload-release-asset2
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: release/fortio-${{ steps.build.outputs.PACKAGE_VERSION }}-1.x86_64.rpm
-          asset_name: fortio-${{ steps.build.outputs.PACKAGE_VERSION }}-1.x86_64.rpm
-          asset_content_type: application/x-rpm
-      - name: Upload release artifact 3
-        id: upload-release-asset3
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: release/fortio-linux_x64-${{ steps.build.outputs.VERSION }}.tgz
-          asset_name: fortio-linux_x64-${{ steps.build.outputs.VERSION }}.tgz
-          asset_content_type: application/x-compressed-tar
-      - name: Upload release artifact 4
-        id: upload-release-asset4
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: release/fortio_${{ steps.build.outputs.VERSION }}_amd64.deb
-          asset_name: fortio_${{ steps.build.outputs.VERSION }}_amd64.deb
-          asset_content_type: application/vnd.debian.binary-package
-      - name: Upload release artifact 5
-        id: upload-release-asset5
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: release/fortio_win_${{ steps.build.outputs.VERSION }}.zip
-          asset_name: fortio_win_${{ steps.build.outputs.VERSION }}.zip
-          asset_content_type: application/zip
+        run: |
+          tag_name="${GITHUB_REF##*/}"
+          gh release upload "${tag_name}" release/*.{tgz,zip}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,4 +68,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag_name="${GITHUB_REF##*/}"
-          gh release upload "${tag_name}" release/*.{tgz,zip}
+          gh release upload "${tag_name}" release/*.{tgz,zip,rpm,deb,gz}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ COPY . fortio
 # but that also couples the 2, this expects to find binaries in the right place etc
 RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_BIN=../fortio_go_latest.bin
 # Check we still build with go 1.8 (and macos does not break)
-RUN make -C fortio official-build BUILD_DIR=/build OFFICIAL_BIN=../fortio_go_latest.mac GOOS=darwin GO_BIN=/usr/local/go/bin/go
+RUN if [ x"$(dpkg --print-architecture)" = x"amd64" ]; then make -C fortio official-build BUILD_DIR=/build OFFICIAL_BIN=../fortio_go_latest.mac GOOS=darwin GO_BIN=/usr/local/go/bin/go; fi
 # Windows release, for now assumes running from fortio directory (static resources in .)
-RUN make -C fortio official-build BUILD_DIR=/build LIB_DIR=. OFFICIAL_BIN=../fortio.exe GOOS=windows
+RUN if [ x"$(dpkg --print-architecture)" = x"amd64" ]; then make -C fortio official-build BUILD_DIR=/build LIB_DIR=. OFFICIAL_BIN=../fortio.exe GOOS=windows; fi
 # Minimal image with just the binary and certs
 FROM scratch as release
 # NOTE: the list of files here, if updated, must be changed in release/Dockerfile.in too

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,7 @@ COPY . fortio
 # We moved a lot of the logic into the Makefile so it can be reused in brew
 # but that also couples the 2, this expects to find binaries in the right place etc
 RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_BIN=../fortio_go_latest.bin
-# Check we still build with go 1.8 (and macos does not break)
-RUN if [ x"$(dpkg --print-architecture)" = x"amd64" ]; then make -C fortio official-build BUILD_DIR=/build OFFICIAL_BIN=../fortio_go_latest.mac GOOS=darwin GO_BIN=/usr/local/go/bin/go; fi
-# Windows release, for now assumes running from fortio directory (static resources in .)
-RUN if [ x"$(dpkg --print-architecture)" = x"amd64" ]; then make -C fortio official-build BUILD_DIR=/build LIB_DIR=. OFFICIAL_BIN=../fortio.exe GOOS=windows; fi
+
 # Minimal image with just the binary and certs
 FROM scratch as release
 # NOTE: the list of files here, if updated, must be changed in release/Dockerfile.in too

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v38 as build
+FROM docker.io/fortio/fortio.build:v39 as build
 WORKDIR /go/src/fortio.org
 COPY . fortio
 # We moved a lot of the logic into the Makefile so it can be reused in brew

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,26 +1,25 @@
 # Dependencies and linters for build:
-FROM ubuntu:focal
+FROM golang:1.17.8
 # Need gcc for -race test (and some linters though those work with CGO_ENABLED=0)
 RUN apt-get -y update && \
   apt-get --no-install-recommends -y upgrade && \
-  DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends -y install ca-certificates curl make git gcc \
-  libc6-dev apt-transport-https ssh ruby-dev build-essential rpm gnupg zip netcat
+  DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends -y install  libc6-dev apt-transport-https ssh \
+  ruby-dev build-essential rpm gnupg zip netcat
+
 # Install FPM
 RUN gem install --no-document fpm
-# From fortio 1.4 onward we dropped go 1.8 compatibility
-RUN curl -f https://dl.google.com/go/go1.17.8.linux-amd64.tar.gz | tar xfz - -C /usr/local
-ENV GOPATH /go
-RUN mkdir -p $GOPATH/bin
-ENV PATH /usr/local/go/bin:$PATH:$GOPATH/bin
 RUN go version # check it's indeed the version we expect
+
 # golangci-lint
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GOPATH/bin
+# See https://github.com/golangci/golangci-lint/issues/2374
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2
 RUN golangci-lint version
+
 # Docker:
-RUN curl -fsSL "https://download.docker.com/linux/ubuntu/gpg" | apt-key add
-RUN echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable" > /etc/apt/sources.list.d/docker.list
-RUN apt-get -y update
-RUN apt-get install --no-install-recommends -y docker-ce
+RUN curl -fsSL "https://download.docker.com/linux/debian/gpg" | apt-key add
+RUN echo "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/debian bullseye stable" > /etc/apt/sources.list.d/docker.list
+RUN apt-get -y update && apt-get install --no-install-recommends -y docker-ce
+
 WORKDIR /build
 VOLUME /build
 COPY .golangci.yml .

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,5 @@
 # Dependencies and linters for build:
-FROM golang:1.17.8
+FROM golang:1.17.9
 # Need gcc for -race test (and some linters though those work with CGO_ENABLED=0)
 RUN apt-get -y update && \
   apt-get --no-install-recommends -y upgrade && \
@@ -11,8 +11,9 @@ RUN gem install --no-document fpm
 RUN go version # check it's indeed the version we expect
 
 # golangci-lint
-# See https://github.com/golangci/golangci-lint/issues/2374
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2
+# See https://github.com/golangci/golangci-lint/issues/2673 (and 2374)
+# Use 1.44.2 which works on arm while 1.45.2 doesn't... somehow
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.2
 RUN golangci-lint version
 
 # Docker:

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,7 +3,7 @@ FROM golang:1.17.8
 # Need gcc for -race test (and some linters though those work with CGO_ENABLED=0)
 RUN apt-get -y update && \
   apt-get --no-install-recommends -y upgrade && \
-  DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends -y install  libc6-dev apt-transport-https ssh \
+  DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends -y install libc6-dev apt-transport-https ssh \
   ruby-dev build-essential rpm gnupg zip netcat
 
 # Install FPM
@@ -16,9 +16,11 @@ RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2
 RUN golangci-lint version
 
 # Docker:
-RUN curl -fsSL "https://download.docker.com/linux/debian/gpg" | apt-key add
-RUN echo "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/debian bullseye stable" > /etc/apt/sources.list.d/docker.list
-RUN apt-get -y update && apt-get install --no-install-recommends -y docker-ce
+RUN set -x; if [ x"$(dpkg --print-architecture)" != x"s390x" ]; then \
+    curl -fsSL "https://download.docker.com/linux/debian/gpg" | apt-key add; \
+    echo "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/debian bullseye stable" > /etc/apt/sources.list.d/docker.list && \
+    apt-get -y update && apt-get install --no-install-recommends -y docker-ce; \
+    fi
 
 WORKDIR /build
 VOLUME /build

--- a/Dockerfile.echosrv
+++ b/Dockerfile.echosrv
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v38 as build
+FROM docker.io/fortio/fortio.build:v39 as build
 WORKDIR /go/src/fortio.org
 COPY . fortio
 RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_TARGET=fortio.org/fortio/echosrv OFFICIAL_BIN=../echosrv.bin

--- a/Dockerfile.fcurl
+++ b/Dockerfile.fcurl
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v38 as build
+FROM docker.io/fortio/fortio.build:v39 as build
 WORKDIR /go/src/fortio.org
 COPY . fortio
 # fcurl should not need vendor/no dependencies

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,5 @@
 # Getting the source tree ready for running tests (sut)
-FROM docker.io/fortio/fortio.build:v38
+FROM docker.io/fortio/fortio.build:v39
 WORKDIR /go/src/fortio.org
 COPY . fortio
 RUN make -C fortio dependencies

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 IMAGES=echosrv fcurl # plus the combo image / Dockerfile without ext.
 
 DOCKER_PREFIX := docker.io/fortio/fortio
-BUILD_IMAGE_TAG := v38
+BUILD_IMAGE_TAG := v39
 BUILDX_PLATFORMS := linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 BUILD_IMAGE := $(DOCKER_PREFIX).build:$(BUILD_IMAGE_TAG)
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ IMAGES=echosrv fcurl # plus the combo image / Dockerfile without ext.
 
 DOCKER_PREFIX := docker.io/fortio/fortio
 BUILD_IMAGE_TAG := v38
+BUILDX_PLATFORMS := linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 BUILD_IMAGE := $(DOCKER_PREFIX).build:$(BUILD_IMAGE_TAG)
 
 TAG:=$(USER)$(shell date +%y%m%d_%H%M%S)
@@ -108,11 +109,11 @@ docker-version:
 
 docker-internal: dependencies
 	@echo "### Now building $(DOCKER_TAG)"
-	docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x -f Dockerfile$(IMAGE) -t $(DOCKER_TAG) .
+	docker buildx build --platform $(BUILDX_PLATFORMS) -f Dockerfile$(IMAGE) --load -t $(DOCKER_TAG) .
 
 docker-push-internal: docker-internal
 	@echo "### Now pushing $(DOCKER_TAG)"
-	docker buildx build --push --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x -f Dockerfile$(IMAGE) -t $(DOCKER_TAG) .
+	docker buildx build --push --platform $(BUILDX_PLATFORMS) -f Dockerfile$(IMAGE) -t $(DOCKER_TAG) .
 
 release: dist
 	release/release.sh

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,6 @@ FILES_WITH_IMAGE:= .circleci/config.yml Dockerfile Dockerfile.echosrv \
 	Dockerfile.test Dockerfile.fcurl release/Dockerfile.in Webtest.sh
 # then run make update-build-image and check the diff, etc... see release/README.md
 update-build-image:
-	docker pull ubuntu:focal
 	$(MAKE) docker-push-internal IMAGE=.build TAG=$(BUILD_IMAGE_TAG)
 
 update-build-image-tag:
@@ -109,11 +108,11 @@ docker-version:
 
 docker-internal: dependencies
 	@echo "### Now building $(DOCKER_TAG)"
-	docker build -f Dockerfile$(IMAGE) -t $(DOCKER_TAG) .
+	docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x -f Dockerfile$(IMAGE) -t $(DOCKER_TAG) .
 
 docker-push-internal: docker-internal
 	@echo "### Now pushing $(DOCKER_TAG)"
-	docker push $(DOCKER_TAG)
+	docker buildx build --push --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x -f Dockerfile$(IMAGE) -t $(DOCKER_TAG) .
 
 release: dist
 	release/release.sh

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ IMAGES=echosrv fcurl # plus the combo image / Dockerfile without ext.
 DOCKER_PREFIX := docker.io/fortio/fortio
 BUILD_IMAGE_TAG := v39
 BUILDX_PLATFORMS := linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+BUILDX_POSTFIX :=
+ifeq '$(shell echo $(BUILDX_PLATFORMS) | awk -F "," "{print NF-1}")' '0'
+	BUILDX_POSTFIX = --load
+endif
 BUILD_IMAGE := $(DOCKER_PREFIX).build:$(BUILD_IMAGE_TAG)
 
 TAG:=$(USER)$(shell date +%y%m%d_%H%M%S)
@@ -111,8 +115,7 @@ docker-version:
 
 docker-internal: dependencies
 	@echo "### Now building $(DOCKER_TAG)"
-	# --load doesn't work on mac m1 with docker desktop even after docker buildx create --use - thoughts?
-	docker buildx build --platform $(BUILDX_PLATFORMS) -f Dockerfile$(IMAGE) --load -t $(DOCKER_TAG) .
+	docker buildx build --platform $(BUILDX_PLATFORMS) -f Dockerfile$(IMAGE) -t $(DOCKER_TAG) $(BUILDX_POSTFIX) .
 
 docker-push-internal: docker-internal docker-buildx-push
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ docker run fortio/fortio load http://www.google.com/ # For a test run
 Or download one of the binary distributions, from the [releases](https://github.com/fortio/fortio/releases) assets page or for instance:
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.25.0/fortio-linux_x64-1.25.0.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.25.0/fortio-linux_amd64-1.25.0.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
 wget https://github.com/fortio/fortio/releases/download/v1.25.0/fortio_1.25.0_amd64.deb

--- a/README.md
+++ b/README.md
@@ -32,27 +32,32 @@ As well as the newly integrated [Dynamic Flags](dflag/) support (greatly inspire
 
 ## Installation
 
-1. [Install go](https://golang.org/doc/install) (golang 1.16 or later)
-2. `go get fortio.org/fortio`
-3. you can now run `fortio` (from your gopath bin/ directory)
+We publish a multi architecture docker image (linux/amd64, linux/arm64, linux/ppc64le, linux/s390x) `fortio/fortio`
 
-Or use docker, for instance:
-
+For instance:
 ```shell
 docker run -p 8080:8080 -p 8079:8079 fortio/fortio server & # For the server
 docker run fortio/fortio load http://www.google.com/ # For a test run
 ```
 
-Or download one of the binary distributions, from the [releases](https://github.com/fortio/fortio/releases) assets page or for instance:
+The [releases](https://github.com/fortio/fortio/releases) page has binaries for many OS/architecture combinations (see assets).
+
+You can install from source:
+
+1. [Install go](https://golang.org/doc/install) (golang 1.16 or later)
+2. `go get fortio.org/fortio`
+3. you can now run `fortio` (from your gopath bin/ directory)
+
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.26.0/fortio-linux_amd64-1.26.0.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.27.0/fortio-linux_amd64-1.27.0.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.26.0/fortio_1.26.0_amd64.deb
-dpkg -i fortio_1.26.0_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.27.0/fortio_1.27.0_amd64.deb
+dpkg -i fortio_1.27.0_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.26.0/fortio-1.26.0-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.27.0/fortio-1.27.0-1.x86_64.rpm
+# and more, see assets in release page
 ```
 
 On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
@@ -61,7 +66,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.26.0/fortio_win_1.26.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.27.0/fortio_win_1.27.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -107,7 +112,7 @@ Full list of command line flags (`fortio help`):
 <details>
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
-Φορτίο 1.26.0 usage:
+Φορτίο 1.27.0 usage:
 where command is one of: load (load testing), server (starts ui, http-echo,
  redirect, proxies, tcp-echo and grpc ping servers), tcp-echo (only the tcp-echo
  server), report (report only UI server), redirect (only the redirect server),

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -115,7 +115,7 @@ docker exec $DOCKERNAME $FORTIO_BIN_PATH grpcping localhost
 PPROF_URL="$BASE_URL/debug/pprof/heap?debug=1"
 $CURL "$PPROF_URL" | grep -i TotalAlloc # should find this in memory profile
 # creating dummy container to hold a volume for test certs due to remote docker bind mount limitation.
-docker create -v $TEST_CERT_VOL --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v38 /bin/true # cleaned up by name
+docker create -v $TEST_CERT_VOL --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v39 /bin/true # cleaned up by name
 # copying cert files into the certs volume of the dummy container
 for f in ca.crt server.crt server.key; do docker cp "$PWD/cert-tmp/$f" "$DOCKERSECVOLNAME:$TEST_CERT_VOL/$f"; done
 # start server in secure grpc mode. uses non-default ports to avoid conflicts with fortio_server container.

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -1,16 +1,43 @@
 # Concatenated after ../Dockerfile to create the tgz
 FROM docker.io/fortio/fortio.build:v38 as stage
+ARG archs="amd64 arm64 ppc64le s390x"
+ENV archs=${archs}
+
 WORKDIR /stage
-COPY --from=release /usr/bin/fortio usr/bin/fortio
 #COPY --from=release /usr/share/fortio usr/share/fortio
 COPY docs/fortio.1 usr/share/man/man1/fortio.1
-RUN mkdir /tgz
-# Make sure the list here is both minimal and complete
-# we could take all of * but that adds system directories to the tar
-RUN tar cvf - usr/share/man/man1/fortio.1 usr/bin/fortio | gzip --best > /tgz/fortio-linux_x64-$(./usr/bin/fortio version -s).tgz
-COPY --from=build /go/src/fortio.org/fortio.exe usr/share/fortio/
-WORKDIR /stage/usr/share/fortio
-RUN zip -9 -r fortio_win_$(/stage/usr/bin/fortio version -s).zip fortio.exe && mv *.zip /tgz
+
+RUN mkdir -p /tgz usr/bin
+
+WORKDIR /go/src/fortio.org
+COPY . fortio
+# Check we still build with go 1.8 (and macos does not break)
+RUN make -C fortio official-build BUILD_DIR=/build OFFICIAL_BIN=../fortio_go_latest.mac GOOS=darwin GO_BIN=/usr/local/go/bin/go
+# Windows release, for now assumes running from fortio directory (static resources in .)
+RUN make -C fortio official-build BUILD_DIR=/build LIB_DIR=. OFFICIAL_BIN=/tmp/fortio.exe GOOS=windows
+# Linux per-architecture binaries building
+RUN sh -c \
+    'set -ex; for arch in ${archs}; do \
+       make -C fortio official-build-version BUILD_DIR=/build GOARCH=${arch} OFFICIAL_BIN=/tmp/fortio_${arch}; \
+    done'
+
+RUN cd fortio && /tmp/fortio_$(go env GOARCH) version -s > /tmp/version
+
+WORKDIR /stage
+
+# Make per-architecture .tgz files
+RUN sh -c \
+    'set -ex; for arch in ${archs}; do \
+        cp /tmp/fortio_${arch} usr/bin/fortio; \
+        # Make sure the list here is both minimal and complete \
+        # we could take all of * but that adds system directories to the tar \
+        tar cvf - usr/share/man/man1/fortio.1 usr/bin/fortio | gzip --best > /tgz/fortio-linux_${arch}-$(cat /tmp/version).tgz; \
+        rm -rf usr/bin/fortio; \
+    done'
+
+WORKDIR /tmp
+RUN zip -9 -r fortio_win_$(cat /tmp/version).zip fortio.exe && mv *.zip /tgz
+
 WORKDIR /tgz
 COPY release/ffpm.sh /
 RUN bash -x /ffpm.sh deb

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -1,5 +1,5 @@
 # Concatenated after ../Dockerfile to create the tgz
-FROM docker.io/fortio/fortio.build:v38 as stage
+FROM docker.io/fortio/fortio.build:v39 as stage
 ARG archs="amd64 arm64 ppc64le s390x"
 ENV archs=${archs}
 

--- a/release/ffpm.sh
+++ b/release/ffpm.sh
@@ -15,7 +15,11 @@
 #
 # Ran from the release/Dockerfile[.in] to invoke fpm with common arguments
 # Assumes the layout from the Dockerfiles (/stage source, /tgz destination etc)
-fpm -v $(/stage/usr/bin/fortio version -s) -n fortio --license "Apache License, Version 2.0" \
-    --category utils --url https://fortio.org/ --maintainer fortio@fortio.org \
-    --description "Fortio is a load testing library, command line tool, advanced echo server and web UI in go (golang)." \
-    -s tar -t $1 /tgz/*.tgz
+for f in /tgz/*.tgz; do
+  arch=${f:18}
+  arch=${arch/-*/}
+  fpm -v "$(cat /tmp/version)" -n fortio --license "Apache License, Version 2.0" \
+      --category utils --url https://fortio.org/ --maintainer fortio@fortio.org \
+      --description "Fortio is a load testing library, command line tool, advanced echo server and web UI in go (golang)." \
+      -s tar -t "$1" -a "${arch}" "$f"
+done

--- a/release/release.sh
+++ b/release/release.sh
@@ -16,9 +16,7 @@
 # To be run by ../Makefile as release/release.sh
 set -x
 set -e
-# Release tgz Dockerfile is based on the normal docker one
-cat Dockerfile release/Dockerfile.in > release/Dockerfile
-docker build -f release/Dockerfile -t fortio/fortio:release .
+docker build -f release/Dockerfile.in -t fortio/fortio:release .
 DOCKERID=$(docker create --name fortio_release fortio/fortio:release x)
 function cleanup {
   docker rm fortio_release
@@ -30,7 +28,9 @@ rm -f release/tgz/*
 rmdir release/tgz || true
 docker cp -a fortio_release:/tgz/ release/tgz
 # Check the tar balls and zip
-tar tvfz release/tgz/*.tgz
+for f in release/tgz/*.tgz; do
+  tar tvfz "$f"
+done
 unzip -l release/tgz/*.zip
 # then save the results 1 level up
 mv release/tgz/* release/


### PR DESCRIPTION
- Switching build image to golang:1.17.8
- Changes golangci-lint installation due to golangci/golangci-lint#2374
- Building windows/mac binaries only when architecture is amd64 in fortio Dockerfile
- The docker Debian repo is now added based on the arch

An alternative that allows installing golang-ci-lint as before also on ARM64 is by bumping to golang:1.18. See the issue above.

cc @yselkowitz

Refers ARMOCP-293