### PR TITLE
Tests for slice/array returned from jrpc calls as well as a cleaner shortcut: `jrpc.GetArray()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ You can install from source:
 The [releases](https://github.com/fortio/fortio/releases) page has binaries for many OS/architecture combinations (see assets).
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.38.1/fortio-linux_amd64-1.38.1.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.38.2/fortio-linux_amd64-1.38.2.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.38.1/fortio_1.38.1_amd64.deb
-dpkg -i fortio_1.38.1_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.38.2/fortio_1.38.2_amd64.deb
+dpkg -i fortio_1.38.2_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.38.1/fortio-1.38.1-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.38.2/fortio-1.38.2-1.x86_64.rpm
 # and more, see assets in release page
 ```
 
@@ -68,7 +68,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.38.1/fortio_win_1.38.1.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.38.2/fortio_win_1.38.2.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -116,7 +116,7 @@ Full list of command line flags (`fortio help`):
 <details>
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
-Φορτίο 1.38.1 usage:
+Φορτίο 1.38.2 usage:
     fortio command [flags] target
 where command is one of: load (load testing), server (starts ui, rest api,
  http-echo, redirect, proxies, tcp-echo and grpc ping servers), tcp-echo (only

--- a/jrpc/jrpcClient.go
+++ b/jrpc/jrpcClient.go
@@ -120,6 +120,16 @@ func Get[Q any](url *Destination) (*Q, error) {
 	return Fetch[Q](url, []byte{})
 }
 
+// GetArray fetches and deseializes the JSON returned by the Destination into a slice of
+// Q struct (ie the response is a json array).
+func GetArray[Q any](url *Destination) ([]Q, error) {
+	slicePtr, err := Fetch[[]Q](url, []byte{})
+	if slicePtr == nil {
+		return nil, err
+	}
+	return *slicePtr, err
+}
+
 // GetURL is Get without additional options (default timeout and headers).
 func GetURL[Q any](url string) (*Q, error) {
 	return Get[Q](NewDestination(url))
@@ -162,7 +172,7 @@ func Fetch[Q any](url *Destination, bytes []byte) (*Q, error) {
 		if ok {
 			return nil, err
 		}
-		return nil, &FetchError{"deserialization error", code, err, bytes}
+		return nil, &FetchError{"non ok http result and deserialization error", code, err, bytes}
 	}
 	if !ok {
 		// can still be "ok" for some callers, they can use the result object as it deserialized as expected.

--- a/jrpc/jrpc_test.go
+++ b/jrpc/jrpc_test.go
@@ -270,7 +270,7 @@ func TestJPRC(t *testing.T) {
 	if unwrap.Error() != expected {
 		t.Errorf("unwrapped error expected to be %q, got %v", expected, unwrap.Error())
 	}
-	expected = "deserialization error, code 747: " + expected + " (raw reply: {bad})"
+	expected = "non ok http result and deserialization error, code 747: " + expected + " (raw reply: {bad})"
 	if err.Error() != expected {
 		t.Errorf("error string expected %q, got %q", expected, err.Error())
 	}

--- a/jrpc/jrpc_test.go
+++ b/jrpc/jrpc_test.go
@@ -425,6 +425,10 @@ func TestJPRCSlices(t *testing.T) {
 			jrpc.ReplyError(w, "invalid negative count", nil)
 			return
 		}
+		if r.FormValue("errror") != "" {
+			jrpc.ReplyError(w, "error requested", nil)
+			return
+		}
 		if n == 0 {
 			n = 42 // for testing of GetArray
 		}
@@ -475,5 +479,13 @@ func TestJPRCSlices(t *testing.T) {
 		if el.Data != fmt.Sprintf("data %d", i) {
 			t.Errorf("expected data %d, got %s", i, el.Data)
 		}
+	}
+	// Empty slice/error
+	slice, err = jrpc.GetArray[SliceOneResponse](jrpc.NewDestination(url + "?errror=true"))
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+	if slice != nil {
+		t.Errorf("expected nil slice, got %v", slice)
 	}
 }


### PR DESCRIPTION

Add tests for slice/array returned from jrpc calls as well as a cleaner shortcut/example of use: `jrpc.GetArray()`

Also fix #633 incidentally
