### PR TITLE
no catchup mode (fixed/set maximum qps; skip requests when falling behind)

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,16 +360,17 @@ There is also the GRPC health and ping servers, as well as the http->https redir
 
 ```Shell
 $ fortio server &
-14:11:05 I fortio_main.go:171> Not using dynamic flag watching (use -config to set watch directory)
-Fortio X.Y.Z tcp-echo server listening on [::]:8078
-Fortio X.Y.Z grpc 'ping' server listening on [::]:8079
-Fortio X.Y.Z https redirector server listening on [::]:8081
-Fortio X.Y.Z echo server listening on [::]:8080
-Data directory is /Users/ldemailly/go/src/fortio.org/fortio
+Fortio X.Y.Z tcp-echo server listening on tcp [::]:8078
+Fortio X.Y.Z udp-echo server listening on udp [::]:8078
+Fortio X.Y.Z grpc 'ping' server listening on tcp [::]:8079
+Fortio X.Y.Z https redirector server listening on tcp [::]:8081
+Fortio X.Y.Z http-echo server listening on tcp [::]:8080
+Data directory is /Users/ldemailly/dev/fortio
 UI started - visit:
 http://localhost:8080/fortio/
 (or any host/ip reachable on this server)
-14:11:05 I fortio_main.go:233> All fortio X.Y.Z release goM.m.p servers started!
+14:11:05 I fortio_main.go:285> Note: not using dynamic flag watching (use -config to set watch directory)
+14:11:05 I fortio_main.go:293> All fortio X.Y.Z unknown goM.m.p servers started!
 ```
 
 ### Change the port / binding address

--- a/README.md
+++ b/README.md
@@ -89,11 +89,12 @@ Most important flags for http load generation:
 | Flag         | Description, example |
 | -------------|----------------------|
 | `-qps rate` | Queries Per Seconds or 0 for no wait/max qps |
