### PR TITLE
Track success vs failure, add that and details string for richer access log, visualize new errors histogram

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,7 @@ jobs:
       - setup_remote_docker:
           version: 20.10.12
       - checkout
-      - run: |
-          docker context create release-tests
-          docker buildx create release-tests --use
-          make release-test BUILDX_PLATFORMS=linux/amd64
+      - run: make release-test
   linters:
     <<: *defaultEnv
     steps:

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,9 @@ update-build-image-tag:
 	@echo 'Need to use gnu sed (brew install gnu-sed; make update-build-image-tag SED=gsed)'
 	$(SED) --in-place=.bak -e 's!$(DOCKER_PREFIX).build:v..!$(BUILD_IMAGE)!g' $(FILES_WITH_IMAGE)
 
+docker-default-platform:
+	@docker buildx --builder default inspect | tail -1 | sed -e "s/Platforms: //" -e "s/,//g" | awk '{print $$1}'
+
 docker-version:
 	@echo "### Docker is `which docker`"
 	@docker version

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ You can install from source:
 
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.27.0/fortio-linux_amd64-1.27.0.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.28.0/fortio-linux_amd64-1.28.0.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.27.0/fortio_1.27.0_amd64.deb
-dpkg -i fortio_1.27.0_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.28.0/fortio_1.28.0_amd64.deb
+dpkg -i fortio_1.28.0_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.27.0/fortio-1.27.0-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.28.0/fortio-1.28.0-1.x86_64.rpm
 # and more, see assets in release page
 ```
 
@@ -66,7 +66,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.27.0/fortio_win_1.27.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.28.0/fortio_win_1.28.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -112,7 +112,7 @@ Full list of command line flags (`fortio help`):
 <details>
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
-Φορτίο 1.27.0 usage:
+Φορτίο 1.28.0 usage:
 where command is one of: load (load testing), server (starts ui, http-echo,
  redirect, proxies, tcp-echo and grpc ping servers), tcp-echo (only the tcp-echo
  server), report (report only UI server), redirect (only the redirect server),
@@ -380,6 +380,13 @@ http://localhost:8080/fortio/
 14:11:05 I fortio_main.go:285> Note: not using dynamic flag watching (use -config to set watch directory)
 14:11:05 I fortio_main.go:293> All fortio X.Y.Z unknown goM.m.p servers started!
 ```
