### PR TITLE
Round robin dns, option to resolve ipv4/ipv6/both, timeout and other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,9 @@ properly). Can be in the form of host:port, ip:port, port or "disabled" to
 disable the feature. (default "8081")
   -resolve IP
         Resolve host name to this IP
+  -resolve-ip-type type
+        Resolve type: ip4 for ipv4, ip6 for ipv6 only, use ip for both (default
+ip4)
   -runid int
         Optional RunID to add to json result and auto save filename, to match
 server mode

--- a/fhttp/http_client.go
+++ b/fhttp/http_client.go
@@ -676,14 +676,15 @@ func (c *FastClient) connect() net.Conn {
 	c.socketCount++
 	var socket net.Conn
 	var err error
+	d := &net.Dialer{Timeout: c.reqTimeout}
 	if c.https {
-		socket, err = tls.Dial(c.dest.Network(), c.dest.String(), c.tlsConfig)
+		socket, err = tls.DialWithDialer(d, c.dest.Network(), c.dest.String(), c.tlsConfig)
 		if err != nil {
 			log.Errf("[%d] Unable to TLS connect to %v : %v", c.id, c.dest, err)
 			return nil
 		}
 	} else {
-		socket, err = net.Dial(c.dest.Network(), c.dest.String())
+		socket, err = d.Dial(c.dest.Network(), c.dest.String())
 		if err != nil {
 			log.Errf("[%d] Unable to connect to %v : %v", c.id, c.dest, err)
 			return nil

--- a/fnet/network.go
+++ b/fnet/network.go
@@ -60,7 +60,7 @@ var (
 	MaxPayloadSize = 256 * KILOBYTE
 	// Payload that is returned during echo call.
 	Payload []byte
-	// Atomically incremented counter for dns resolution
+	// Atomically incremented counter for dns resolution.
 	dnsRoundRobin uint32
 )
 


### PR DESCRIPTION
fixes #557

```
go run . load -c 15 -n 30 ...

IP addresses distribution:
10.144.94.186:443: 5
10.144.105.0:443: 5
10.144.68.177:443: 5
```

also fixes #567 (only show actual threads for dns) and fixes #458 (option to pick ipv6/v4/both dns resolution) and fixes #568 (connect timeout in fast client)