### PR TITLE
fix spurious dns change message when dns isn't changing

### DIFF
--- a/fhttp/http_client.go
+++ b/fhttp/http_client.go
@@ -456,11 +456,10 @@ func NewStdClient(o *HTTPOptions) (*Client, error) {
 			}).DialContext(ctx, network, addr)
 
 			if conn != nil {
-				newRemoteAddress := conn.RemoteAddr().String()
-				if req.RemoteAddr != "" {
-					log.Infof("Standard client IP address changed from %s to %s", req.RemoteAddr, newRemoteAddress)
+				if newRemoteAddress := conn.RemoteAddr().String(); newRemoteAddress != req.RemoteAddr {
+					log.Infof("[%d] Standard client IP address changed from %s to %s", client.id, req.RemoteAddr, newRemoteAddress)
+					req.RemoteAddr = newRemoteAddress
 				}
-				req.RemoteAddr = newRemoteAddress
 				client.socketCount++
 			}
 

--- a/fhttp/http_client.go
+++ b/fhttp/http_client.go
@@ -456,10 +456,12 @@ func NewStdClient(o *HTTPOptions) (*Client, error) {
 			}).DialContext(ctx, network, addr)
 
 			if conn != nil {
-				if newRemoteAddress := conn.RemoteAddr().String(); newRemoteAddress != req.RemoteAddr {
+				newRemoteAddress := conn.RemoteAddr().String()
+				// No change when it wasn't set before (first time) and when the value isn't actually changing either.
+				if req.RemoteAddr != "" && newRemoteAddress != req.RemoteAddr {
 					log.Infof("[%d] Standard client IP address changed from %s to %s", client.id, req.RemoteAddr, newRemoteAddress)
-					req.RemoteAddr = newRemoteAddress
 				}
+				req.RemoteAddr = newRemoteAddress
 				client.socketCount++
 			}
 


### PR DESCRIPTION
also show connection id while at it

fixes #563

manual test:
```
10:30:02 I http_client.go:462> [7] Standard client IP address changed from 10.144.105.0:443 to 10.144.68.177:443
10:30:03 I http_client.go:462> [8] Standard client IP address changed from 10.144.105.0:443 to 10.144.68.177:443
10:30:03 I http_client.go:462> [9] Standard client IP address changed from 10.144.105.0:443 to 10.144.94.186:443
10:30:03 I http_client.go:462> [0] Standard client IP address changed from 10.144.105.0:443 to 10.144.94.186:443
10:30:03 I http_client.go:462> [1] Standard client IP address changed from 10.144.105.0:443 to 10.144.94.186:443
10:30:03 I http_client.go:462> [2] Standard client IP address changed from 10.144.105.0:443 to 10.144.94.186:443
```