### PR TITLE
removing testify dependency

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,4 @@ coverage:
   round: nearest       # how coverage is rounded: down/up/nearest
   ignore:              # files and folders that will be removed during processing
     - "**.pb.go"
+    - "dflag/test_utils.go"

--- a/dflag/checksum_test.go
+++ b/dflag/checksum_test.go
@@ -9,8 +9,11 @@ import (
 	"time"
 
 	"fortio.org/fortio/dflag"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+)
+
+var (
+	assert  = dflag.Testify{}
+	require = assert
 )
 
 func TestChecksumFlagSet_Differs(t *testing.T) {

--- a/dflag/configmap/updater_test.go
+++ b/dflag/configmap/updater_test.go
@@ -100,7 +100,7 @@ func (s *updaterTestSuite) TestSetupFunction() {
 func (s *updaterTestSuite) TestInitializeSetsValues() {
 	require.NoError(s.T(), s.updater.Initialize(), "the updater initialize should not return errors on good flags")
 	assert.EqualValues(s.T(), *s.staticInt, 1234, "staticInt should be some_int from first directory")
-	assert.EqualValues(s.T(), s.dynInt.Get(), 10001, "staticInt should be some_int from first directory")
+	assert.EqualValues(s.T(), s.dynInt.Get(), int64(10001), "staticInt should be some_int from first directory")
 }
 
 func (s *updaterTestSuite) TestDynamicUpdatesPropagate() {
@@ -108,7 +108,7 @@ func (s *updaterTestSuite) TestDynamicUpdatesPropagate() {
 	require.NoError(s.T(), s.updater.Start(), "updater start should not return an error")
 	s.linkDataDirTo(secondGoodDir)
 	eventually(s.T(), 1*time.Second,
-		assert.ObjectsAreEqualValues, 20002,
+		assert.ObjectsAreEqualValues, int64(20002),
 		func() interface{} { return s.dynInt.Get() },
 		"some_dynint value should change to the value from secondGoodDir")
 }

--- a/dflag/configmap/updater_test.go
+++ b/dflag/configmap/updater_test.go
@@ -17,7 +17,6 @@ import (
 
 	"fortio.org/fortio/dflag"
 	"fortio.org/fortio/dflag/configmap"
-	"github.com/stretchr/testify/suite"
 )
 
 const (
@@ -29,11 +28,11 @@ const (
 var (
 	assert  = dflag.Testify{}
 	require = assert
+	suite   = assert
 )
 
 type updaterTestSuite struct {
-	suite.Suite
-
+	dflag.TestSuite
 	tempDir string
 
 	flagSet   *flag.FlagSet

--- a/dflag/configmap/updater_test.go
+++ b/dflag/configmap/updater_test.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -65,7 +64,7 @@ func (s *updaterTestSuite) TearDownTest() {
 }
 
 func (s *updaterTestSuite) copyTestDataToDir() {
-	copyCmd := exec.Command("cp", "--archive", "testdata", s.tempDir)
+	copyCmd := exec.Command("cp", "-a", "testdata", s.tempDir)
 	require.NoError(s.T(), copyCmd.Run(), "copying testdata directory to tempdir must not fail")
 	// We are storing file testdata/9989_09_09_07_32_32.099817316 and renaming it to testdata/..9989_09_09_07_32_32.099817316,
 	// because go modules don't allow repos with files with .. in their filename. See https://github.com/golang/go/issues/27299.
@@ -77,7 +76,7 @@ func (s *updaterTestSuite) copyTestDataToDir() {
 }
 
 func (s *updaterTestSuite) linkDataDirTo(newDataDir string) {
-	copyCmd := exec.Command("ln", "--symbolic", "--no-dereference", "--force",
+	copyCmd := exec.Command("ln", "-s", "-n", "-f",
 		path.Join(s.tempDir, "testdata", newDataDir),
 		path.Join(s.tempDir, "testdata", "..data"))
 	require.NoError(s.T(), copyCmd.Run(), "relinking ..data in tempdir tempdir must not fail")
@@ -113,9 +112,6 @@ func (s *updaterTestSuite) TestDynamicUpdatesPropagate() {
 }
 
 func TestUpdaterSuite(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skipf("Not running on linux (%v), skipping configmap tests", runtime.GOOS)
-	}
 	suite.Run(t, &updaterTestSuite{})
 }
 

--- a/dflag/configmap/updater_test.go
+++ b/dflag/configmap/updater_test.go
@@ -17,8 +17,6 @@ import (
 
 	"fortio.org/fortio/dflag"
 	"fortio.org/fortio/dflag/configmap"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -26,6 +24,11 @@ const (
 	firstGoodDir  = "..9989_09_09_07_32_32.099817316"
 	secondGoodDir = "..9289_09_10_03_32_32.039823124"
 	badStaticDir  = "..1289_09_10_03_32_32.039823124"
+)
+
+var (
+	assert  = dflag.Testify{}
+	require = assert
 )
 
 type updaterTestSuite struct {

--- a/dflag/dynbool_test.go
+++ b/dflag/dynbool_test.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDynBool_SetAndGet(t *testing.T) {

--- a/dflag/dynduration_test.go
+++ b/dflag/dynduration_test.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDynDuration_SetAndGet(t *testing.T) {

--- a/dflag/dynfloat64_test.go
+++ b/dflag/dynfloat64_test.go
@@ -7,8 +7,6 @@ import (
 	"flag"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDynFloat64_SetAndGet(t *testing.T) {

--- a/dflag/dynint64_test.go
+++ b/dflag/dynint64_test.go
@@ -7,8 +7,6 @@ import (
 	"flag"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDynInt64_SetAndGet(t *testing.T) {
@@ -37,8 +35,8 @@ func TestDynInt64_FiresValidators(t *testing.T) {
 func TestDynInt64_FiresNotifier(t *testing.T) {
 	waitCh := make(chan bool, 1)
 	notifier := func(oldVal int64, newVal int64) {
-		assert.EqualValues(t, 13371337, oldVal, "old value in notify must match previous value")
-		assert.EqualValues(t, 77007700, newVal, "new value in notify must match set value")
+		assert.EqualValues(t, int64(13371337), oldVal, "old value in notify must match previous value")
+		assert.EqualValues(t, int64(77007700), newVal, "new value in notify must match set value")
 		waitCh <- true
 	}
 

--- a/dflag/dynjson_test.go
+++ b/dflag/dynjson_test.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 var defaultJSON = &outerJSON{
@@ -108,7 +106,7 @@ func TestDynJSONArray_SetAndGet(t *testing.T) {
 
 	assert.EqualValues(t, defaultJSONArray, dynFlag.Get(), "value must be default after create")
 
-	err := set.Set("some_json_array", `[{"ints": [42], "string": "new-value", "inner": { "bool": false } }, 
+	err := set.Set("some_json_array", `[{"ints": [42], "string": "new-value", "inner": { "bool": false } },
 																							{"ints": [24], "string": "new-value", "inner": { "bool": true } }]`)
 	assert.NoError(t, err, "setting value must succeed")
 

--- a/dflag/dynstring_test.go
+++ b/dflag/dynstring_test.go
@@ -8,8 +8,6 @@ import (
 	"regexp"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDynString_SetAndGet(t *testing.T) {

--- a/dflag/dynstringset_test.go
+++ b/dflag/dynstringset_test.go
@@ -7,8 +7,6 @@ import (
 	"flag"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDynStringSet_SetAndGet(t *testing.T) {

--- a/dflag/dynstringslice_test.go
+++ b/dflag/dynstringslice_test.go
@@ -7,8 +7,6 @@ import (
 	"flag"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDynStringSlice_SetAndGet(t *testing.T) {

--- a/dflag/endpoint/endpoint_test.go
+++ b/dflag/endpoint/endpoint_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 
 	"fortio.org/fortio/dflag"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -23,6 +21,11 @@ type endpointTestSuite struct {
 	flagSet  *flag.FlagSet
 	endpoint *FlagsEndpoint
 }
+
+var (
+	assert  = dflag.Testify{}
+	require = assert
+)
 
 func TestEndpointTestSuite(t *testing.T) {
 	suite.Run(t, &endpointTestSuite{})

--- a/dflag/endpoint/endpoint_test.go
+++ b/dflag/endpoint/endpoint_test.go
@@ -13,11 +13,10 @@ import (
 	"testing"
 
 	"fortio.org/fortio/dflag"
-	"github.com/stretchr/testify/suite"
 )
 
 type endpointTestSuite struct {
-	suite.Suite
+	dflag.TestSuite
 	flagSet  *flag.FlagSet
 	endpoint *FlagsEndpoint
 }
@@ -25,6 +24,7 @@ type endpointTestSuite struct {
 var (
 	assert  = dflag.Testify{}
 	require = assert
+	suite   = assert
 )
 
 func TestEndpointTestSuite(t *testing.T) {

--- a/dflag/fileread_flag_test.go
+++ b/dflag/fileread_flag_test.go
@@ -6,8 +6,6 @@ package dflag
 import (
 	"flag"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFileFlag_ReadsWithADefault(t *testing.T) {

--- a/dflag/test_utils.go
+++ b/dflag/test_utils.go
@@ -67,8 +67,7 @@ func (d *Testify) Fail(t *testing.T, msg string) {
 }
 
 var (
-	assert  = Testify{}
-	require = assert
+	assert = Testify{}
 )
 
 // --- End of replacement for "github.com/stretchr/testify/assert"

--- a/dflag/test_utils.go
+++ b/dflag/test_utils.go
@@ -10,64 +10,73 @@ import (
 
 // --- Start of replacement for "github.com/stretchr/testify/assert"
 
+// ObjectsAreEqualValues returns true if a == b (through refection).
 func (d *Testify) ObjectsAreEqualValues(a, b interface{}) bool {
 	return reflect.DeepEqual(a, b)
 }
 
+// Testify is a short replacement for github.com/stretchr/testify/assert.
 type Testify struct{}
 
+// NotEqual checks for a not equal b.
 func (d *Testify) NotEqual(t *testing.T, a, b interface{}, msg ...string) {
 	if d.ObjectsAreEqualValues(a, b) {
 		t.Errorf("%v unexpectedly equal: %v", a, msg)
 	}
 }
 
+// EqualValues checks for a equal b.
 func (d *Testify) EqualValues(t *testing.T, a, b interface{}, msg ...string) {
 	if !d.ObjectsAreEqualValues(a, b) {
 		t.Errorf("%v unexpectedly not equal %v: %v", a, b, msg)
 	}
 }
 
+// Equal also checks for a equal b.
 func (d *Testify) Equal(t *testing.T, a, b interface{}, msg ...string) {
 	d.EqualValues(t, a, b, msg...)
 }
 
+// NoError checks for no errors (nil).
 func (d *Testify) NoError(t *testing.T, err error, msg ...string) {
 	if err != nil {
 		t.Errorf("expecting no error, got %v: %v", err, msg)
 	}
 }
 
+// Error checks/expects an error.
 func (d *Testify) Error(t *testing.T, err error, msg ...string) {
 	if err == nil {
 		t.Errorf("expecting and error, didn't get it: %v", msg)
 	}
 }
 
+// True checks bool is true.
 func (d *Testify) True(t *testing.T, b bool, msg ...string) {
 	if !b {
 		t.Errorf("expecting true, didn't: %v", msg)
 	}
 }
 
+// False checks bool is false.
 func (d *Testify) False(t *testing.T, b bool, msg ...string) {
 	if b {
 		t.Errorf("expecting false, didn't: %v", msg)
 	}
 }
 
+// Contains checks that needle is in haystack.
 func (d *Testify) Contains(t *testing.T, haystack, needle string, msg ...string) {
 	if !strings.Contains(haystack, needle) {
 		t.Errorf("%v doesn't contain %v: %v", haystack, needle, msg)
 	}
 }
 
+// Fail fails the test.
 func (d *Testify) Fail(t *testing.T, msg string) {
 	t.Fatal(msg)
 }
 
-var (
-	assert = Testify{}
-)
+var assert = Testify{}
 
 // --- End of replacement for "github.com/stretchr/testify/assert"

--- a/dflag/test_utils.go
+++ b/dflag/test_utils.go
@@ -116,8 +116,13 @@ func (d *Testify) Run(t *testing.T, suite hasT) {
 	suite.SetT(t)
 	tests := []testing.InternalTest{}
 	methodFinder := reflect.TypeOf(suite)
-	if setup, ok := suite.(hasSetupTest); ok {
-		setup.SetupTest()
+	var setup hasSetupTest
+	if s, ok := suite.(hasSetupTest); ok {
+		setup = s
+	}
+	var tearDown hasTearDown
+	if td, ok := suite.(hasTearDown); ok {
+		tearDown = td
 	}
 	for i := 0; i < methodFinder.NumMethod(); i++ {
 		method := methodFinder.Method(i)
@@ -133,10 +138,13 @@ func (d *Testify) Run(t *testing.T, suite hasT) {
 		tests = append(tests, test)
 	}
 	for _, test := range tests {
+		if setup != nil {
+			setup.SetupTest()
+		}
 		t.Run(test.Name, test.F)
-	}
-	if tearDown, ok := suite.(hasTearDown); ok {
-		tearDown.TearDownTest()
+		if tearDown != nil {
+			tearDown.TearDownTest()
+		}
 	}
 }
 

--- a/dflag/test_utils.go
+++ b/dflag/test_utils.go
@@ -1,5 +1,8 @@
 // Copyright 2022 Fortio Authors
 
+// Only in "dflag" for sharing with tests.
+// As tests don't fail, coverage of this particular file is poor.
+
 package dflag
 
 import (

--- a/dflag/test_utils.go
+++ b/dflag/test_utils.go
@@ -1,0 +1,74 @@
+// Copyright 2022 Fortio Authors
+
+package dflag
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// --- Start of replacement for "github.com/stretchr/testify/assert"
+
+func (d *Testify) ObjectsAreEqualValues(a, b interface{}) bool {
+	return reflect.DeepEqual(a, b)
+}
+
+type Testify struct{}
+
+func (d *Testify) NotEqual(t *testing.T, a, b interface{}, msg ...string) {
+	if d.ObjectsAreEqualValues(a, b) {
+		t.Errorf("%v unexpectedly equal: %v", a, msg)
+	}
+}
+
+func (d *Testify) EqualValues(t *testing.T, a, b interface{}, msg ...string) {
+	if !d.ObjectsAreEqualValues(a, b) {
+		t.Errorf("%v unexpectedly not equal %v: %v", a, b, msg)
+	}
+}
+
+func (d *Testify) Equal(t *testing.T, a, b interface{}, msg ...string) {
+	d.EqualValues(t, a, b, msg...)
+}
+
+func (d *Testify) NoError(t *testing.T, err error, msg ...string) {
+	if err != nil {
+		t.Errorf("expecting no error, got %v: %v", err, msg)
+	}
+}
+
+func (d *Testify) Error(t *testing.T, err error, msg ...string) {
+	if err == nil {
+		t.Errorf("expecting and error, didn't get it: %v", msg)
+	}
+}
+
+func (d *Testify) True(t *testing.T, b bool, msg ...string) {
+	if !b {
+		t.Errorf("expecting true, didn't: %v", msg)
+	}
+}
+
+func (d *Testify) False(t *testing.T, b bool, msg ...string) {
+	if b {
+		t.Errorf("expecting false, didn't: %v", msg)
+	}
+}
+
+func (d *Testify) Contains(t *testing.T, haystack, needle string, msg ...string) {
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("%v doesn't contain %v: %v", haystack, needle, msg)
+	}
+}
+
+func (d *Testify) Fail(t *testing.T, msg string) {
+	t.Fatal(msg)
+}
+
+var (
+	assert  = Testify{}
+	require = assert
+)
+
+// --- End of replacement for "github.com/stretchr/testify/assert"

--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,5 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/yaml.v3 v3.0.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,17 +6,13 @@ require (
 	github.com/fsnotify/fsnotify v1.5.4
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0
-	github.com/stretchr/testify v1.7.1
 	golang.org/x/net v0.0.0-20220524220425-1d687d428aca
 	google.golang.org/grpc v1.46.0
 )
 
 require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -130,5 +130,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0 h1:hjy8E9ON/egN1tAYqKb61G10WtihqetD4sz2H+8nIeA=
+gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go.sum
+++ b/go.sum
@@ -11,7 +11,6 @@ github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XP
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -50,15 +49,12 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -130,11 +126,9 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
Fixes #580 

Only fixes one of the 2 alerts about gopkg.in/yaml as looks like get the the other from grpc

https://github.com/fortio/fortio/security/dependabot/1 and https://github.com/fortio/fortio/security/dependabot/2