### PR TITLE
dns cache lock fix, tls grpc test restoration, bug fix for -sync error case and increased timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/fortio/fortio.svg)](https://hub.docker.com/r/fortio/fortio)
 <img src="./ui/static/img/fortio-logo-gradient-no-bg.svg" height=109 width=167 align=right />
 
-Fortio (Φορτίο) started as, and is, [Istio](https://istio.io/)'s load testing tool and now graduated to be its own project.
+Fortio (Φορτίο) started as, and is, [Istio](https://istio.io/)'s load testing tool and later (2018) graduated to be its own project.
 
 Fortio is also used by, among others, [Meshery](https://docs.meshery.io/extensibility/load-generators)
 
@@ -20,7 +20,7 @@ It can run for a set duration, for a fixed number of calls, or until interrupted
 
 The name fortio comes from greek [φορτίο](https://fortio.org/fortio.mp3) which means load/burden.
 
-Fortio is a fast, small (3Mb docker image, minimal dependencies), reusable, embeddable go library as well as a command line tool and server process,
+Fortio is a fast, small (4Mb docker image, minimal dependencies), reusable, embeddable go library as well as a command line tool and server process,
 the server includes a simple web UI and REST API to trigger run and see graphical representation of the results (both a single latency graph and a multiple results comparative min, max, avg, qps and percentiles graphs).
 
 Fortio also includes a set of server side features (similar to httpbin) to help debugging and testing: request echo back including headers, adding latency or error codes with a probability distribution, tcp echoing, tcp proxying, http fan out/scatter and gather proxy server, GRPC echo/health in addition to http, etc...
@@ -30,6 +30,8 @@ and when bugs are found they are fixed quickly, so after 1 year of development a
 
 Fortio components can be used a library even for unrelated projects, for instance the `log`, `stats`, or `fhttp` utilities both client and server.
 As well as the newly integrated [Dynamic Flags](dflag/) support (greatly inspired/imported initially from https://github.com/mwitkow/go-flagz)
+
+If you want to connect to fortio using https and fortio to provide real TLS certificates, or to multiplex grpc and regular http behind a single port, check out [Fortio Proxy](https://github.com/fortio/proxy#fortio-proxy)
 
 ## Installation
 
@@ -50,13 +52,13 @@ You can install from source:
 The [releases](https://github.com/fortio/fortio/releases) page has binaries for many OS/architecture combinations (see assets).
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.31.0/fortio-linux_amd64-1.31.0.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.31.1/fortio-linux_amd64-1.31.1.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.31.0/fortio_1.31.0_amd64.deb
-dpkg -i fortio_1.31.0_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.31.1/fortio_1.31.1_amd64.deb
+dpkg -i fortio_1.31.1_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.31.0/fortio-1.31.0-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.31.1/fortio-1.31.1-1.x86_64.rpm
 # and more, see assets in release page
 ```
 
@@ -66,7 +68,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.31.0/fortio_win_1.31.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.31.1/fortio_win_1.31.1.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -114,7 +116,7 @@ Full list of command line flags (`fortio help`):
 <details>
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
-Φορτίο 1.31.0 usage:
+Φορτίο 1.31.1 usage:
 where command is one of: load (load testing), server (starts ui, http-echo,
  redirect, proxies, tcp-echo and grpc ping servers), tcp-echo (only the tcp-echo
  server), report (report only UI server), redirect (only the redirect server),

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ You can install from source:
 The [releases](https://github.com/fortio/fortio/releases) page has binaries for many OS/architecture combinations (see assets).
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.31.1/fortio-linux_amd64-1.31.1.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.32.0/fortio-linux_amd64-1.32.0.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.31.1/fortio_1.31.1_amd64.deb
-dpkg -i fortio_1.31.1_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.32.0/fortio_1.32.0_amd64.deb
+dpkg -i fortio_1.32.0_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.31.1/fortio-1.31.1-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.32.0/fortio-1.32.0-1.x86_64.rpm
 # and more, see assets in release page
 ```
 
@@ -68,7 +68,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.31.1/fortio_win_1.31.1.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.32.0/fortio_win_1.32.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -116,7 +116,7 @@ Full list of command line flags (`fortio help`):
 <details>
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
-Φορτίο 1.31.1 usage:
+Φορτίο 1.32.0 usage:
 where command is one of: load (load testing), server (starts ui, http-echo,
  redirect, proxies, tcp-echo and grpc ping servers), tcp-echo (only the tcp-echo
  server), report (report only UI server), redirect (only the redirect server),

--- a/README.md
+++ b/README.md
@@ -593,12 +593,17 @@ RTT histogram usec : count 3 avg 501.45233 +/- 94.7 min 371.828 max 595.441 sum 
 `grpcping` can connect to a non-Fortio TLS server by prefacing the destination with `https://`:
 
 ```Shell
-$ fortio grpcping https://fortio.istio.io
-11:07:55 I grpcrunner.go:275> stripping https scheme. grpc destination: fortio.istio.io. grpc port: 443
-Clock skew histogram usec : count 1 avg 12329.795 +/- 0 min 12329.795 max 12329.795 sum 12329.795
+$ fortio grpcping https://grpc.fortio.org
+13:48:20 I grpcrunner.go:276> stripping https scheme. grpc destination: grpc.fortio.org. grpc port: 443
+13:48:26 I pingsrv.go:152> Ping RTT 63101562 (avg of 63577000, 63192688, 62535000 ns) clock skew 32021375
+Clock skew histogram usec : count 1 avg 32021.375 +/- 0 min 32021.375 max 32021.375 sum 32021.375
 # range, mid point, percentile, count
->= 12329.8 <= 12329.8 , 12329.8 , 100.00, 1
-# target 50% 12329.8
+>= 32021.4 <= 32021.4 , 32021.4 , 100.00, 1
+# target 50% 32021.4
+RTT histogram usec : count 3 avg 63101.563 +/- 430.2 min 62535 max 63577 sum 189304.688
+# range, mid point, percentile, count
+>= 62535 <= 63577 , 63056 , 100.00, 3
+# target 50% 62795.5
 ```
 
 ### Simple load test
@@ -942,7 +947,7 @@ body:
 If you have json files saved from running the full UI or downloaded, using the `-sync` option, from an amazon or google cloud storage bucket or from a peer fortio server (to synchronize from a peer fortio, use `http://`_peer_`:8080/data/index.tsv` as the sync URL). You can then serve just the reports:
 
 ```Shell
-$ fortio report -sync-interval 15m -sync http://storage.googleapis.com:443/fortio-data?prefix=fortio.istio.io/
+$ fortio report -sync-interval 15m -sync "https://storage.googleapis.com/fortio-data?prefix=fortio.istio.io/"
 Browse only UI starting - visit:
 http://localhost:8080/
 Https redirector running on :8081

--- a/bincommon/commonflags.go
+++ b/bincommon/commonflags.go
@@ -125,7 +125,7 @@ func SharedMain(usage func(io.Writer, ...interface{})) {
 			// so `fortio version -s` is the short version; everything else is long/full
 			fmt.Println(version.Short())
 		} else {
-			fmt.Println(version.Full())
+			fmt.Print(version.Full())
 		}
 		os.Exit(0)
 	}

--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@
 #export DEB_BUILD_OPTIONS=--no-parallel
 
 # debian build farms don't have internet access so some of our grpc tests against
-# fortio.istio.io can't work, so disabling tests by default
+# grpc.fortio.org can't work, so disabling tests by default
 
 ifndef FORTIO_SKIP_TESTS
 export FORTIO_SKIP_TESTS=Y
@@ -12,4 +12,3 @@ endif
 
 %:
 	dh $@
-

--- a/fgrpc/grpcrunner_test.go
+++ b/fgrpc/grpcrunner_test.go
@@ -88,7 +88,6 @@ func TestGRPCRunner(t *testing.T) {
 			},
 			expect: false,
 		},
-		/* re-enable once we have a replacement / we have demo.fortio.org running https
 		{
 			name: "valid secure runner using nil credentials to Internet https server",
 			runnerOpts: GRPCRunnerOptions{
@@ -99,33 +98,25 @@ func TestGRPCRunner(t *testing.T) {
 		{
 			name: "valid secure runner using nil credentials to Internet https server, default https port, trailing slash",
 			runnerOpts: GRPCRunnerOptions{
-				Destination: "https://fortio.istio.io/",
+				Destination: "https://grpc.fortio.org/",
 			},
 			expect: true,
 		},
 		{
 			name: "invalid secure runner to insecure server",
 			runnerOpts: GRPCRunnerOptions{
-				Destination: "fortio.istio.io:443",
+				Destination: "grpc.fortio.org:443",
 			},
 			expect: false,
 		},
 		{
 			name: "invalid secure runner using test cert to https prefix Internet server",
 			runnerOpts: GRPCRunnerOptions{
-				Destination: "https://fortio.istio.io:443",
-				CACert:      caCrt,
+				Destination: "https://grpc.fortio.org:443",
+				TLSOptions:  fhttp.TLSOptions{CACert: caCrt},
 			},
 			expect: false,
 		},
-		{
-			name: "invalid secure runner using test cert to no prefix Internet server",
-			runnerOpts: GRPCRunnerOptions{
-				Destination: "fortio.istio.io:443",
-			},
-			expect: false,
-		},
-		*/
 		{
 			name: "invalid name in secure runner cert",
 			runnerOpts: GRPCRunnerOptions{
@@ -265,28 +256,26 @@ func TestGRPCRunnerWithError(t *testing.T) {
 				CertOverride: "invalidName",
 			},
 		},
-		/* re-enable once we get replacement
 		{
 			name: "valid runner using nil credentials to Internet https server",
 			runnerOpts: GRPCRunnerOptions{
-				Destination: "https://fortio.istio.io/",
+				Destination: "https://grpc.fortio.org/",
 			},
 		},
 		{
 			name: "invalid runner using test cert to https prefix Internet server",
 			runnerOpts: GRPCRunnerOptions{
-				Destination: "https://fortio.istio.io/",
-				CACert:      caCrt,
+				Destination: "https://grpc.fortio.org/",
+				TLSOptions:  fhttp.TLSOptions{CACert: caCrt},
 			},
 		},
 		{
 			name: "invalid runner using test cert to no prefix Internet server",
 			runnerOpts: GRPCRunnerOptions{
-				Destination: "fortio.istio.io:443",
-				CACert:      caCrt,
+				Destination: "grpc.fortio.org:443",
+				TLSOptions:  fhttp.TLSOptions{CACert: caCrt},
 			},
 		},
-		*/
 	}
 	for _, test := range tests {
 		test.runnerOpts.Service = "svc2"

--- a/fgrpc/pingsrv_test.go
+++ b/fgrpc/pingsrv_test.go
@@ -32,6 +32,7 @@ func init() {
 	log.SetLogLevel(log.Debug)
 }
 
+//nolint: gocognit
 func TestPingServer(t *testing.T) {
 	TLSSecure := &fhttp.TLSOptions{CACert: caCrt, Insecure: false}
 	TLSSecureMissingCert := &fhttp.TLSOptions{Insecure: false}

--- a/fgrpc/pingsrv_test.go
+++ b/fgrpc/pingsrv_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"fortio.org/fortio/fhttp"
+	"fortio.org/fortio/fnet"
 	"fortio.org/fortio/log"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -36,6 +37,7 @@ func TestPingServer(t *testing.T) {
 	TLSSecureMissingCert := &fhttp.TLSOptions{Insecure: false}
 	TLSSecureBadCert := &fhttp.TLSOptions{CACert: failCrt, Insecure: true}
 	TLSInsecure := &fhttp.TLSOptions{Insecure: true}
+	TLSInternet := &fhttp.TLSOptions{}
 	iPort := PingServerTCP("0", "", "", "foo", 0)
 	iAddr := fmt.Sprintf("localhost:%d", iPort)
 	t.Logf("insecure grpc ping server running, will connect to %s", iAddr)
@@ -47,12 +49,10 @@ func TestPingServer(t *testing.T) {
 	if err != nil || latency < delay.Seconds() || latency > 10.*delay.Seconds() {
 		t.Errorf("Unexpected result %f, %v with ping calls and delay of %v", latency, err, delay)
 	}
-	/* re-enable once we get https://demo.fortio.org/
-	if latency, err := PingClientCall(fnet.PrefixHTTPS+"fortio.istio.io:443", "", 7,
-		"test payload", 0); err != nil || latency <= 0 {
+	if latency, err := PingClientCall(fnet.PrefixHTTPS+"grpc.fortio.org:443", 7,
+		"test payload", 0, TLSInternet); err != nil || latency <= 0 {
 		t.Errorf("Unexpected result %f, %v with ping calls", latency, err)
 	}
-	*/
 	if latency, err := PingClientCall(sAddr, 7, "test payload", 0, TLSSecure); err != nil || latency <= 0 {
 		t.Errorf("Unexpected result %f, %v with ping calls", latency, err)
 	}
@@ -78,11 +78,9 @@ func TestPingServer(t *testing.T) {
 	if r, err := GrpcHealthCheck(sAddr, "", 1, TLSSecure); err != nil || (*r)[serving] != 1 {
 		t.Errorf("Unexpected result %+v, %v with empty service health check", r, err)
 	}
-	/* re-enable once we get https://demo.fortio.org/
-	if r, err := GrpcHealthCheck(fnet.PrefixHTTPS+"fortio.istio.io:443", "", "", 1); err != nil || (*r)[serving] != 1 {
+	if r, err := GrpcHealthCheck(fnet.PrefixHTTPS+"grpc.fortio.org:443", "", 1, TLSInternet); err != nil || (*r)[serving] != 1 {
 		t.Errorf("Unexpected result %+v, %v with empty service health check", r, err)
 	}
-	*/
 	if r, err := GrpcHealthCheck(iAddr, "foo", 3, TLSInsecure); err != nil || (*r)[serving] != 3 {
 		t.Errorf("Unexpected result %+v, %v with health check for same service as started (foo)", r, err)
 	}

--- a/fhttp/http_server.go
+++ b/fhttp/http_server.go
@@ -502,14 +502,16 @@ func RedirectToHTTPS(port string) net.Addr {
 
 // LogRequest logs the incoming request, including headers when loglevel is verbose.
 func LogRequest(r *http.Request, msg string) {
-	log.Infof("%s: %v %v %v %v (%s) %s %q", msg, r.Method, r.URL, r.Proto, r.RemoteAddr,
-		r.Header.Get("X-Forwarded-Proto"), r.Header.Get("X-Forwarded-For"), r.Header.Get("User-Agent"))
+	if log.Log(log.Info) {
+		log.Printf("%s: %v %v %v %v (%s) %s %q", msg, r.Method, r.URL, r.Proto, r.RemoteAddr,
+			r.Header.Get("X-Forwarded-Proto"), r.Header.Get("X-Forwarded-For"), r.Header.Get("User-Agent"))
+	}
 	if log.LogVerbose() {
 		// Host is removed from headers map and put separately
-		log.LogVf("Header Host: %v", r.Host)
+		log.Printf("Header Host: %v", r.Host)
 		for name, headers := range r.Header {
 			for _, h := range headers {
-				log.LogVf("Header %v: %v\n", name, h)
+				log.Printf("Header %v: %v\n", name, h)
 			}
 		}
 	}

--- a/fnet/network.go
+++ b/fnet/network.go
@@ -148,7 +148,7 @@ func Listen(name string, port string) (net.Listener, net.Addr) {
 	}
 	lAddr := listener.Addr()
 	if len(name) > 0 {
-		fmt.Printf("Fortio %s %s server listening on %s %s\n", version.Short(), name, sockType, lAddr)
+		log.Printf("Fortio %s %s server listening on %s %s\n", version.Short(), name, sockType, lAddr)
 	}
 	return listener, lAddr
 }
@@ -167,7 +167,7 @@ func UDPListen(name string, port string) (*net.UDPConn, net.Addr) {
 		return nil, nil
 	}
 	if len(name) > 0 {
-		fmt.Printf("Fortio %s %s server listening on udp %s\n", version.Short(), name, udpconn.LocalAddr())
+		log.Printf("Fortio %s %s server listening on udp %s\n", version.Short(), name, udpconn.LocalAddr())
 	}
 	return udpconn, udpconn.LocalAddr()
 }

--- a/fnet/network_test.go
+++ b/fnet/network_test.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -549,6 +550,23 @@ func TestDNSMethods(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error setting method to cached-rr: %v", err)
 	}
+	fnet.FlagResolveIPType.Set("ip4")
+}
+
+func TestDNSCacheConcurrency(t *testing.T) {
+	// Test isn't actually testing unless you use the debugger but coverage shows the extra if
+	// does happen.
+	fnet.FlagResolveIPType.Set("ip")
+	var wg sync.WaitGroup
+	n := 20
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			fnet.Resolve("localhost", "80")
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 	fnet.FlagResolveIPType.Set("ip4")
 }
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -53,7 +53,8 @@ var (
 
 // SetFlagDefaultsForClientTools changes the default value of -logprefix and -logcaller
 // to make output without caller and prefix, a default more suitable for command line tools (like dnsping).
-// Needs to be called before flag.Parse().
+// Needs to be called before flag.Parse(). Caller could also use log.Printf instead of changing this
+// if not wanting to use levels.
 func SetFlagDefaultsForClientTools() {
 	lcf := flag.Lookup("logcaller")
 	lcf.DefValue = "false"

--- a/log/logger.go
+++ b/log/logger.go
@@ -191,6 +191,11 @@ func logPrintf(lvl Level, format string, rest ...interface{}) {
 	}
 }
 
+// Printf forwards to the underlying go logger to print (with only timestamp prefixing).
+func Printf(format string, rest ...interface{}) {
+	log.Printf(format, rest...)
+}
+
 // SetOutput sets the output to a different writer (forwards to system logger).
 func SetOutput(w io.Writer) {
 	log.SetOutput(w)

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -107,6 +107,8 @@ func TestLogger1(t *testing.T) {
 	expected += "I Log level is now 5 Critical (was 0 Debug)\n"
 	Critf("testing crit %d", i) // should show
 	expected += "C testing crit 7\n"
+	Printf("Printf should always show n=%d", 8)
+	expected += "Printf should always show n=8\n"
 	_ = w.Flush()
 	actual := b.String()
 	if actual != expected {

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -966,16 +966,16 @@ func Serve(baseurl, port, debugpath, uipath, datadir string, percentileList []fl
 				datadir = dataDir
 			}
 		}
-		fmt.Println("Data directory is", datadir)
+		log.Printf("Data directory is %s", datadir)
 	}
 	urlHostPort = fnet.NormalizeHostPort(port, addr)
-	uiMsg := "UI started - visit:\n"
+	uiMsg := "\t UI started - visit:\n\t "
 	if strings.Contains(urlHostPort, "-unix-socket=") {
 		uiMsg += fmt.Sprintf("fortio curl %s http://localhost%s", urlHostPort, uiPath)
 	} else {
 		uiMsg += fmt.Sprintf("http://%s%s", urlHostPort, uiPath)
 		if strings.Contains(urlHostPort, "localhost") {
-			uiMsg += "\n(or any host/ip reachable on this server)"
+			uiMsg += "\n\t (or any host/ip reachable on this server)"
 		}
 	}
 	fmt.Println(uiMsg)


### PR DESCRIPTION
initial code was incorrect because more than one thread could think they are the first one and reset each others state/cache

now with retest we ensure exactly one will set the state and everyone else will use it in the right order guaranteeing if you have connections = n*number_of_ips_returned by first one to get the 2nd lock we will get exactly n of each in use.

Also in this MR:
- grpc tls test reinstated now that we have grpc.fortio.org with TLS (thanks to https://github.com/fortio/proxy)
- bug fix and doc update for -sync error case; increased timeout so fetching tsv works better.
- improvement to logger `fhttp.LogRequest` and new `log.Printf` like log.Info without file and line (used in proxy)