+
+### Sample of the graphing UI
+
+With the 2 histograms - total and errors overlayed
+
+![Graphical result](https://user-images.githubusercontent.com/3664595/165001248-33e180d5-fd6b-4389-b73e-79a21e76d5b0.png)
+
 
 ### Change the port / binding address
 

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 set -x
 # Check we can build the image
-NATIVE_PLATFORM="$(make docker-default-platform 2> /dev/null)"
+NATIVE_PLATFORM=$(docker buildx --builder default inspect | tail -1 | sed -e "s/Platforms: //" -e "s/,//g" | awk '{print $1}')
 echo "Building for $NATIVE_PLATFORM"
 make docker-internal TAG=webtest BUILDX_PLATFORMS="$NATIVE_PLATFORM" || exit 1
 FORTIO_UI_PREFIX=/newprefix/ # test the non default prefix (not /fortio/)

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -14,7 +14,9 @@
 # limitations under the License.
 set -x
 # Check we can build the image
-make docker-internal TAG=webtest BUILDX_PLATFORMS="$(make docker-default-platform)" || exit 1
+NATIVE_PLATFORM="$(make docker-default-platform)"
+echo "Building for $NATIVE_PLATFORM"
+make docker-internal TAG=webtest BUILDX_PLATFORMS="$NATIVE_PLATFORM" || exit 1
 FORTIO_UI_PREFIX=/newprefix/ # test the non default prefix (not /fortio/)
 FILE_LIMIT=25 # must be low to detect leaks, go 1.14 seems to need more than go1.8 (!)
 LOGLEVEL=info # change to debug to debug

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 set -x
 # Check we can build the image
-make docker-internal TAG=webtest BUILDX_PLATFORMS=$(make docker-default-platform) || exit 1
+make docker-internal TAG=webtest BUILDX_PLATFORMS="$(make docker-default-platform)" || exit 1
 FORTIO_UI_PREFIX=/newprefix/ # test the non default prefix (not /fortio/)
 FILE_LIMIT=25 # must be low to detect leaks, go 1.14 seems to need more than go1.8 (!)
 LOGLEVEL=info # change to debug to debug

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 set -x
 # Check we can build the image
-NATIVE_PLATFORM="$(make docker-default-platform)"
+NATIVE_PLATFORM="$(make docker-default-platform 2> /dev/null)"
 echo "Building for $NATIVE_PLATFORM"
 make docker-internal TAG=webtest BUILDX_PLATFORMS="$NATIVE_PLATFORM" || exit 1
 FORTIO_UI_PREFIX=/newprefix/ # test the non default prefix (not /fortio/)

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 set -x
 # Check we can build the image
-make docker-internal TAG=webtest || exit 1
+make docker-internal TAG=webtest BUILDX_PLATFORMS=$(make docker-default-platform) || exit 1
 FORTIO_UI_PREFIX=/newprefix/ # test the non default prefix (not /fortio/)
 FILE_LIMIT=25 # must be low to detect leaks, go 1.14 seems to need more than go1.8 (!)
 LOGLEVEL=info # change to debug to debug

--- a/fgrpc/grpcrunner.go
+++ b/fgrpc/grpcrunner.go
@@ -80,7 +80,7 @@ type GRPCRunnerResults struct {
 
 // Run exercises GRPC health check or ping at the target QPS.
 // To be set as the Function in RunnerOptions.
-func (grpcstate *GRPCRunnerResults) Run(t int) {
+func (grpcstate *GRPCRunnerResults) Run(t int) (bool, string) {
 	log.Debugf("Calling in %d", t)
 	var err error
 	var res interface{}
@@ -99,9 +99,13 @@ func (grpcstate *GRPCRunnerResults) Run(t int) {
 	if err != nil {
 		log.Warnf("Error making grpc call: %v", err)
 		grpcstate.RetCodes[Error]++
-	} else {
-		grpcstate.RetCodes[status.String()]++
+		return false, err.Error()
 	}
+	grpcstate.RetCodes[status.String()]++
+	if status == grpc_health_v1.HealthCheckResponse_SERVING {
+		return true, "SERVING"
+	}
+	return false, status.String()
 }
 
 // GRPCRunnerOptions includes the base RunnerOptions plus grpc specific

--- a/fhttp/http_forwarder_test.go
+++ b/fhttp/http_forwarder_test.go
@@ -19,13 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-
-	"fortio.org/fortio/log"
 )
-
-func init() {
-	log.SetLogLevel(log.Debug)
-}
 
 func TestMultiProxy(t *testing.T) {
 	_, debugAddr := ServeTCP("0", "/debug")

--- a/fhttp/http_test.go
+++ b/fhttp/http_test.go
@@ -36,7 +36,6 @@ import (
 var uuids map[string]bool
 
 func init() {
-	log.SetLogLevel(log.Debug)
 	uuids = map[string]bool{}
 }
 

--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -16,6 +16,7 @@ package fhttp
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"runtime"
 	"runtime/pprof"
@@ -51,7 +52,7 @@ type HTTPRunnerResults struct {
 
 // Run tests http request fetching. Main call being run at the target QPS.
 // To be set as the Function in RunnerOptions.
-func (httpstate *HTTPRunnerResults) Run(t int) {
+func (httpstate *HTTPRunnerResults) Run(t int) (bool, string) {
 	log.Debugf("Calling in %d", t)
 	code, body, headerSize := httpstate.client.Fetch()
 	size := len(body)
@@ -63,6 +64,10 @@ func (httpstate *HTTPRunnerResults) Run(t int) {
 		httpstate.aborter.Abort()
 		log.Infof("Aborted run because of code %d - data %s", code, DebugSummary(body, 1024))
 	}
+	if code == http.StatusOK {
+		return true, "200"
+	}
+	return false, fmt.Sprint(code)
 }
 
 // HTTPRunnerOptions includes the base RunnerOptions plus http specific

--- a/fhttp/httprunner_test.go
+++ b/fhttp/httprunner_test.go
@@ -251,6 +251,7 @@ func gUnzipData(t *testing.T, data []byte) (resData []byte) {
 	return
 }
 
+// nolint: gocognit
 func TestAccessLog(t *testing.T) {
 	mux, addr := DynamicHTTPServer(false)
 	mux.HandleFunc("/echo-for-alog/", EchoHandler)

--- a/fhttp/httprunner_test.go
+++ b/fhttp/httprunner_test.go
@@ -80,7 +80,8 @@ func testHTTPNotLeaking(t *testing.T, opts *HTTPRunnerOptions) {
 	t.Logf("Number go routine before test %d", ngBefore1)
 	mux, addr := DynamicHTTPServer(false)
 	mux.HandleFunc("/echo100", EchoHandler)
-	url := fmt.Sprintf("http://localhost:%d/echo100", addr.Port)
+	// Avoid using localhost which can timeout with stdclient (thought this might fail on ipv6 only machines?)
+	url := fmt.Sprintf("http://127.0.0.1:%d/echo100", addr.Port)
 	numCalls := 100
 	opts.NumThreads = numCalls / 2 // make 2 calls per thread
 	opts.Exactly = int64(numCalls)

--- a/periodic/periodic.go
+++ b/periodic/periodic.go
@@ -504,9 +504,7 @@ func (r *periodicRunner) Run() RunnerResults {
 	}
 	if log.Log(log.Warning) {
 		result.DurationHistogram.Print(r.Out, "Aggregated Function Time")
-		if result.ErrorsDurationHistogram.Count > 0 {
-			result.ErrorsDurationHistogram.Print(r.Out, "Error cases")
-		}
+		result.ErrorsDurationHistogram.Print(r.Out, "Error cases")
 	} else {
 		functionDuration.Counter.Print(r.Out, "Aggregated Function Time")
 		for _, p := range result.DurationHistogram.Percentiles {

--- a/periodic/periodic_test.go
+++ b/periodic/periodic_test.go
@@ -277,7 +277,6 @@ func TestAccessLogs(t *testing.T) {
 	}
 	if logger.success != expected/2 {
 		t.Errorf("Access logs status success unexpected number of times %d instead %d", logger.success, expected/2)
-
 	}
 	r.Options().ReleaseRunners()
 }

--- a/periodic/periodic_test.go
+++ b/periodic/periodic_test.go
@@ -15,8 +15,10 @@
 package periodic
 
 import (
+	"bufio"
 	"math"
 	"os"
+	"path"
 	"strings"
 	"sync"
 	"testing"
@@ -279,6 +281,71 @@ func TestAccessLogs(t *testing.T) {
 		t.Errorf("Access logs status success unexpected number of times %d instead %d", logger.success, expected/2)
 	}
 	r.Options().ReleaseRunners()
+}
+
+func TestAccessLogFile(t *testing.T) {
+	var count int64
+	var lock sync.Mutex
+
+	c := TestCount{&count, &lock}
+	expected := int64(10)
+	o := RunnerOptions{
+		QPS:        -1, // max qps
+		NumThreads: 4,
+		Exactly:    expected,
+	}
+
+	for _, format := range []string{"json", "influx"} {
+		dir := t.TempDir()
+		fname := path.Join(dir, "access.log")
+		err := o.AddAccessLogger(fname, format)
+		r := NewPeriodicRunner(&o)
+		r.Options().MakeRunners(&c)
+		count = 0
+		if err != nil {
+			t.Errorf("unexpected error for log file %q %s: %v", fname, format, err)
+		}
+		res := r.Run()
+		totalReq := res.DurationHistogram.Count
+		if totalReq != expected {
+			t.Errorf("Mismatch between requests %d and expected %d", totalReq, expected)
+		}
+		if count != expected {
+			t.Errorf("Mismatch between count %d and expected %d", count, expected)
+		}
+		numErr := res.ErrorsDurationHistogram.Count
+		if numErr <= 1 || numErr >= expected-1 {
+			t.Errorf("Unexpected non ok count %d should be ~ 50%% of %d", numErr, expected)
+		}
+		numOk := res.DurationHistogram.Count - numErr
+		if numOk <= 1 || numOk >= expected-1 {
+			t.Errorf("Unexpected ok count %d should be ~ 50%% of %d", numOk, expected)
+		}
+		file, _ := os.Open(fname)
+		scanner := bufio.NewScanner(file)
+		lineCount := 0
+		linesOk := 0
+		linesNotOk := 0
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.Contains(line, "true") {
+				linesOk++
+			}
+			if strings.Contains(line, "false") {
+				linesNotOk++
+			}
+			lineCount++
+		}
+		if lineCount != int(expected) {
+			t.Errorf("unexpected number of lines in access log %s: %d", format, lineCount)
+		}
+		if linesOk != int(numOk) {
+			t.Errorf("unexpected number of lines in access log %s: with ok: %d instead of %d", format, linesOk, numOk)
+		}
+		if linesNotOk != int(numErr) {
+			t.Errorf("unexpected number of lines in access log %s: with not ok: %d instead of %d", format, linesNotOk, numErr)
+		}
+	}
 }
 
 func TestUniformAndNoCatchUp(t *testing.T) {

--- a/periodic/periodic_test.go
+++ b/periodic/periodic_test.go
@@ -27,7 +27,8 @@ import (
 
 type Noop struct{}
 
-func (n *Noop) Run(t int) {
+func (n *Noop) Run(t int) (bool, string) {
+	return true, ""
 }
 
 // used for when we don't actually run periodic test/want to initialize
@@ -75,11 +76,12 @@ type TestCount struct {
 	lock  *sync.Mutex
 }
 
-func (c *TestCount) Run(i int) {
+func (c *TestCount) Run(i int) (bool, string) {
 	c.lock.Lock()
 	(*c.count)++
 	c.lock.Unlock()
 	time.Sleep(100 * time.Millisecond)
+	return true, ""
 }
 
 func TestStart(t *testing.T) {
@@ -229,7 +231,7 @@ type testAccessLogger struct {
 	reports int64
 }
 
-func (t *testAccessLogger) Report(thread int, time int64, latency float64) {
+func (t *testAccessLogger) Report(thread int, time int64, latency float64, status bool, details string) {
 	t.Lock()
 	defer t.Unlock()
 	t.reports++

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -61,11 +61,17 @@ func (c *Counter) RecordN(v float64, n int) {
 
 // Avg returns the average.
 func (c *Counter) Avg() float64 {
+	if c.Count == 0 {
+		return 0.
+	}
 	return c.Sum / float64(c.Count)
 }
 
 // StdDev returns the standard deviation.
 func (c *Counter) StdDev() float64 {
+	if c.Count == 0 {
+		return 0.
+	}
 	fC := float64(c.Count)
 	sigma := (c.sumOfSquares - c.Sum*c.Sum/fC) / fC
 	// should never happen but it does

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -34,7 +34,7 @@ func TestCounter(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 	c.Counter.Print(w, "test1c")
-	expected := "test1c : count 0 avg NaN +/- NaN min 0 max 0 sum 0\n"
+	expected := "test1c : count 0 avg 0 +/- 0 min 0 max 0 sum 0\n"
 	c.Print(w, "test1h", []float64{50.0})
 	expected += "test1h : no data\n"
 	*log.LogFileAndLine = false
@@ -118,9 +118,9 @@ func TestTransferCounter(t *testing.T) {
 	expected := `c1 before merge : count 2 avg 15 +/- 5 min 10 max 20 sum 30
 c2 before merge : count 2 avg 85 +/- 5 min 80 max 90 sum 170
 mergedC1C2 : count 4 avg 50 +/- 35.36 min 10 max 90 sum 200
-c2 after merge : count 0 avg NaN +/- NaN min 0 max 0 sum 0
+c2 after merge : count 0 avg 0 +/- 0 min 0 max 0 sum 0
 mergedC2C1 : count 4 avg 50 +/- 35.36 min 10 max 90 sum 200
-c1 should now be empty : count 0 avg NaN +/- NaN min 0 max 0 sum 0
+c1 should now be empty : count 0 avg 0 +/- 0 min 0 max 0 sum 0
 c3 after merge - 1 : count 4 avg 50 +/- 35.36 min 10 max 90 sum 200
 c3 after merge - 2 : count 4 avg 50 +/- 35.36 min 10 max 90 sum 200
 `

--- a/tcprunner/tcprunner.go
+++ b/tcprunner/tcprunner.go
@@ -47,14 +47,16 @@ type RunnerResults struct {
 
 // Run tests tcp request fetching. Main call being run at the target QPS.
 // To be set as the Function in RunnerOptions.
-func (tcpstate *RunnerResults) Run(t int) {
+func (tcpstate *RunnerResults) Run(t int) (bool, string) {
 	log.Debugf("Calling in %d", t)
 	_, err := tcpstate.client.Fetch()
 	if err != nil {
-		tcpstate.RetCodes[err.Error()]++
-	} else {
-		tcpstate.RetCodes[TCPStatusOK]++
+		errStr := err.Error()
+		tcpstate.RetCodes[errStr]++
+		return false, errStr
 	}
+	tcpstate.RetCodes[TCPStatusOK]++
+	return true, TCPStatusOK
 }
 
 // TCPOptions are options to the TCPClient.

--- a/udprunner/udprunner.go
+++ b/udprunner/udprunner.go
@@ -50,14 +50,16 @@ type RunnerResults struct {
 
 // Run tests udp request fetching. Main call being run at the target QPS.
 // To be set as the Function in RunnerOptions.
-func (udpstate *RunnerResults) Run(t int) {
+func (udpstate *RunnerResults) Run(t int) (bool, string) {
 	log.Debugf("Calling in %d", t)
 	_, err := udpstate.client.Fetch()
 	if err != nil {
-		udpstate.RetCodes[err.Error()]++
-	} else {
-		udpstate.RetCodes[UDPStatusOK]++
+		errStr := err.Error()
+		udpstate.RetCodes[errStr]++
+		return false, errStr
 	}
+	udpstate.RetCodes[UDPStatusOK]++
+	return true, UDPStatusOK
 }
 
 // UDPOptions are options to the UDPClient.

--- a/ui/static/js/fortio_chart.js
+++ b/ui/static/js/fortio_chart.js
@@ -70,22 +70,22 @@ let chart = {}
 let overlayChart = {}
 let mchart = {}
 
-function myRound(v, digits = 6) {
+function myRound (v, digits = 6) {
   const p = Math.pow(10, digits)
   return Math.round(v * p) / p
 }
 
-function pad(n) {
+function pad (n) {
   return (n < 10) ? ('0' + n) : n
 }
 
-function formatDate(dStr) {
+function formatDate (dStr) {
   const d = new Date(dStr)
   return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate()) + ' ' +
     pad(d.getHours()) + ':' + pad(d.getMinutes()) + ':' + pad(d.getSeconds())
 }
 
-function makeTitle(res) {
+function makeTitle (res) {
   const title = []
   let firstLine = ''
   if ((typeof res.RunID !== 'undefined') && (res.RunID !== 0)) {
@@ -112,7 +112,7 @@ function makeTitle(res) {
   let errStr = 'no error'
   if (!res.ErrorsDurationHistogram) {
     // Newer simpler calculation when we have the ErrorsDurationHistogram:
-    let statusNotOk = res.ErrorsDurationHistogram.Count
+    const statusNotOk = res.ErrorsDurationHistogram.Count
     if (statusNotOk !== 0) {
       errStr = myRound(100.0 * statusNotOk / total, 2) + '% errors'
     }
@@ -138,7 +138,7 @@ function makeTitle(res) {
   return title
 }
 
-function fortioResultToJsChartData(res) {
+function fortioResultToJsChartData (res) {
   const dataP = [{
     x: 0.0,
     y: 0.0
@@ -197,7 +197,7 @@ function fortioResultToJsChartData(res) {
     prev = endX
   }
   const dataE = []
-  if (res.ErrorsDurationHistogram.Count > 0) {
+  if (res.ErrorsDurationHistogram != null && res.ErrorsDurationHistogram.Count > 0) {
     // TODO: make a function, same as above with dataH->dataE
     prev = 1000.0 * res.ErrorsDurationHistogram.Data[0].Start
     for (let i = 0; i < len; i++) {
@@ -231,20 +231,20 @@ function fortioResultToJsChartData(res) {
   }
 }
 
-function showChart(data) {
+function showChart (data) {
   makeChart(data)
   // Load configuration (min, max, isLogarithmic, ...) from the update form.
   updateChartOptions(chart)
   toggleVisibility()
 }
 
-function toggleVisibility() {
+function toggleVisibility () {
   document.getElementById('running').style.display = 'none'
   document.getElementById('cc1').style.display = 'block'
   document.getElementById('update').style.visibility = 'visible'
 }
 
-function makeOverlayChartTitle(titleA, titleB) {
+function makeOverlayChartTitle (titleA, titleB) {
   // Each string in the array is a separate line
   return [
     'A: ' + titleA[0], titleA[1], // Skip 3rd line.
@@ -253,7 +253,7 @@ function makeOverlayChartTitle(titleA, titleB) {
   ]
 }
 
-function makeOverlayChart(dataA, dataB) {
+function makeOverlayChart (dataA, dataB) {
   const chartEl = document.getElementById('chart1')
   chartEl.style.visibility = 'visible'
   if (Object.keys(overlayChart).length !== 0) {
@@ -329,7 +329,7 @@ function makeOverlayChart(dataA, dataB) {
             labelString: '%'
           }
         },
-          linearYAxe
+        linearYAxe
         ]
       }
     }
@@ -337,7 +337,7 @@ function makeOverlayChart(dataA, dataB) {
   updateChart(overlayChart)
 }
 
-function makeChart(data) {
+function makeChart (data) {
   const chartEl = document.getElementById('chart1')
   chartEl.style.visibility = 'visible'
   if (Object.keys(chart).length === 0) {
@@ -404,7 +404,7 @@ function makeChart(data) {
               labelString: '%'
             }
           },
-            linearYAxe
+          linearYAxe
           ]
         }
       }
@@ -419,7 +419,7 @@ function makeChart(data) {
   }
 }
 
-function getUpdateForm() {
+function getUpdateForm () {
   const form = document.getElementById('updtForm')
   const xMin = form.xmin.value.trim()
   const xMax = form.xmax.value.trim()
@@ -430,7 +430,7 @@ function getUpdateForm() {
   return { xMin, xMax, xIsLogarithmic, yMin, yMax, yIsLogarithmic }
 }
 
-function getSelectedResults() {
+function getSelectedResults () {
   // Undefined if on "graph-only" page
   const select = document.getElementById('files')
   let selectedResults
@@ -446,7 +446,7 @@ function getSelectedResults() {
   return selectedResults
 }
 
-function updateQueryString() {
+function updateQueryString () {
   const location = document.location
   const params = new URLSearchParams(location.search)
   const form = getUpdateForm()
@@ -466,7 +466,7 @@ function updateQueryString() {
   window.history.replaceState({}, '', `${location.pathname}?${params}`)
 }
 
-function updateChartOptions(chart) {
+function updateChartOptions (chart) {
   const form = getUpdateForm()
   const scales = chart.config.options.scales
   const newXMin = parseFloat(form.xMin)
@@ -493,11 +493,11 @@ function updateChartOptions(chart) {
   chart.update()
 }
 
-function objHasProps(obj) {
+function objHasProps (obj) {
   return Object.keys(obj).length > 0
 }
 
-function getCurrentChart() {
+function getCurrentChart () {
   let currentChart
   if (objHasProps(chart)) {
     currentChart = chart
@@ -512,7 +512,7 @@ function getCurrentChart() {
 }
 
 let timeoutID = 0
-function updateChart(chart = getCurrentChart()) {
+function updateChart (chart = getCurrentChart()) {
   updateChartOptions(chart)
   if (timeoutID > 0) {
     clearTimeout(timeoutID)
@@ -520,7 +520,7 @@ function updateChart(chart = getCurrentChart()) {
   timeoutID = setTimeout(updateQueryString, 750)
 }
 
-function multiLabel(res) {
+function multiLabel (res) {
   let l = formatDate(res.StartTime)
   if (res.Labels !== '') {
     l += ' - ' + res.Labels
@@ -528,7 +528,7 @@ function multiLabel(res) {
   return l
 }
 
-function findData(slot, idx, res, p) {
+function findData (slot, idx, res, p) {
   // Not very efficient but there are only a handful of percentiles
   const pA = res.DurationHistogram.Percentiles
   if (!pA) {
@@ -546,7 +546,7 @@ function findData(slot, idx, res, p) {
   // not found, not set
 }
 
-function fortioAddToMultiResult(i, res) {
+function fortioAddToMultiResult (i, res) {
   mchart.data.labels[i] = multiLabel(res)
   mchart.data.datasets[0].data[i] = 1000.0 * res.DurationHistogram.Min
   findData(1, i, res, '50')
@@ -559,7 +559,7 @@ function fortioAddToMultiResult(i, res) {
   mchart.data.datasets[8].data[i] = res.ActualQPS
 }
 
-function endMultiChart(len) {
+function endMultiChart (len) {
   mchart.data.labels = mchart.data.labels.slice(0, len)
   for (let i = 0; i < mchart.data.datasets.length; i++) {
     mchart.data.datasets[i].data = mchart.data.datasets[i].data.slice(0, len)
@@ -567,7 +567,7 @@ function endMultiChart(len) {
   mchart.update()
 }
 
-function deleteOverlayChart() {
+function deleteOverlayChart () {
   if (Object.keys(overlayChart).length === 0) {
     return
   }
@@ -575,7 +575,7 @@ function deleteOverlayChart() {
   overlayChart = {}
 }
 
-function deleteMultiChart() {
+function deleteMultiChart () {
   if (Object.keys(mchart).length === 0) {
     return
   }
@@ -583,7 +583,7 @@ function deleteMultiChart() {
   mchart = {}
 }
 
-function deleteSingleChart() {
+function deleteSingleChart () {
   if (Object.keys(chart).length === 0) {
     return
   }
@@ -591,7 +591,7 @@ function deleteSingleChart() {
   chart = {}
 }
 
-function makeMultiChart() {
+function makeMultiChart () {
   document.getElementById('running').style.display = 'none'
   document.getElementById('update').style.visibility = 'hidden'
   const chartEl = document.getElementById('chart1')
@@ -725,7 +725,7 @@ function makeMultiChart() {
   }
 }
 
-function runTestForDuration(durationInSeconds) {
+function runTestForDuration (durationInSeconds) {
   const progressBar = document.getElementById('progressBar')
   if (durationInSeconds <= 0) {
     // infinite case
@@ -745,7 +745,7 @@ function runTestForDuration(durationInSeconds) {
 
 let lastDuration = ''
 
-function toggleDuration(el) {
+function toggleDuration (el) {
   const d = document.getElementById('duration')
   if (el.checked) {
     lastDuration = d.value
@@ -757,13 +757,13 @@ function toggleDuration(el) {
 
 const customHeaderElement = '<input type="text" name="H" size=40 value="" /> <br />'
 
-function addCustomHeader() {
+function addCustomHeader () {
   const customHeaderElements = document.getElementsByName('H')
   const lastElement = customHeaderElements[customHeaderElements.length - 1]
   lastElement.nextElementSibling.insertAdjacentHTML('afterend', customHeaderElement)
 }
 
-function checkPayload() {
+function checkPayload () {
   const len = document.getElementById('payload').value.length
   // console.log("payload length is ", len)
   if (len > 100) {


### PR DESCRIPTION
- [x] richer access log (with success/failure boolean and details)
- [x] use it in runner results: additional histogram of error cases
- [x] show it in report ui

Looks like this:

<img width="1828" alt="Screen Shot 2022-04-24 at 4 32 03 PM" src="https://user-images.githubusercontent.com/3664595/165001248-33e180d5-fd6b-4389-b73e-79a21e76d5b0.png">

With text output:
```
Starting at 1000 qps with 8 thread(s) [gomax 10] for 3s : 375 calls each (total 3000)
Ended after 3.012998625s : 1811 calls. qps=601.06
Sleep times : count 1803 avg 0.0068899165 +/- 0.001709 min 1.7011e-05 max 0.007993206 sum 12.4225194
Aggregated Function Time : count 1811 avg 0.0062169943 +/- 0.01646 min 0.00010075 max 0.12141675 sum 11.2589767
# range, mid point, percentile, count
>= 0.00010075 <= 0.0002 , 0.000150375 , 31.92, 578
> 0.0002 <= 0.0003 , 0.00025 , 53.40, 389
> 0.0003 <= 0.0004 , 0.00035 , 55.60, 40
> 0.0004 <= 0.0005 , 0.00045 , 68.97, 242
> 0.0005 <= 0.0006 , 0.00055 , 79.79, 196
> 0.0006 <= 0.0007 , 0.00065 , 81.39, 29
> 0.0007 <= 0.0008 , 0.00075 , 81.94, 10
> 0.0008 <= 0.0009 , 0.00085 , 82.33, 7
> 0.0009 <= 0.001 , 0.00095 , 82.55, 4
> 0.001 <= 0.0011 , 0.00105 , 82.72, 3
> 0.0011 <= 0.0012 , 0.00115 , 82.83, 2
> 0.0012 <= 0.0014 , 0.0013 , 83.10, 5
> 0.0014 <= 0.0016 , 0.0015 , 83.21, 2
> 0.002 <= 0.0025 , 0.00225 , 83.38, 3
> 0.005 <= 0.006 , 0.0055 , 87.58, 76
> 0.007 <= 0.008 , 0.0075 , 87.63, 1
> 0.03 <= 0.035 , 0.0325 , 88.68, 19
> 0.035 <= 0.04 , 0.0375 , 94.20, 100
> 0.04 <= 0.045 , 0.0425 , 97.57, 61
> 0.045 <= 0.05 , 0.0475 , 98.18, 11
> 0.05 <= 0.06 , 0.055 , 98.23, 1
> 0.07 <= 0.08 , 0.075 , 99.06, 15
> 0.08 <= 0.09 , 0.085 , 99.56, 9
> 0.1 <= 0.121417 , 0.110708 , 100.00, 8
# target 50% 0.00028419
# target 75% 0.00055574
# target 90% 0.036195
# target 99% 0.07926
# target 99.9% 0.116569
Error cases : count 33 avg 0.0056101022 +/- 0.01298 min 0.000140792 max 0.045081625 sum 0.185133373
# range, mid point, percentile, count
>= 0.000140792 <= 0.0002 , 0.000170396 , 15.15, 5
> 0.0002 <= 0.0003 , 0.00025 , 48.48, 11
> 0.0003 <= 0.0004 , 0.00035 , 57.58, 3
> 0.0004 <= 0.0005 , 0.00045 , 66.67, 3
> 0.0005 <= 0.0006 , 0.00055 , 72.73, 2
> 0.0006 <= 0.0007 , 0.00065 , 78.79, 2
> 0.005 <= 0.006 , 0.0055 , 87.88, 3
> 0.035 <= 0.04 , 0.0375 , 93.94, 2
> 0.04 <= 0.045 , 0.0425 , 96.97, 1
> 0.045 <= 0.0450816 , 0.0450408 , 100.00, 1
# target 50% 0.000316667
# target 75% 0.0006375
# target 90% 0.03675
# target 99% 0.0450547
# target 99.9% 0.0450789
Sockets used: 41 (for perfect keepalive, would be 8)
Uniform: true, Jitter: false
Code 200 : 1778 (98.2 %)
Code 429 : 26 (1.4 %)
Code 503 : 7 (0.4 %)
Response Header Sizes : count 1811 avg 73.633352 +/- 10.03 min 0 max 75 sum 133350
Response Body/Total Sizes : count 1811 avg 75.28106 +/- 2.066 min 75 max 92 sum 136334
Saved result to [data/2022-04-24-163139_4_Fortio.json](http://localhost:8080/fortio/data/2022-04-24-163139_4_Fortio.json) ([graph link](http://localhost:8080/fortio/browse?url=2022-04-24-163139_4_Fortio.json))
All done 1811 calls 6.217 ms avg, 601.1 qps
```

fixes #553