### PR TITLE
put the per connection socket count and ip on the normal out

### DIFF
--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -45,6 +45,7 @@ type HTTPRunnerResults struct {
 	HTTPOptions
 	Sizes       *stats.HistogramData
 	HeaderSizes *stats.HistogramData
+	Sockets     []int
 	SocketCount int
 	// http code to abort the run on (-1 for connection or other socket error)
 	AbortOn int
@@ -190,14 +191,16 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 	numThreads = total.RunnerResults.NumThreads
 	// But we also must cleanup all the created clients.
 	keys := []int{}
+	fmt.Fprintf(o.Out, "# Socket and IP used for each connection:\n")
 	for i := 0; i < numThreads; i++ {
 		// Get the report on the IP address each thread use to send traffic
 		ip := httpstate[i].client.GetIPAddress()
 		currentSocketUsed := httpstate[i].client.Close()
-		log.Infof("[%d] %3d socket used, resolved to %s\n", i, currentSocketUsed, ip)
+		fmt.Fprintf(o.Out, "[%d] %3d socket used, resolved to %s\n", i, currentSocketUsed, ip)
 		total.IPCountMap[ip]++
 
 		total.SocketCount += currentSocketUsed
+		total.Sockets = append(total.Sockets, currentSocketUsed)
 		// Q: is there some copying each time stats[i] is used?
 		for k := range httpstate[i].RetCodes {
 			if _, exists := total.RetCodes[k]; !exists {

--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -191,12 +191,12 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 	numThreads = total.RunnerResults.NumThreads
 	// But we also must cleanup all the created clients.
 	keys := []int{}
-	fmt.Fprintf(o.Out, "# Socket and IP used for each connection:\n")
+	fmt.Fprintf(out, "# Socket and IP used for each connection:\n")
 	for i := 0; i < numThreads; i++ {
 		// Get the report on the IP address each thread use to send traffic
 		ip := httpstate[i].client.GetIPAddress()
 		currentSocketUsed := httpstate[i].client.Close()
-		fmt.Fprintf(o.Out, "[%d] %3d socket used, resolved to %s\n", i, currentSocketUsed, ip)
+		fmt.Fprintf(out, "[%d] %3d socket used, resolved to %s\n", i, currentSocketUsed, ip)
 		total.IPCountMap[ip]++
 
 		total.SocketCount += currentSocketUsed


### PR DESCRIPTION
put the per connection socket count and ip on the normal out so it shows up in web too. also export socket count per connection to json

fixes #601 


looks like this:
```
# Socket and IP used for each connection:
[0]   2 socket used, resolved to 127.0.0.1:8080
[1]   2 socket used, resolved to 127.0.0.1:8080
[2]   3 socket used, resolved to 127.0.0.1:8080
[3]   2 socket used, resolved to 127.0.0.1:8080
[4]   4 socket used, resolved to 127.0.0.1:8080
[5]   5 socket used, resolved to 127.0.0.1:8080
[6]   2 socket used, resolved to 127.0.0.1:8080
[7]   2 socket used, resolved to 127.0.0.1:8080
[8]   2 socket used, resolved to 127.0.0.1:8080
[9]   3 socket used, resolved to 127.0.0.1:8080
Sockets used: 27 (for perfect keepalive, would be 10)
```

and json
```json
  "Sockets": [
    1,
    1,
    1,
    1,
    1,
    1,
    1,
    2,
    1,
    1
  ],
  "SocketCount": 11,
```