### PR TITLE
support for gzip with new gzip=true echo param (or gzip=10 for 10%)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ docker run fortio/fortio load http://www.google.com/ # For a test run
 Or download one of the binary distributions, from the [releases](https://github.com/fortio/fortio/releases) assets page or for instance:
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.24.0/fortio-linux_x64-1.24.0.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.25.0/fortio-linux_x64-1.25.0.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.24.0/fortio_1.24.0_amd64.deb
-dpkg -i fortio_1.24.0_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.25.0/fortio_1.25.0_amd64.deb
+dpkg -i fortio_1.25.0_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.24.0/fortio-1.24.0-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.25.0/fortio-1.25.0-1.x86_64.rpm
 ```
 
 On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
@@ -61,7 +61,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.24.0/fortio_win_1.24.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.25.0/fortio_win_1.25.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -106,7 +106,7 @@ Full list of command line flags (`fortio help`):
 <details>
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
-Φορτίο 1.24.0 usage:
+Φορτίο 1.25.0 usage:
 where command is one of: load (load testing), server (starts ui, http-echo,
  redirect, proxies, tcp-echo and grpc ping servers), tcp-echo (only the tcp-echo
  server), report (report only UI server), redirect (only the redirect server),

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Fortio `server` has the following feature for the http listening on 8080 (all pa
 | size      | size of the payload to reply instead of echoing input. Also works as probabilities list. `size=1024:10,512:5` 10% of response will be 1k and 5% will be 512 bytes payload and the rest defaults to echoing back. |
 | close     | close the socket after answering e.g `close=true` to close after all requests or `close=5.3` to close after approximately 5.3% of requests|
 | header    | header(s) to add to the reply e.g. `&header=Foo:Bar&header=X:Y` |
+| gzip      | If `Accept-Encoding: gzip` is passed in headers by the caller/client; and `gzip=true` is in the query args, all response will be gzipped; or if `gzip=42.7` is passed, approximately 42.7% will|
 
 You can set a default value for all these by passing `-echo-server-default-params` to the server command line, for instance:
 `fortio server -echo-server-default-params="delay=0.5s:50,1s:40&status=418"` will make the server respond with http 418 and a delay of either 0.5s half of the time, 1s 40% and no delay in 10% of the calls; unless any `?` query args is passed by the client. Note that the quotes (&quot;) are for the shell to escape the ampersand (&amp;) but should not be put in a yaml nor the dynamicflag url for instance.

--- a/fhttp/http_server.go
+++ b/fhttp/http_server.go
@@ -104,7 +104,7 @@ func EchoHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	gzip := strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") && generateGzip(r.FormValue("gzip"))
 	if gzip {
-		gwz := NewGzipHttpResponseWriter(w)
+		gwz := NewGzipHTTPResponseWriter(w)
 		defer gwz.Close()
 		w = gwz
 	}

--- a/fhttp/http_test.go
+++ b/fhttp/http_test.go
@@ -515,6 +515,28 @@ func TestGenerateClose(t *testing.T) {
 	}
 }
 
+func TestGenerateGzip(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		// not numbers
+		{"true", true},
+		{"false", false},
+		{"x", true},
+		// Numbers
+		{"0", false},
+		{"0.0", false},
+		{"99.9999999", true}, // well, in theory this should fail once in a blue moon
+		{"100", true},
+	}
+	for _, tst := range tests {
+		if actual := generateGzip(tst.input); actual != tst.expected {
+			t.Errorf("Got %v, expected %v for generateGzip(%q)", actual, tst.expected, tst.input)
+		}
+	}
+}
+
 func TestPayloadWithEchoBack(t *testing.T) {
 	tests := []struct {
 		payload           []byte

--- a/fhttp/http_utils.go
+++ b/fhttp/http_utils.go
@@ -468,7 +468,6 @@ func generateSingleProbability(value string, name string) bool {
 		return true
 	}
 	return false
-
 }
 
 // generateClose from string, format: close=true for 100% close
@@ -525,8 +524,8 @@ func (w *GzipResponseWriter) Close() error {
 	return err
 }
 
-// NewGzipHttpResponseWriter returns a wrapper for gzip'ing the response.
-func NewGzipHttpResponseWriter(w http.ResponseWriter) *GzipResponseWriter {
+// NewGzipHTTPResponseWriter returns a wrapper for gzip'ing the response.
+func NewGzipHTTPResponseWriter(w http.ResponseWriter) *GzipResponseWriter {
 	log.LogVf("Doing gzip compression")
 	w.Header().Set("Content-Encoding", "gzip")
 	gz := gzPool.Get().(*gzip.Writer)
@@ -543,7 +542,7 @@ func Gzip(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
-		gzw := NewGzipHttpResponseWriter(w)
+		gzw := NewGzipHTTPResponseWriter(w)
 		defer gzw.Close()
 		next.ServeHTTP(gzw, r)
 	})

--- a/fhttp/http_utils.go
+++ b/fhttp/http_utils.go
@@ -445,49 +445,42 @@ func generateDelay(delay string) time.Duration {
 	return 0
 }
 
-// generateClose from string, format: close=true for 100% close
-// close=true:10 or close=10 for 10% socket close.
-func generateClose(closeStr string) bool {
-	if closeStr == "" || closeStr == "false" {
+// generateSingleProbability takes a string value and a name and returns a boolean.
+// false if the value is missing or "false".
+// true if the value is "true" or doesn't parse as a floating point number.
+// otherwise if the value is a floating point number X; use it as a percentage
+// and roll a dice to be true X% of the time.
+func generateSingleProbability(value string, name string) bool {
+	if value == "" || value == "false" {
 		return false
 	}
-	if closeStr == "true" { // avoid throwing error for pre 1.22 syntax
+	if value == "true" { // avoid throwing error for pre 1.22 syntax
 		return true
 	}
-	p, err := strconv.ParseFloat(closeStr, 32)
+	p, err := strconv.ParseFloat(value, 32)
 	if err != nil {
-		log.Debugf("error %v parsing close=%q treating as true", err, closeStr)
+		log.Debugf("error %v parsing %s=%q treating as true", err, name, value)
 		return true
 	}
 	res := 100. * rand.Float32() // nolint: gosec // we want fast not crypto
-	log.Debugf("close=%f rolled %f", p, res)
+	log.Debugf("%s=%f rolled %f", name, p, res)
 	if res <= float32(p) {
 		return true
 	}
 	return false
+
+}
+
+// generateClose from string, format: close=true for 100% close
+// close=true:10 or close=10 for 10% socket close.
+func generateClose(closeStr string) bool {
+	return generateSingleProbability(closeStr, "close")
 }
 
 // generateGzip from string, format: gzip=true or gzip=100 for 100% gzip
 // gzip=42.3 for 42.3% gzip result (if Accept-Encoding is gzip).
-// TODO refactor common stuff.
 func generateGzip(gzipStr string) bool {
-	if gzipStr == "" || gzipStr == "false" {
-		return false
-	}
-	if gzipStr == "true" { // avoid throwing error for pre 1.22 syntax
-		return true
-	}
-	p, err := strconv.ParseFloat(gzipStr, 32)
-	if err != nil {
-		log.Debugf("error %v parsing gzip=%q treating as true", err, gzipStr)
-		return true
-	}
-	res := 100. * rand.Float32() // nolint: gosec // we want fast not crypto
-	log.Debugf("gzip=%f rolled %f", p, res)
-	if res <= float32(p) {
-		return true
-	}
-	return false
+	return generateSingleProbability(gzipStr, "gzip")
 }
 
 // RoundDuration rounds to 10th of second.
@@ -513,15 +506,18 @@ type GzipResponseWriter struct {
 	gz *gzip.Writer
 }
 
+// WriteHeader intercepts the actual to remove any Content-Length that may have been added before compression.
 func (w *GzipResponseWriter) WriteHeader(status int) {
 	w.ResponseWriter.Header().Del("Content-Length")
 	w.ResponseWriter.WriteHeader(status)
 }
 
+// Write sends the Write() to the gzip Writer.
 func (w *GzipResponseWriter) Write(b []byte) (int, error) {
 	return w.Writer.Write(b)
 }
 
+// Close must be called in defer inside the handler using this.
 func (w *GzipResponseWriter) Close() error {
 	err := w.gz.Close()
 	gzPool.Put(w.gz)

--- a/fhttp/http_utils.go
+++ b/fhttp/http_utils.go
@@ -15,6 +15,7 @@
 package fhttp // import "fortio.org/fortio/fhttp"
 
 import (
+	"compress/gzip"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -466,9 +467,90 @@ func generateClose(closeStr string) bool {
 	return false
 }
 
+// generateGzip from string, format: gzip=true or gzip=100 for 100% gzip
+// gzip=42.3 for 42.3% gzip result (if Accept-Encoding is gzip).
+// TODO refactor common stuff.
+func generateGzip(gzipStr string) bool {
+	if gzipStr == "" || gzipStr == "false" {
+		return false
+	}
+	if gzipStr == "true" { // avoid throwing error for pre 1.22 syntax
+		return true
+	}
+	p, err := strconv.ParseFloat(gzipStr, 32)
+	if err != nil {
+		log.Debugf("error %v parsing gzip=%q treating as true", err, gzipStr)
+		return true
+	}
+	res := 100. * rand.Float32() // nolint: gosec // we want fast not crypto
+	log.Debugf("gzip=%f rolled %f", p, res)
+	if res <= float32(p) {
+		return true
+	}
+	return false
+}
+
 // RoundDuration rounds to 10th of second.
 func RoundDuration(d time.Duration) time.Duration {
 	return d.Round(100 * time.Millisecond)
+}
+
+// Inspired by https://gist.github.com/CJEnright/bc2d8b8dc0c1389a9feeddb110f822d7 (thanks!)
+// (with fixes/adaptation)
+
+var gzPool = sync.Pool{
+	New: func() interface{} {
+		log.LogVf("Pool new gzip")
+		w := gzip.NewWriter(ioutil.Discard)
+		return w
+	},
+}
+
+// GzipResponseWriter wraps the response and gzips the content.
+type GzipResponseWriter struct {
+	io.Writer
+	http.ResponseWriter
+	gz *gzip.Writer
+}
+
+func (w *GzipResponseWriter) WriteHeader(status int) {
+	w.ResponseWriter.Header().Del("Content-Length")
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *GzipResponseWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
+}
+
+func (w *GzipResponseWriter) Close() error {
+	err := w.gz.Close()
+	gzPool.Put(w.gz)
+	w.gz = nil // just in case there is a bug, will be NPE instead of race
+	return err
+}
+
+// NewGzipHttpResponseWriter returns a wrapper for gzip'ing the response.
+func NewGzipHttpResponseWriter(w http.ResponseWriter) *GzipResponseWriter {
+	log.LogVf("Doing gzip compression")
+	w.Header().Set("Content-Encoding", "gzip")
+	gz := gzPool.Get().(*gzip.Writer)
+	gz.Reset(w)
+	return &GzipResponseWriter{ResponseWriter: w, Writer: gz, gz: gz}
+}
+
+// Gzip wraps a handler for automatic gzip.
+func Gzip(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// in our case we only wrap if we decided (gzip=x % rolled true) to gzip and so we already checked headers
+		// but leaving the check so this can be reused in generic code.
+		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			next.ServeHTTP(w, r)
+			return
+		}
+		gzw := NewGzipHttpResponseWriter(w)
+		defer gzw.Close()
+		next.ServeHTTP(gzw, r)
+	})
 }
 
 // -- formerly in uihandler:


### PR DESCRIPTION
Fixes #540 

For the echo handlers (main and behind debug) need both Accept-Encoding: gzip and gzip=true or percentage to trigger.

Also enabled for the debug handler (conditional only on Accept-Encoding: gzip)

Unrelated but also improving error output:
```
23:30:00 E http_client.go:776> [0] Read error for xxxxx:443 0 : read tcp 10.255.12.158:62761-> xxxxx:443: i/o timeout
```
instead of
```
23:26:02 E http_client.go:776> Read error &{0x14000302[...lots and lots of output...]0 1 0 0 [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]} xxxxx:443 0 : read tcp 10.255.12.158:61779->xxxxx:443: i/o timeout
```