### PR TITLE
Updates /rest/status to provide runner status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,9 @@ require (
 )
 
 require (
+	github.com/google/go-cmp v0.5.7 // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20220525015930-6ca3db687a9d // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,9 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -139,7 +140,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0 h1:hjy8E9ON/egN1tAYqKb61G10WtihqetD4sz2H+8nIeA=
-gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/periodic/periodic.go
+++ b/periodic/periodic.go
@@ -106,49 +106,49 @@ func NewAborter() *Aborter {
 // RunnerOptions are the parameters to the PeriodicRunner.
 type RunnerOptions struct {
 	// Type of run (to be copied into results)
-	RunType string
+	RunType string `json:"-"`
 	// Array of objects to run in each thread (use MakeRunners() to clone the same one)
-	Runners []Runnable
+	Runners []Runnable `json:"-"`
 	// At which (target) rate to run the Runners across NumThreads.
-	QPS float64
+	QPS float64 `json:"qps"`
 	// How long to run the test for. Unless Exactly is specified.
-	Duration time.Duration
+	Duration time.Duration `json:"-"`
 	// Note that this actually maps to gorountines and not actual threads
 	// but threads seems like a more familiar name to use for non go users
 	// and in a benchmarking context
-	NumThreads  int
-	Percentiles []float64
-	Resolution  float64
+	NumThreads  int       `json:"numthreads"`
+	Percentiles []float64 `json:"-"`
+	Resolution  float64   `json:"-"`
 	// Where to write the textual version of the results, defaults to stdout
-	Out io.Writer
+	Out io.Writer `json:"-"`
 	// Extra data to be copied back to the results (to be saved/JSON serialized)
-	Labels string
+	Labels string `json:"labels"`
 	// Aborter to interrupt a run. Will be created if not set/left nil. Or you
 	// can pass your own. It is very important this is a pointer and not a field
 	// as RunnerOptions themselves get copied while the channel and lock must
 	// stay unique (per run).
-	Stop *Aborter
+	Stop *Aborter `json:"-"`
 	// Mode where an exact number of iterations is requested. Default (0) is
 	// to not use that mode. If specified Duration is not used.
-	Exactly int64
+	Exactly int64 `json:"exactly"`
 	// When multiple clients are used to generate requests, they tend to send
 	// requests very close to one another, causing a thundering herd problem
 	// Enabling jitter (+/-10%) allows these requests to be de-synchronized
 	// When enabled, it is only effective in the '-qps' mode.
-	Jitter bool
+	Jitter bool `json:"jitter"`
 	// When multiple clients are used to generate requests, they tend to send
 	// requests very close to one another, causing a thundering herd problem
 	// Enabling uniform causes the requests between connections to be uniformly staggered.
 	// When enabled, it is only effective in the '-qps' mode.
-	Uniform bool
+	Uniform bool `json:"uniform"`
 	// Optional run id; used by the server to identify runs.
-	RunID int64
+	RunID int64 `json:"runid"`
 	// Optional Offset Duration; to offset the histogram function duration
-	Offset time.Duration
+	Offset time.Duration `json:"-"`
 	// Optional AccessLogger to log every request made. See AddAccessLogger.
-	AccessLogger AccessLogger
+	AccessLogger AccessLogger `json:"-"`
 	// No catch-up: if true we will do exactly the requested QPS and not try to catch up if the target is temporarily slow.
-	NoCatchUp bool
+	NoCatchUp bool `json:"nocatchup"`
 }
 
 // RunnerResults encapsulates the actual QPS observed and duration histogram.

--- a/ui/restHandler.go
+++ b/ui/restHandler.go
@@ -27,10 +27,12 @@ type ErrorReply struct {
 	Exception error
 }
 
+// StatusResults contains multiple StatusResult.
 type StatusResults struct {
 	Results []StatusResult `json:"results"`
 }
 
+// StatusResult used to output the status from periodic.RunnerOptions and include the RunID.
 type StatusResult struct {
 	RunID  int64                   `json:"runid"`
 	Status *periodic.RunnerOptions `json:"status"`

--- a/ui/restHandler_test.go
+++ b/ui/restHandler_test.go
@@ -1,0 +1,25 @@
+package ui // import "fortio.org/fortio/ui"
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const emptyResult = `{"results":null}`
+
+func TestEmptyResult(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/fortio/rest/status", nil)
+	w := httptest.NewRecorder()
+	RESTStatusHandler(w, r)
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+	if string(data) != emptyResult {
+		t.Errorf("expected %s got %v", emptyResult, string(data))
+	}
+}


### PR DESCRIPTION
Implements information about what is running by re-using PeriodicRunner.RunnerOptions
I did add one basic test, but after fiddling around by mocking the results it became a bit messy. So I kept it simple for now.


Status with runid that does not exist:

```
 curl -d 'runid=200' http://localhost:8080/fortio/rest/status
{"error": runid not found}
```

Status without runid with no runs:

```
curl http://localhost:8080/fortio/rest/status
{"Results":null}
```

Status with multiple runs:

```
curl -k http://localhost:8080/fortio/rest/status
{"results":[{"runid":1,"status":{"qps":10,"numthreads":1,"labels":"Fortio","exactly":0,"jitter":false,"uniform":false,"runid":1,"nocatchup":false}},{"runid":2,"status":{"qps":10,"numthreads":8,"labels":"Fortio","exactly":0,"jitter":false,"uniform":false,"runid":2,"nocatchup":false}}]}
```

Single run:

```
curl -k http://localhost:8080/fortio/rest/status
{"results":[{"runid":1,"status":{"qps":10,"numthreads":1,"labels":"Fortio","exactly":0,"jitter":false,"uniform":false,"runid":1,"nocatchup":false}}]}
```

Single run, explicit defined:

```
curl -d 'runid=1' http://localhost:8080/fortio/rest/status
{"results":[{"runid":1,"status":{"qps":10,"numthreads":1,"labels":"Fortio","exactly":0,"jitter":false,"uniform":false,"runid":1,"nocatchup":false}}]}
```
