### PR TITLE
add echo back to the connection reuse flag and revert readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,10 @@ connections, if empty, use https:// prefix for standard internet/system CAs
   -config path
         Config directory path to watch for changes of dynamic flags (empty for
 no watch)
-  -connection-reuse-range min:max
-        Range min:max for the max number of connections to reuse for each thread, 
-default to unlimited. e.g. 10:30 means randomly choose a max connection reuse threshold between 10 and 30 requests.
+  -connection-reuse min:max
+        Range min:max for the max number of connections to reuse for each
+thread, default to unlimited. e.g. 10:30 means randomly choose a max connection
+reuse threshold between 10 and 30 requests.
   -content-type string
         Sets http content type. Setting this value switches the request method
 from GET to POST.

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ You can install from source:
 The [releases](https://github.com/fortio/fortio/releases) page has binaries for many OS/architecture combinations (see assets).
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.34.0/fortio-linux_amd64-1.34.0.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.33.0/fortio-linux_amd64-1.33.0.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.34.0/fortio_1.34.0_amd64.deb
-dpkg -i fortio_1.34.0_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.33.0/fortio_1.33.0_amd64.deb
+dpkg -i fortio_1.33.0_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.34.0/fortio-1.34.0-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.33.0/fortio-1.33.0-1.x86_64.rpm
 # and more, see assets in release page
 ```
 
@@ -67,7 +67,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.34.0/fortio_win_1.34.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.33.0/fortio_win_1.33.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -115,7 +115,7 @@ Full list of command line flags (`fortio help`):
 <details>
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
-Φορτίο 1.34.0 usage:
+Φορτίο 1.33.0 usage:
 where command is one of: load (load testing), server (starts ui, http-echo,
  redirect, proxies, tcp-echo and grpc ping servers), tcp-echo (only the tcp-echo
  server), report (report only UI server), redirect (only the redirect server),

--- a/bincommon/commonflags.go
+++ b/bincommon/commonflags.go
@@ -108,7 +108,7 @@ var (
 	curlHeadersStdout = flag.Bool("curl-stdout-headers", false,
 		"Restore pre 1.22 behavior where http headers of the fast client are output to stdout in curl mode. now stderr by default.")
 	// ConnectionReuseRange Dynamic string flag to set the max connection reuse range.
-	ConnectionReuseRange = dflag.DynString(flag.CommandLine, "connection-reuse-range", "",
+	ConnectionReuseRange = dflag.DynString(flag.CommandLine, "connection-reuse", "",
 		"Range `min:max` for the max number of connections to reuse for each thread, default to unlimited. "+
 			"e.g. 10:30 means randomly choose a max connection reuse threshold between 10 and 30 requests.").
 		WithValidator(ConnectionReuseRangeValidator(&httpOpts))

--- a/fhttp/http_client.go
+++ b/fhttp/http_client.go
@@ -46,7 +46,7 @@ type Fetcher interface {
 	// Close() cleans up connections and state - must be paired with NewClient calls.
 	// returns how many sockets have been used (Fastclient only)
 	Close() int
-	// GetIPAddress() returns the pair hostname, ip address that DNS resolved to.
+	// GetIPAddress() returns the ip address that DNS resolved to.
 	GetIPAddress() string
 }
 
@@ -585,7 +585,7 @@ type FastClient struct {
 	reuseCount     int
 }
 
-// GetIPAddress get the hostname and ip address that DNS resolved to when using fast client.
+// GetIPAddress get ip address that DNS resolved to when using fast client.
 func (c *FastClient) GetIPAddress() string {
 	return c.dest.String()
 }

--- a/fhttp/http_client.go
+++ b/fhttp/http_client.go
@@ -47,7 +47,7 @@ type Fetcher interface {
 	// returns how many sockets have been used (Fastclient only)
 	Close() int
 	// GetIPAddress() returns the pair hostname, ip address that DNS resolved to.
-	GetIPAddress() (string, string)
+	GetIPAddress() string
 }
 
 const (
@@ -446,8 +446,8 @@ func (c *Client) Fetch() (int, []byte, int) {
 }
 
 // GetIPAddress get the ip address that DNS resolves to when using stdClient.
-func (c *Client) GetIPAddress() (string, string) {
-	return c.req.URL.Host, c.req.RemoteAddr
+func (c *Client) GetIPAddress() string {
+	return c.req.RemoteAddr
 }
 
 // NewClient creates either a standard or fast client (depending on
@@ -586,8 +586,8 @@ type FastClient struct {
 }
 
 // GetIPAddress get the hostname and ip address that DNS resolved to when using fast client.
-func (c *FastClient) GetIPAddress() (string, string) {
-	return c.host, c.dest.String()
+func (c *FastClient) GetIPAddress() string {
+	return c.dest.String()
 }
 
 // Close cleans up any resources used by FastClient.

--- a/fhttp/http_client.go
+++ b/fhttp/http_client.go
@@ -46,7 +46,7 @@ type Fetcher interface {
 	// Close() cleans up connections and state - must be paired with NewClient calls.
 	// returns how many sockets have been used (Fastclient only)
 	Close() int
-	// GetIPAddress() returns the ip address that DNS resolved to.
+	// GetIPAddress() returns the last ip address used by this client connection.
 	GetIPAddress() string
 }
 

--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -192,9 +192,9 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 	keys := []int{}
 	for i := 0; i < numThreads; i++ {
 		// Get the report on the IP address each thread use to send traffic
-		host, ip := httpstate[i].client.GetIPAddress()
+		ip := httpstate[i].client.GetIPAddress()
 		currentSocketUsed := httpstate[i].client.Close()
-		log.Infof("[%d] %d socket used, %s resolved to %s\n", i, currentSocketUsed, host, ip)
+		log.Infof("[%d] %d socket used, resolved to %s\n", i, currentSocketUsed, ip)
 		total.IPCountMap[ip]++
 
 		total.SocketCount += currentSocketUsed

--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -91,9 +91,9 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 		warmupMode = "sequential"
 	}
 
-	connReuseMsg := fmt.Sprintf("with connection reuse range between %d and %d", o.ConnReuseRange[0], o.ConnReuseRange[1])
-	if o.ConnReuseRange == [2]int{0, 0} {
-		connReuseMsg = ""
+	connReuseMsg := ""
+	if o.ConnReuseRange != [2]int{0, 0} {
+		connReuseMsg = fmt.Sprintf(" with connection reuse [%d, %d]", o.ConnReuseRange[0], o.ConnReuseRange[1])
 	}
 	log.Infof("Starting http test for %s with %d threads at %.1f qps and %s warmup %s",
 		o.URL, o.NumThreads, o.QPS, warmupMode, connReuseMsg)

--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -90,7 +90,13 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 	if o.SequentialWarmup {
 		warmupMode = "sequential"
 	}
-	log.Infof("Starting http test for %s with %d threads at %.1f qps and %s warmup", o.URL, o.NumThreads, o.QPS, warmupMode)
+
+	connReuseMsg := fmt.Sprintf("with connection reuse range between %d and %d", o.ConnReuseRange[0], o.ConnReuseRange[1])
+	if o.ConnReuseRange == [2]int{0, 0} {
+		connReuseMsg = ""
+	}
+	log.Infof("Starting http test for %s with %d threads at %.1f qps and %s warmup %s",
+		o.URL, o.NumThreads, o.QPS, warmupMode, connReuseMsg)
 	r := periodic.NewPeriodicRunner(&o.RunnerOptions)
 	defer r.Options().Abort()
 	numThreads := r.Options().NumThreads // can change during run for c > 2 n
@@ -187,10 +193,11 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 	for i := 0; i < numThreads; i++ {
 		// Get the report on the IP address each thread use to send traffic
 		host, ip := httpstate[i].client.GetIPAddress()
-		log.Infof("[%d] %s resolved to %s\n", i, host, ip)
+		currentSocketUsed := httpstate[i].client.Close()
+		log.Infof("[%d] %d socket used, %s resolved to %s\n", i, currentSocketUsed, host, ip)
 		total.IPCountMap[ip]++
 
-		total.SocketCount += httpstate[i].client.Close()
+		total.SocketCount += currentSocketUsed
 		// Q: is there some copying each time stats[i] is used?
 		for k := range httpstate[i].RetCodes {
 			if _, exists := total.RetCodes[k]; !exists {

--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -95,7 +95,7 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 	if o.ConnReuseRange != [2]int{0, 0} {
 		connReuseMsg = fmt.Sprintf(" with connection reuse [%d, %d]", o.ConnReuseRange[0], o.ConnReuseRange[1])
 	}
-	log.Infof("Starting http test for %s with %d threads at %.1f qps and %s warmup %s",
+	log.Infof("Starting http test for %s with %d threads at %.1f qps and %s warmup%s",
 		o.URL, o.NumThreads, o.QPS, warmupMode, connReuseMsg)
 	r := periodic.NewPeriodicRunner(&o.RunnerOptions)
 	defer r.Options().Abort()

--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -93,7 +93,7 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 
 	connReuseMsg := ""
 	if o.ConnReuseRange != [2]int{0, 0} {
-		connReuseMsg = fmt.Sprintf(" with connection reuse [%d, %d]", o.ConnReuseRange[0], o.ConnReuseRange[1])
+		connReuseMsg = fmt.Sprintf(", with connection reuse [%d, %d]", o.ConnReuseRange[0], o.ConnReuseRange[1])
 	}
 	log.Infof("Starting http test for %s with %d threads at %.1f qps and %s warmup%s",
 		o.URL, o.NumThreads, o.QPS, warmupMode, connReuseMsg)
@@ -194,7 +194,7 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 		// Get the report on the IP address each thread use to send traffic
 		ip := httpstate[i].client.GetIPAddress()
 		currentSocketUsed := httpstate[i].client.Close()
-		log.Infof("[%d] %d socket used, resolved to %s\n", i, currentSocketUsed, ip)
+		log.Infof("[%d] %3d socket used, resolved to %s\n", i, currentSocketUsed, ip)
 		total.IPCountMap[ip]++
 
 		total.SocketCount += currentSocketUsed

--- a/ui/restHandler.go
+++ b/ui/restHandler.go
@@ -196,7 +196,7 @@ func RESTRunHandler(w http.ResponseWriter, r *http.Request) { // nolint: funlen
 	// Set the connection reuse range.
 	err = bincommon.ConnectionReuseRange.
 		WithValidator(bincommon.ConnectionReuseRangeValidator(httpopts)).
-		Set(FormValue(r, jd, "connection-reuse-range"))
+		Set(FormValue(r, jd, "connection-reuse"))
 	if err != nil {
 		log.Errf("Fail to validate connection reuse range flag, err: %v", err)
 	}


### PR DESCRIPTION
- Add info about connection reuse flag in the test runner log
- revert the readme to the previous fortio version since the new version is not ready for tag yet
- remove host from GetIPAddress method in http_client