### PR TITLE
fix fortio version when used as library/module

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,10 @@ name: Release
 
 on:
   push:
-    tags-ignore:
-    - '*test*'
     tags:
-    - '*'
+    # so a vX.Y.Z-test1 doesn't trigger build
+    - 'v*.*.*'
+    - 'v*.*.*-pre*'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,8 @@ on:
   push:
     tags:
     # so a vX.Y.Z-test1 doesn't trigger build
-    - 'v*.*.*'
-    - 'v*.*.*-pre*'
+    - 'v[0-9]+.[0-9]+.[0-9]+'
+    - 'v[0-9]+.[0-9]+.[0-9]+-pre*'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ name: Release
 
 on:
   push:
+    tags-ignore:
+    - '*test*'
     tags:
     - '*'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 
-name: Release
+name: Test Tags
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+
+name: Release
+
+on:
+  push:
+    tags:
+    - 'v[0-9]+.[0-9]+.[0-9]+-test*'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Just a test step
+        run: echo it works

--- a/version/version.go
+++ b/version/version.go
@@ -68,7 +68,7 @@ func FromBuildInfoPath(path string) (short, long, full string) {
 	}
 	var sum string
 	if path == "" || binfo.Main.Path == path { // nolint: nestif
-		fmt.Printf("version: found main path: %q", path)
+		fmt.Printf("version: found main path: %q\n", path)
 		short = binfo.Main.Version
 		// '(devel)' messes up the release-tests paths
 		if short == "(devel)" || short == "" {
@@ -81,7 +81,7 @@ func FromBuildInfoPath(path string) (short, long, full string) {
 		// try to find the right module
 		for _, m := range binfo.Deps {
 			if path == m.Path {
-				fmt.Printf("version: found module path: %q", path)
+				fmt.Printf("version: found module path: %q\n", path)
 				short = m.Version
 				sum = m.Sum
 				break
@@ -97,8 +97,8 @@ func FromBuildInfoPath(path string) (short, long, full string) {
 // depending if we are a module or main.
 func init() { // nolint:gochecknoinits //we do need an init for this
 	version, longVersion, fullVersion = FromBuildInfoPath("fortio.org/fortio")
-	fmt.Printf("fortio/version: called init: %s", longVersion)
+	fmt.Printf("fortio/version: called init: %s\n", longVersion)
 	// testing
 	_, lv, _ := FromBuildInfoPath("")
-	fmt.Printf("fortio/version: called init debug main: %s", lv)
+	fmt.Printf("fortio/version: called init debug main: %s\n", lv)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -79,6 +79,7 @@ func FromBuildInfoPath(path string) (short, long, full string) {
 		sum = binfo.Main.Sum
 	} else {
 		// try to find the right module
+		short = path + " not found in buildinfo"
 		for i, m := range binfo.Deps {
 			if path == m.Path {
 				fmt.Printf("version: found module path: %q\n", path)

--- a/version/version.go
+++ b/version/version.go
@@ -79,13 +79,14 @@ func FromBuildInfoPath(path string) (short, long, full string) {
 		sum = binfo.Main.Sum
 	} else {
 		// try to find the right module
-		for _, m := range binfo.Deps {
+		for i, m := range binfo.Deps {
 			if path == m.Path {
 				fmt.Printf("version: found module path: %q\n", path)
 				short = m.Version
 				sum = m.Sum
 				break
 			}
+			fmt.Printf("%d dep is %s v %s s %s\n", i, m.Path, m.Version, m.Sum)
 		}
 	}
 	long = short + " " + sum + " " + binfo.GoVersion + " " + runtime.GOARCH + " " + runtime.GOOS
@@ -97,8 +98,10 @@ func FromBuildInfoPath(path string) (short, long, full string) {
 // depending if we are a module or main.
 func init() { // nolint:gochecknoinits //we do need an init for this
 	version, longVersion, fullVersion = FromBuildInfoPath("fortio.org/fortio")
-	fmt.Printf("fortio/version: called init: %s\n", longVersion)
+	fmt.Printf("fortio/version: called init           : %s\n", longVersion)
 	// testing
 	_, lv, _ := FromBuildInfoPath("")
 	fmt.Printf("fortio/version: called init debug main: %s\n", lv)
+	_, lv, _ = FromBuildInfoPath("doesnt/exists")
+	fmt.Printf("fortio/version: called init debug all : %s\n", lv)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -71,7 +71,8 @@ func FromBuildInfo() (short, long, full string) {
 	return
 }
 
-// This "burns in" the fortio version.
+// This "burns in" the fortio version. (or not... depending on how this is built/used)
 func init() { // nolint:gochecknoinits //we do need an init for this
 	version, longVersion, fullVersion = FromBuildInfo()
+	fmt.Printf("fortio/version: called init: %s", longVersion)
 }


### PR DESCRIPTION
so we can get
```
proxy version
15:27:00 I proxy_main.go:67> Fortio Proxy 0.8.2-test-2 h1:1bWYUQhVjNIqnx6M4cpGumojUalUPmWxd+xhJEqyKic= go1.18.2 arm64 darwin starting
Fortio 1.30.1-test-7 https redirector server listening on tcp [::]:80
```

instead of the fortio version being the proxy version