### PR TITLE
only do compression if requested explictly when forwarding/fetching 

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,8 @@ Fortio `server` has the following feature for the http listening on 8080 (all pa
 | header    | header(s) to add to the reply e.g. `&header=Foo:Bar&header=X:Y` |
 | gzip      | If `Accept-Encoding: gzip` is passed in headers by the caller/client; and `gzip=true` is in the query args, all response will be gzipped; or if `gzip=42.7` is passed, approximately 42.7% will|
 
+`delay`, `close` and `header` query arguments are also supported for the `debug` endpoint which echoes back the request (gzip is always done if `Accept-Encoding: gzip` is present, status is always 200, and the payload is the echo back debug information).
+
 You can set a default value for all these by passing `-echo-server-default-params` to the server command line, for instance:
 `fortio server -echo-server-default-params="delay=0.5s:50,1s:40&status=418"` will make the server respond with http 418 and a delay of either 0.5s half of the time, 1s 40% and no delay in 10% of the calls; unless any `?` query args is passed by the client. Note that the quotes (&quot;) are for the shell to escape the ampersand (&amp;) but should not be put in a yaml nor the dynamicflag url for instance.
 

--- a/fhttp/http_forwarder.go
+++ b/fhttp/http_forwarder.go
@@ -247,6 +247,9 @@ func CreateProxyClient() *http.Client {
 			// TODO make configurable, should be fine for now for most but extreme -c values
 			MaxIdleConnsPerHost: 128, // must be more than incoming parallelization; divided by number of fan out if using parallel mode
 			MaxIdleConns:        256,
+			// This avoids Accept-Encoding: gzip being added to outgoing requests when no encoding accept is specified
+			// yet if passed by request, it will do gzip end to end. Issue #624.
+			DisableCompression: true,
 		},
 	}
 	return client

--- a/fhttp/http_forwarder_test.go
+++ b/fhttp/http_forwarder_test.go
@@ -43,6 +43,10 @@ func TestMultiProxy(t *testing.T) {
 		if !bytes.Contains(data, []byte(payload)) {
 			t.Errorf("Result %s doesn't contain expected payload echo back %q", DebugSummary(data, 1024), payload)
 		}
+		// Issue #624
+		if bytes.Contains(data, []byte("gzip")) {
+			t.Errorf("Result %s contains unexpected gzip (accept encoding)", DebugSummary(data, 1024))
+		}
 		if !bytes.Contains(data, []byte("X-Fortio-Multi-Id: 1")) {
 			t.Errorf("Result %s doesn't contain expected X-Fortio-Multi-Id: 1", DebugSummary(data, 1024))
 		}

--- a/fhttp/http_server.go
+++ b/fhttp/http_server.go
@@ -33,6 +33,7 @@ import (
 
 	"fortio.org/fortio/dflag"
 	"fortio.org/fortio/fnet"
+	"fortio.org/fortio/jrpc"
 	"fortio.org/fortio/log"
 	"fortio.org/fortio/version"
 	"golang.org/x/net/http2"
@@ -104,7 +105,7 @@ func EchoHandler(w http.ResponseWriter, r *http.Request) {
 	// echo back the Content-Type and Content-Length in the response
 	for _, k := range []string{"Content-Type", "Content-Length"} {
 		if v := r.Header.Get(k); v != "" {
-			w.Header().Set(k, v)
+			jrpc.SetHeaderIfMissing(w.Header(), k, v)
 		}
 	}
 	w.WriteHeader(status)
@@ -146,7 +147,7 @@ func handleCommonArgs(w http.ResponseWriter, r *http.Request) {
 }
 
 func writePayload(w http.ResponseWriter, status int, size int) {
-	w.Header().Set("Content-Type", "application/octet-stream")
+	jrpc.SetHeaderIfMissing(w.Header(), "Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Length", strconv.Itoa(size))
 	w.WriteHeader(status)
 	n, err := w.Write(fnet.Payload[:size])
@@ -344,7 +345,7 @@ func DebugHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	handleCommonArgs(w, r)
-	w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
+	jrpc.SetHeaderIfMissing(w.Header(), "Content-Type", "text/plain; charset=UTF-8")
 	if _, err = w.Write(buf.Bytes()); err != nil {
 		log.Errf("Error writing response %v to %v", err, r.RemoteAddr)
 	}

--- a/fhttp/http_server.go
+++ b/fhttp/http_server.go
@@ -114,6 +114,7 @@ func EchoHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleCommonArgs common flags for debug and echo handlers.
+// Must be called after body is read.
 func handleCommonArgs(w http.ResponseWriter, r *http.Request) {
 	dur := generateDelay(r.FormValue("delay"))
 	if dur > 0 {
@@ -274,7 +275,6 @@ environment:
 
 // DebugHandler returns debug/useful info to http client.
 func DebugHandler(w http.ResponseWriter, r *http.Request) {
-	handleCommonArgs(w, r)
 	LogRequest(r, "Debug")
 	var buf bytes.Buffer
 	buf.WriteString("Φορτίο version ")
@@ -343,6 +343,7 @@ func DebugHandler(w http.ResponseWriter, r *http.Request) {
 			buf.WriteByte('\n')
 		}
 	}
+	handleCommonArgs(w, r)
 	w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
 	if _, err = w.Write(buf.Bytes()); err != nil {
 		log.Errf("Error writing response %v to %v", err, r.RemoteAddr)

--- a/fhttp/http_test.go
+++ b/fhttp/http_test.go
@@ -1112,7 +1112,8 @@ func TestDebugHandlerSortedHeaders(t *testing.T) {
 	m.HandleFunc("/debug", DebugHandler)
 	// Debug handler does respect the delay arg but not status, status is always 200
 	url := fmt.Sprintf("http://localhost:%d/debug?delay=500ms&status=555", a.Port)
-	o := HTTPOptions{URL: url, DisableFastClient: true}
+	// Trigger transparent compression (which will add Accept-Encoding: gzip header)
+	o := HTTPOptions{URL: url, DisableFastClient: true, Compression: true}
 	o.AddAndValidateExtraHeader("BBB: bbb")
 	o.AddAndValidateExtraHeader("CCC: ccc")
 	o.AddAndValidateExtraHeader("ZZZ: zzz")
@@ -1136,6 +1137,7 @@ func TestDebugHandlerSortedHeaders(t *testing.T) {
 		"headers:\n\n"+
 		"Host: localhost:%d\n"+
 		"Aaa: aaa\n"+
+		"Accept-Encoding: gzip\n"+
 		"Bbb: bbb\n"+
 		"Ccc: ccc\n"+
 		"User-Agent: %s\n"+

--- a/periodic/periodic.go
+++ b/periodic/periodic.go
@@ -105,12 +105,13 @@ func (a *Aborter) Abort(wait bool) {
 		return
 	}
 	a.stopRequested = true
-	if a.hasStarted || !wait {
+	started := a.hasStarted
+	if started || !wait {
 		log.LogVf("ABORT Closing %v", a)
 		close(a.StopChan)
 		a.StopChan = nil
 		a.Unlock()
-		if a.hasStarted {
+		if started {
 			log.LogVf("ABORT reading start channel")
 			// shouldn't block/hang, just purging/resetting
 			<-a.StartChan


### PR DESCRIPTION
fixes #624

also

- fix a data race
- enable delay,close and header query args for debug endpoint
- improved tests