+| `-nocatchup` | Do not try to reach the target qps by going faster when the service falls behind and then recovers. Makes QPS an absolute ceiling even if the service has some spikes in latency, fortio will not compensate (but also won't stress the target more than the set qps). Recommended to use jointly with `-uniform`. |
 | `-c connections` | Number of parallel simultaneous connections (and matching go routine) |
 | `-t duration` | How long to run the test  (for instance `-t 30m` for 30 minutes) or 0 to run until ^C, example (default 5s) |
 | `-n numcalls` | Run for exactly this number of calls instead of duration. Default (0) is to use duration (-t). |
 | `-payload str` or `-payload-file fname` | Switch to using POST with the given payload (see also `-payload-size` for random payload)|
-| `-uniform` | Spread the calls across threads |
+| `-uniform` | Spread the calls in time across threads for a more uniform call distribution. Works even better in conjunction with `-nocatchup`. |
 | `-r resolution` | Resolution of the histogram lowest buckets in seconds (default 0.001 i.e 1ms), use 1/10th of your expected typical latency |
 | `-H "header: value"` | Can be specified multiple times to add headers (including Host:) |
 | `-a`     |  Automatically save JSON result with filename based on labels and timestamp |

--- a/fhttp/http_server.go
+++ b/fhttp/http_server.go
@@ -356,7 +356,7 @@ func EchoDebugPath(debugPath string) string {
 // input for dynamic http server.
 func Serve(port, debugPath string) (*http.ServeMux, net.Addr) {
 	startTime = time.Now()
-	mux, addr := HTTPServer("echo", port)
+	mux, addr := HTTPServer("http-echo", port)
 	if addr == nil {
 		return nil, nil // error already logged
 	}

--- a/fnet/network.go
+++ b/fnet/network.go
@@ -113,7 +113,7 @@ func Listen(name string, port string) (net.Listener, net.Addr) {
 	}
 	lAddr := listener.Addr()
 	if len(name) > 0 {
-		fmt.Printf("Fortio %s %s TCP server listening on %s\n", version.Short(), name, lAddr)
+		fmt.Printf("Fortio %s %s server listening on %s %s\n", version.Short(), name, sockType, lAddr)
 	}
 	return listener, lAddr
 }
@@ -132,7 +132,7 @@ func UDPListen(name string, port string) (*net.UDPConn, net.Addr) {
 		return nil, nil
 	}
 	if len(name) > 0 {
-		fmt.Printf("Fortio %s %s UDP server listening on %s\n", version.Short(), name, udpconn.LocalAddr())
+		fmt.Printf("Fortio %s %s server listening on udp %s\n", version.Short(), name, udpconn.LocalAddr())
 	}
 	return udpconn, udpconn.LocalAddr()
 }

--- a/fortio_main.go
+++ b/fortio_main.go
@@ -167,8 +167,10 @@ var (
 
 	maxStreamsFlag = flag.Uint("grpc-max-streams", 0,
 		"MaxConcurrentStreams for the grpc server. Default (0) is to leave the option unset.")
-	jitterFlag  = flag.Bool("jitter", false, "set to true to de-synchronize parallel clients' by 10%")
-	uniformFlag = flag.Bool("uniform", false, "set to true to de-synchronize parallel clients' requests uniformly")
+	jitterFlag    = flag.Bool("jitter", false, "set to true to de-synchronize parallel clients' by 10%")
+	uniformFlag   = flag.Bool("uniform", false, "set to true to de-synchronize parallel clients' requests uniformly")
+	nocatchupFlag = flag.Bool("nocatchup", false,
+		"set to exact fixed qps and prevent fortio from trying to catchup when the target fails to keep up temporarily")
 	// nc mode flag(s).
 	ncDontStopOnCloseFlag = flag.Bool("nc-dont-stop-on-eof", false, "in netcat (nc) mode, don't abort as soon as remote side closes")
 	// Mirror origin global setting (should be per destination eventually).
@@ -409,6 +411,7 @@ func fortioLoad(justCurl bool, percList []float64) {
 		Uniform:     *uniformFlag,
 		RunID:       *bincommon.RunIDFlag,
 		Offset:      *offsetFlag,
+		NoCatchUp:   *nocatchupFlag,
 	}
 	err := ro.AddAccessLogger(*accessLogFileFlag, *accessLogFileFormat)
 	if err != nil {

--- a/periodic/periodic_test.go
+++ b/periodic/periodic_test.go
@@ -275,11 +275,11 @@ func TestUniformAndNoCatchUp(t *testing.T) {
 	var count int64
 	var lock sync.Mutex
 	c := TestCount{&count, &lock}
-	// TODO: make an actual test vs just exercise the code.
-	// +3 warmup -3 at the end
-	expected := int64(20)
+	// TODO: make an actual test vs sort of just exercise the code.
+	// also explain why 34 (with nocatchup, 40 without)
+	expected := int64(34)
 	o := RunnerOptions{
-		QPS:        10,
+		QPS:        85,
 		NumThreads: 2,
 		Duration:   2 * time.Second,
 		Uniform:    true,

--- a/periodic/periodic_test.go
+++ b/periodic/periodic_test.go
@@ -271,16 +271,19 @@ func TestAccessLogs(t *testing.T) {
 	r.Options().ReleaseRunners()
 }
 
-func TestUniform(t *testing.T) {
+func TestUniformAndNoCatchUp(t *testing.T) {
 	var count int64
 	var lock sync.Mutex
 	c := TestCount{&count, &lock}
-	expected := int64(40)
+	// TODO: make an actual test vs just exercise the code.
+	// +3 warmup -3 at the end
+	expected := int64(20)
 	o := RunnerOptions{
-		QPS:        100,
-		NumThreads: 4,
-		Duration:   time.Second,
+		QPS:        10,
+		NumThreads: 2,
+		Duration:   2 * time.Second,
 		Uniform:    true,
+		NoCatchUp:  true,
 	}
 	r := NewPeriodicRunner(&o)
 	r.Options().MakeRunners(&c)

--- a/ui/restHandler.go
+++ b/ui/restHandler.go
@@ -136,6 +136,7 @@ func RESTRunHandler(w http.ResponseWriter, r *http.Request) { // nolint: funlen
 	durStr := FormValue(r, jd, "t")
 	jitter := (FormValue(r, jd, "jitter") == "on")
 	uniform := (FormValue(r, jd, "uniform") == "on")
+	nocatchup := (FormValue(r, jd, "nocatchup") == "on")
 	stdClient := (FormValue(r, jd, "stdclient") == "on")
 	sequentialWarmup := (FormValue(r, jd, "sequential-warmup") == "on")
 	httpsInsecure := (FormValue(r, jd, "https-insecure") == "on")
@@ -173,6 +174,7 @@ func RESTRunHandler(w http.ResponseWriter, r *http.Request) { // nolint: funlen
 		Exactly:     n,
 		Jitter:      jitter,
 		Uniform:     uniform,
+		NoCatchUp:   nocatchup,
 	}
 	ro.Normalize()
 	uiRunMapMutex.Lock()

--- a/ui/templates/main.html
+++ b/ui/templates/main.html
@@ -46,7 +46,8 @@
     or run until interrupted:<input type="checkbox" name="t" onchange="toggleDuration(this)" />
     or run for exactly <input type="text" name="n" size="6" value="" /> calls. <br />
     Threads/Simultaneous connections: <input type="text" name="c" size="6" value="8" /> <br />
-    Jitter:<input type="checkbox" name="jitter" /> Uniform:<input type="checkbox" name="uniform" /><br />
+    Uniform:<input type="checkbox" name="uniform" /> or Jitter:<input type="checkbox" name="jitter" /> &nbsp;&nbsp;
+    No Catch-Up (qps is a ceiling): <input type="checkbox" name="nocatchup" /><br />
     Percentiles: <input type="text" name="p" size="20" value="50, 75, 90, 99, 99.9" /> <br />
     Histogram Resolution: <input type="text" name="r" size="8" value="0.0001" /> <br />
     Headers: <br />

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -148,6 +148,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	durStr := r.FormValue("t")
 	jitter := (r.FormValue("jitter") == "on")
 	uniform := (r.FormValue("uniform") == "on")
+	nocatchup := (r.FormValue("nocatchup") == "on")
 	grpcSecure := (r.FormValue("grpc-secure") == "on")
 	grpcPing := (r.FormValue("ping") == "on")
 	grpcPingDelay, _ := time.ParseDuration(r.FormValue("grpc-ping-delay"))
@@ -194,6 +195,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		Exactly:     n,
 		Jitter:      jitter,
 		Uniform:     uniform,
+		NoCatchUp:   nocatchup,
 	}
 	if mode == run {
 		ro.Normalize()


### PR DESCRIPTION
- [x] minor clarifications and improvements in periodic. document access logger for max qps too
- [x] actual no catchup/max catchup mode (Fix #543)
- [x] minor improvement on listen and http echo server log output

manually tested using various echo with % of delay above qps; yields stuff like
```
16:11:28 V periodic.go:675> T000 request took too long 0.2125 s, would sleep -13.968ms, skipping iter 171
```