### PR TITLE
add configurable `-dns-method` to resolve dns

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ You can install from source:
 The [releases](https://github.com/fortio/fortio/releases) page has binaries for many OS/architecture combinations (see assets).
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.30.1/fortio-linux_amd64-1.30.1.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.31.0/fortio-linux_amd64-1.31.0.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.30.1/fortio_1.30.1_amd64.deb
-dpkg -i fortio_1.30.1_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.31.0/fortio_1.31.0_amd64.deb
+dpkg -i fortio_1.31.0_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.30.1/fortio-1.30.1-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.31.0/fortio-1.31.0-1.x86_64.rpm
 # and more, see assets in release page
 ```
 
@@ -66,7 +66,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.30.1/fortio_win_1.30.1.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.31.0/fortio_win_1.31.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -114,7 +114,7 @@ Full list of command line flags (`fortio help`):
 <details>
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
-Φορτίο 1.30.1 usage:
+Φορτίο 1.31.0 usage:
 where command is one of: load (load testing), server (starts ui, http-echo,
  redirect, proxies, tcp-echo and grpc ping servers), tcp-echo (only the tcp-echo
  server), report (report only UI server), redirect (only the redirect server),
@@ -169,6 +169,10 @@ from GET to POST.
 output to stdout in curl mode. now stderr by default.
   -data-dir Directory
         Directory where JSON results are stored/read (default ".")
+  -dns-method method
+        When a name resolves to multiple ip, which method to pick: cached-rr
+for cached round robin, rnd for random, first for first answer (pre 1.30
+behavior), rr for round robin. (default cached-rr)
   -echo-debug-path URI
         http echo server URI for debug, empty turns off that part (more secure)
 (default "/debug")

--- a/fnet/network.go
+++ b/fnet/network.go
@@ -319,8 +319,8 @@ func Resolve(host string, port string) (*net.TCPAddr, error) {
 	return &net.TCPAddr{IP: addr.IP, Port: addr.Port}, nil
 }
 
-// Clear DNS cache for cached-rr resolution mode. For instance in case of error, to force re-resolving
-// to potentially changed IPs.
+// ClearResolveCache clears the DNS cache for cached-rr resolution mode.
+// For instance in case of error, to force re-resolving to potentially changed IPs.
 func ClearResolveCache() {
 	dnsMutex.Lock()
 	dnsHost = ""
@@ -332,7 +332,7 @@ func ClearResolveCache() {
 // nil in case of errors. works for both "tcp" and "udp" proto.
 // Limit which address type is returned using `resolve-ip` ip4/ip6/ip (for both, default).
 // If the same host is requested, and it has more than 1 IP, returned value will first,
-// random or roundrobin over the ips depending on the -dns-method flag value.
+// random or roundrobin or cached roundrobin over the ips depending on the -dns-method flag value.
 func ResolveByProto(host string, port string, proto string) (*HostPortAddr, error) {
 	log.Debugf("Resolve() called with host=%s port=%s proto=%s", host, port, proto)
 	dest := &HostPortAddr{}

--- a/fnet/network_test.go
+++ b/fnet/network_test.go
@@ -452,8 +452,11 @@ func TestResolveBW(t *testing.T) {
 
 // This test relies on google answer 2 ips, first ipv4, second ipv6.
 // if that's not the case anymore or in the testing environment, this will fail.
-func TestClearResolveCache(t *testing.T) {
-	fnet.FlagResolveMethod.Set("first")
+func TestDNSMethods(t *testing.T) {
+	err := fnet.FlagResolveMethod.Set("first")
+	if err != nil {
+		t.Errorf("unexpected error setting method to first: %v", err)
+	}
 	fnet.FlagResolveIPType.Set("ip4")
 	addr4, err := fnet.Resolve("www.google.com", "80")
 	if err != nil {
@@ -516,6 +519,35 @@ func TestClearResolveCache(t *testing.T) {
 	}
 	if addrAfterCache.String() != addrFirst.String() {
 		t.Errorf("after cache clear we expect to get first %v, we got %v", addrFirst, addrAfterCache)
+	}
+	// few extra resolve just for coverage
+	err = fnet.FlagResolveMethod.Set("rnd")
+	if err != nil {
+		t.Errorf("unexpected error setting method to rnd: %v", err)
+	}
+	_, err = fnet.Resolve("www.google.com", "80")
+	if err != nil {
+		t.Errorf("unexpected error in rnd mode for resolve of google: %v", err)
+	}
+	fnet.FlagResolveMethod.Set("rr")
+	if err != nil {
+		t.Errorf("unexpected error setting method to rr: %v", err)
+	}
+	_, err = fnet.Resolve("www.google.com", "80")
+	if err != nil {
+		t.Errorf("unexpected error in rr mode for resolve of google: %v", err)
+	}
+	// put it back to default
+	err = fnet.FlagResolveMethod.Set("cached-rr")
+	if err != nil {
+		t.Errorf("unexpected error setting method to cached-rr: %v", err)
+	}
+}
+
+func TestBadValueForDNSMethod(t *testing.T) {
+	err := fnet.FlagResolveMethod.Set("foo")
+	if err == nil {
+		t.Errorf("passing foo to FlagResolveMethod.Set should error out/fail validation")
 	}
 }
 

--- a/fnet/network_test.go
+++ b/fnet/network_test.go
@@ -486,7 +486,10 @@ func TestDNSMethods(t *testing.T) {
 	if addrFirst.String() != addrSecond.String() {
 		log.Warnf("first ip %v not == second %v in first mode", addrFirst, addrSecond)
 	}
-	fnet.FlagResolveMethod.Set("cached-rr")
+	err = fnet.FlagResolveMethod.Set("cached-rr")
+	if err != nil {
+		t.Fatalf("error setting back cached-rr mode: %v", err)
+	}
 	addrThird, err := fnet.Resolve("www.google.com", "80")
 	if err != nil {
 		t.Errorf("error ip any resolving (3) google: %v", err)
@@ -504,13 +507,13 @@ func TestDNSMethods(t *testing.T) {
 	if addrFourth.String() == addrThird.String() {
 		t.Errorf("in cached rr mode, 2nd call %v shouldn't be same as first %v for google", addrFourth, addrThird)
 	}
-	// back to first (rr)
+	// back to first (rr) [only if there are only 2 ips]
 	addrFifth, err := fnet.Resolve("www.google.com", "80")
 	if err != nil {
 		t.Errorf("error ip any resolving (5) google: %v", err)
 	}
 	if addrThird.String() != addrFifth.String() {
-		t.Errorf("third cached ip %v not == back to first %v in cached-rr mode", addrFifth, addrThird)
+		log.Warnf("third cached ip %v not == back to first %v in cached-rr mode (if only 2 ips)", addrFifth, addrThird)
 	}
 	// clear cache we'll get first again (if we don't get a completely different one that is)
 	fnet.ClearResolveCache()

--- a/fnet/network_test.go
+++ b/fnet/network_test.go
@@ -476,14 +476,15 @@ func TestDNSMethods(t *testing.T) {
 		t.Errorf("error ip any resolving google: %v", err)
 	}
 	if addrFirst.String() != addr4.String() {
-		t.Errorf("first ip %v not ipv4 %v", addrFirst, addr4)
+		// dns might change when not in cached mode
+		log.Warnf("first ip %v not ipv4 %v", addrFirst, addr4)
 	}
 	addrSecond, err := fnet.Resolve("www.google.com", "80")
 	if err != nil {
 		t.Errorf("error ip any resolving (2) google: %v", err)
 	}
 	if addrFirst.String() != addrSecond.String() {
-		t.Errorf("first ip %v not == second %v in first mode", addrFirst, addrSecond)
+		log.Warnf("first ip %v not == second %v in first mode", addrFirst, addrSecond)
 	}
 	fnet.FlagResolveMethod.Set("cached-rr")
 	addrThird, err := fnet.Resolve("www.google.com", "80")
@@ -491,22 +492,25 @@ func TestDNSMethods(t *testing.T) {
 		t.Errorf("error ip any resolving (3) google: %v", err)
 	}
 	if addrFirst.String() != addrThird.String() {
-		t.Errorf("first cached ip %v not == first %v in cached-rr mode", addrThird, addrFirst)
+		log.Warnf("first cached ip %v not == first %v in cached-rr mode", addrThird, addrFirst)
 	}
 	addrFourth, err := fnet.Resolve("www.google.com", "80")
 	if err != nil {
 		t.Errorf("error ip any resolving (4) google: %v", err)
 	}
 	if addrFourth.String() != addr6.String() {
-		t.Errorf("second cached ip %v not == ipv6 %v in cached-rr mode", addrFourth, addr6)
+		log.Warnf("second cached ip %v not == ipv6 %v in cached-rr mode", addrFourth, addr6)
+	}
+	if addrFourth.String() == addrThird.String() {
+		t.Errorf("in cached rr mode, 2nd call %v shouldn't be same as first %v for google", addrFourth, addrThird)
 	}
 	// back to first (rr)
 	addrFifth, err := fnet.Resolve("www.google.com", "80")
 	if err != nil {
 		t.Errorf("error ip any resolving (5) google: %v", err)
 	}
-	if addrFirst.String() != addrFifth.String() {
-		t.Errorf("third cached ip %v not == back to first %v in cached-rr mode", addrFifth, addrFirst)
+	if addrThird.String() != addrFifth.String() {
+		t.Errorf("third cached ip %v not == back to first %v in cached-rr mode", addrFifth, addrThird)
 	}
 	// clear cache we'll get first again (if we don't get a completely different one that is)
 	fnet.ClearResolveCache()
@@ -514,11 +518,11 @@ func TestDNSMethods(t *testing.T) {
 	if err != nil {
 		t.Errorf("error ip any resolving (6) google: %v", err)
 	}
-	if addrAfterCache.String() == addr6.String() {
-		t.Errorf("cache clear failure, we still got 2nd ip (v6): %v", addrAfterCache)
+	if addrAfterCache.String() == addrFourth.String() {
+		t.Errorf("cache clear failure, we still got 2nd ip: %v", addrAfterCache)
 	}
-	if addrAfterCache.String() != addrFirst.String() {
-		t.Errorf("after cache clear we expect to get first %v, we got %v", addrFirst, addrAfterCache)
+	if addrAfterCache.String() != addrThird.String() {
+		log.Warnf("after cache clear we expect to get first %v, we got %v", addrThird, addrAfterCache)
 	}
 	// few extra resolve just for coverage
 	err = fnet.FlagResolveMethod.Set("rnd")

--- a/fnet/network_test.go
+++ b/fnet/network_test.go
@@ -549,6 +549,7 @@ func TestDNSMethods(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error setting method to cached-rr: %v", err)
 	}
+	fnet.FlagResolveIPType.Set("ip4")
 }
 
 func TestBadValueForDNSMethod(t *testing.T) {


### PR DESCRIPTION
 with the default being cached round robin (`cached-rr`) to ensure as balanced as possible ip (if -c is multiple of the # of ips returned for the target

also usable `rnd` for a random address, `first` for the first one, `rr` for the previously implemented round robin