### PR TITLE
Better names for CallNoPayload -> Get and CallWithPayload -> Fetch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test: dependencies
 
 local-lint:
 	golangci-lint version
-	golangci-lint $(DEBUG_LINTERS) run $(LINT_PACKAGES)
+	golangci-lint --timeout 120s $(DEBUG_LINTERS) run $(LINT_PACKAGES)
 
 # Lint everything by default but ok to "make lint LINT_PACKAGES=./fhttp"
 LINT_PACKAGES:=./...

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ You can install from source:
 The [releases](https://github.com/fortio/fortio/releases) page has binaries for many OS/architecture combinations (see assets).
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.36.0/fortio-linux_amd64-1.36.0.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.37.0/fortio-linux_amd64-1.37.0.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.36.0/fortio_1.36.0_amd64.deb
-dpkg -i fortio_1.36.0_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.37.0/fortio_1.37.0_amd64.deb
+dpkg -i fortio_1.37.0_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.36.0/fortio-1.36.0-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.37.0/fortio-1.37.0-1.x86_64.rpm
 # and more, see assets in release page
 ```
 
@@ -68,7 +68,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.36.0/fortio_win_1.36.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.37.0/fortio_win_1.37.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -116,7 +116,7 @@ Full list of command line flags (`fortio help`):
 <details>
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
-Φορτίο 1.36.0 usage:
+Φορτίο 1.37.0 usage:
     fortio command [flags] target
 where command is one of: load (load testing), server (starts ui, rest api,
  http-echo, redirect, proxies, tcp-echo and grpc ping servers), tcp-echo (only

--- a/jrpc/jrpcClient.go
+++ b/jrpc/jrpcClient.go
@@ -216,17 +216,17 @@ func NewDestination(url string) *Destination {
 	return &Destination{URL: url}
 }
 
+// FetchURL is Send without a payload and no additional options (default timeout and headers).
+// Technically this should be called FetchBytesURL().
+func FetchURL(url string) (int, []byte, error) {
+	return Send(NewDestination(url), []byte{})
+}
+
 // Fetch is Send without a payload (so will be a GET request).
 // Used to be called Fetch() but we needed that shorter name to
 // simplify the former CallWithPayload function name.
 func FetchBytes(url *Destination) (int, []byte, error) {
 	return Send(url, []byte{})
-}
-
-// FetchURL is Send without a payload and no additional options (default timeout and headers).
-// Technically this should be called FetchBytesURL().
-func FetchURL(url string) (int, []byte, error) {
-	return Send(NewDestination(url), []byte{})
 }
 
 // EscapeBytes returns printable string. Same as %q format without the

--- a/jrpc/jrpc_test.go
+++ b/jrpc/jrpc_test.go
@@ -144,8 +144,8 @@ func TestJPRC(t *testing.T) {
 		t.Errorf("response doesn't contain expected string: %+v", res)
 	}
 	// Error cases
-	// Empty request, using Fetch()
-	code, bytes, err := jrpc.Fetch(jrpc.NewDestination(url))
+	// Empty request, using FetchBytes()
+	code, bytes, err := jrpc.FetchBytes(jrpc.NewDestination(url))
 	if err != nil {
 		t.Errorf("failed Fetch: %v - %s", err, jrpc.DebugSummary(bytes, 256))
 	}
@@ -176,7 +176,7 @@ func TestJPRC(t *testing.T) {
 	if de != nil && !strings.HasPrefix(de.Error(), expected) {
 		t.Errorf("expected dns error to start with %q, got %q", expected, de.Error())
 	}
-	// bad json payload sent
+	// bad json payload sent - call deprecated one for coverage for now, replace with Retrieve() when it's gone:
 	errReply, err := jrpc.CallWithPayload[Response](jrpc.NewDestination(url), []byte(`{foo: missing-quotes}`))
 	if err == nil {
 		t.Errorf("expected error, got nil and %v", res)
@@ -195,8 +195,8 @@ func TestJPRC(t *testing.T) {
 	if errReply.Exception != expected {
 		t.Errorf("expected Exception in body to be %q, got %+v", expected, errReply)
 	}
-	// bad json response, using Fetch()
-	errReply, err = jrpc.CallNoPayloadURL[Response](url)
+	// bad json response, using GetURL()
+	errReply, err = jrpc.GetURL[Response](url)
 	if err == nil {
 		t.Errorf("expected error %v", errReply)
 	}
@@ -310,6 +310,7 @@ func TestJPRCHeaders(t *testing.T) {
 		URL:     url,
 		Headers: &inp,
 	}
+	// use the deprecated for coverage. switch to jrpc.Get() in next version
 	res, err := jrpc.CallNoPayload[http.Header](dest)
 	if err != nil {
 		t.Errorf("failed Call: %v", err)

--- a/jrpc/jrpc_test.go
+++ b/jrpc/jrpc_test.go
@@ -176,7 +176,7 @@ func TestJPRC(t *testing.T) {
 	if de != nil && !strings.HasPrefix(de.Error(), expected) {
 		t.Errorf("expected dns error to start with %q, got %q", expected, de.Error())
 	}
-	// bad json payload sent - call deprecated one for coverage for now, replace with Retrieve() when it's gone:
+	// bad json payload sent - call deprecated one for coverage for now, replace with Fetch() when it's gone:
 	errReply, err := jrpc.CallWithPayload[Response](jrpc.NewDestination(url), []byte(`{foo: missing-quotes}`))
 	if err == nil {
 		t.Errorf("expected error, got nil and %v", res)

--- a/rapi/restHandler_test.go
+++ b/rapi/restHandler_test.go
@@ -37,7 +37,7 @@ import (
 
 // Generics ftw.
 func FetchResult[T any](t *testing.T, url string, jsonPayload string) *T {
-	r, err := jrpc.CallWithPayload[T](jrpc.NewDestination(url), []byte(jsonPayload))
+	r, err := jrpc.Fetch[T](jrpc.NewDestination(url), []byte(jsonPayload))
 	if err != nil {
 		t.Errorf("Got unexpected error for URL %s: %v - %v", url, err, r)
 	}
@@ -63,7 +63,7 @@ func GetAsyncResult(t *testing.T, url string, jsonPayload string) *AsyncReply {
 
 // Same as above but when expecting to get an error reply.
 func GetErrorResult(t *testing.T, url string, jsonPayload string) *jrpc.ServerReply {
-	r, err := jrpc.CallWithPayload[jrpc.ServerReply](jrpc.NewDestination(url), []byte(jsonPayload))
+	r, err := jrpc.Fetch[jrpc.ServerReply](jrpc.NewDestination(url), []byte(jsonPayload))
 	if err == nil {
 		t.Errorf("Got unexpected no error for URL %s: %v", url, r)
 	}
@@ -199,7 +199,7 @@ func TestHTTPRunnerRESTApi(t *testing.T) {
 		URL:     statusURL,
 		Timeout: 3 * time.Second,
 	}
-	statuses, err := jrpc.CallNoPayload[StatusReply](statusDest)
+	statuses, err := jrpc.Get[StatusReply](statusDest)
 	if err != nil {
 		t.Errorf("Error getting status %q: %v", statusURL, err)
 	}
@@ -259,7 +259,7 @@ func TestHTTPRunnerRESTApi(t *testing.T) {
 		t.Errorf("2nd stop should be noop, got %+v", asyncObj)
 	}
 	// Status should be empty (nothing running)
-	statuses, err = jrpc.CallNoPayload[StatusReply](statusDest)
+	statuses, err = jrpc.Get[StatusReply](statusDest)
 	if err != nil {
 		t.Errorf("Error getting status %q: %v", statusURL, err)
 	}
@@ -274,7 +274,7 @@ func TestHTTPRunnerRESTApi(t *testing.T) {
 	// Get all statuses
 	statusURL = fmt.Sprintf("http://localhost:%d%s%s", addr.Port, uiPath, RestStatusURI)
 	statusDest.URL = statusURL
-	statuses, err = jrpc.CallNoPayload[StatusReply](statusDest)
+	statuses, err = jrpc.Get[StatusReply](statusDest)
 	if err != nil {
 		t.Errorf("Error getting status %q: %v", statusURL, err)
 	}
@@ -376,7 +376,7 @@ func TestRESTStopTimeBased(t *testing.T) {
 	// Get status
 	statusURL := fmt.Sprintf("http://localhost:%d%s%s?runid=%d", addr.Port, uiPath, RestStatusURI, runID)
 	statusDest := jrpc.NewDestination(statusURL)
-	statuses, err := jrpc.CallNoPayload[StatusReply](statusDest)
+	statuses, err := jrpc.Get[StatusReply](statusDest)
 	if err != nil {
 		t.Errorf("Error getting status %q: %v", statusURL, err)
 	}
@@ -418,7 +418,7 @@ func TestRESTStopTimeBased(t *testing.T) {
 		t.Errorf("2nd stop should be noop, got %+v", asyncObj)
 	}
 	// Status should be empty (nothing running)
-	statuses, err = jrpc.CallNoPayload[StatusReply](statusDest)
+	statuses, err = jrpc.Get[StatusReply](statusDest)
 	if err != nil {
 		t.Errorf("Error getting status %q: %v", statusURL, err)
 	}
@@ -475,7 +475,7 @@ func TestRESTStopTimeBased(t *testing.T) {
 
 // If jsonPayload isn't empty we POST otherwise get the url.
 func GetGRPCResult(t *testing.T, url string, jsonPayload string) *fgrpc.GRPCRunnerResults {
-	r, err := jrpc.CallWithPayload[fgrpc.GRPCRunnerResults](jrpc.NewDestination(url), []byte(jsonPayload))
+	r, err := jrpc.Fetch[fgrpc.GRPCRunnerResults](jrpc.NewDestination(url), []byte(jsonPayload))
 	if err != nil {
 		t.Errorf("Got unexpected err for URL %s: %v", url, err)
 	}


### PR DESCRIPTION
Better names for CallNoPayload -> Get and CallWithPayload -> Fetch (and thus Fetch -> FetchBytes to free up that short name)

This came up while using the API internally