### PR TITLE
bump build image (go 1.19.3), added govulncheck, fix permissions in /go - also stop using /go/src

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ defaultEnv:
   &defaultEnv
   docker:
     # specify the version
-    - image: docker.io/fortio/fortio.build:v47
-  working_directory: /go/src/fortio.org/fortio
+    - image: docker.io/fortio/fortio.build:v50
+  working_directory: /build/fortio
 
 jobs:
   unit-tests:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v47 as build
-WORKDIR /go/src/fortio.org
+FROM docker.io/fortio/fortio.build:v50 as build
+WORKDIR /build
 COPY . fortio
 ARG MODE=install
 # We moved a lot of the logic into the Makefile so it can be reused in brew
@@ -12,8 +12,8 @@ FROM scratch as release
 # NOTE: the list of files here, if updated, must be changed in release/Dockerfile.in too
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 # TODO: get rid of *.bak, *~ and other spurious non source files
-#COPY --from=build /go/src/fortio.org/fortio/ui/static /usr/share/fortio/static
-#COPY --from=build /go/src/fortio.org/fortio/ui/templates /usr/share/fortio/templates
+#COPY --from=build /build/fortio/ui/static /usr/share/fortio/static
+#COPY --from=build /build/fortio/ui/templates /usr/share/fortio/templates
 COPY --from=build /build/result/fortio /usr/bin/fortio
 EXPOSE 8078
 EXPOSE 8079

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,5 @@
 # Dependencies and linters for build:
-FROM golang:1.19.2
+FROM golang:1.19.3
 # Need gcc for -race test (and some linters though those work with CGO_ENABLED=0)
 RUN apt-get -y update && \
   apt-get --no-install-recommends -y upgrade && \
@@ -21,9 +21,12 @@ RUN set -x; if [ x"$(dpkg --print-architecture)" != x"s390x" ]; then \
     apt-get -y update && apt-get install --no-install-recommends -y docker-ce; \
     fi
 
+# govulncheck
+RUN go install golang.org/x/vuln/cmd/govulncheck@latest
 WORKDIR /build
 COPY .golangci.yml .
 VOLUME /build
 RUN useradd -m build -d /build
 RUN chown -R build:build /build
+RUN chown -R build:build /go
 USER build

--- a/Dockerfile.echosrv
+++ b/Dockerfile.echosrv
@@ -1,10 +1,10 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v47 as build
-WORKDIR /go/src/fortio.org
+FROM docker.io/fortio/fortio.build:v50 as build
+WORKDIR /build
 COPY . fortio
 RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_TARGET=fortio.org/fortio/echosrv OFFICIAL_BIN=../echosrv.bin
 # Minimal image with just the binary
 FROM scratch
-COPY --from=build /go/src/fortio.org/echosrv.bin /usr/bin/echosrv
+COPY --from=build /build/echosrv.bin /usr/bin/echosrv
 EXPOSE 8080
 ENTRYPOINT ["/usr/bin/echosrv"]

--- a/Dockerfile.fcurl
+++ b/Dockerfile.fcurl
@@ -1,11 +1,11 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v47 as build
-WORKDIR /go/src/fortio.org
+FROM docker.io/fortio/fortio.build:v50 as build
+WORKDIR /build
 COPY . fortio
 # fcurl should not need vendor/no dependencies
 RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_TARGET=fortio.org/fortio/fcurl OFFICIAL_BIN=../fcurl.bin
 # Minimal image with just the binary and certs
 FROM scratch
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build /go/src/fortio.org/fcurl.bin /usr/bin/fcurl
+COPY --from=build /build/fcurl.bin /usr/bin/fcurl
 ENTRYPOINT ["/usr/bin/fcurl"]

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 IMAGES=echosrv fcurl # plus the combo image / Dockerfile without ext.
 
 DOCKER_PREFIX := docker.io/fortio/fortio
-BUILD_IMAGE_TAG := v47
+BUILD_IMAGE_TAG := v50
 BUILDX_PLATFORMS := linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 BUILDX_POSTFIX :=
 ifeq '$(shell echo $(BUILDX_PLATFORMS) | awk -F "," "{print NF-1}")' '0'
@@ -57,23 +57,24 @@ test: dependencies
 # DEBUG_LINTERS="--debug"
 
 local-lint:
+	govulncheck $(LINT_PACKAGES)
 	golangci-lint version
 	golangci-lint --timeout 120s $(DEBUG_LINTERS) run $(LINT_PACKAGES)
 
 # Lint everything by default but ok to "make lint LINT_PACKAGES=./fhttp"
 LINT_PACKAGES:=./...
 lint:
-	docker run -v $(CURDIR):/go/src/fortio.org/fortio $(BUILD_IMAGE) bash -c \
-		"cd /go/src/fortio.org/fortio \
+	docker run -v $(CURDIR):/build/fortio $(BUILD_IMAGE) bash -c \
+		"cd /build/fortio \
 		&& time make local-lint DEBUG_LINTERS=\"$(DEBUG_LINTERS)\" LINT_PACKAGES=\"$(LINT_PACKAGES)\""
 
 docker-test:
-	docker run -v $(CURDIR):/go/src/fortio.org/fortio $(BUILD_IMAGE) bash -c \
-		"cd /go/src/fortio.org/fortio \
+	docker run -v $(CURDIR):/build/fortio $(BUILD_IMAGE) bash -c \
+		"cd /build/fortio \
 		&& time make test"
 
 shell:
-	docker run -ti -v $(CURDIR):/go/src/fortio.org/fortio $(BUILD_IMAGE)
+	docker run -ti -v $(CURDIR):/build/fortio $(BUILD_IMAGE)
 
 # This really also tests the release process and build on windows,mac,linux
 # and the docker images, not just "web" (ui) stuff that it also exercises.

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -125,7 +125,7 @@ fi
 PPROF_URL="$BASE_URL/debug/pprof/heap?debug=1"
 $CURL "$PPROF_URL" | grep -i TotalAlloc # should find this in memory profile
 # creating dummy container to hold a volume for test certs due to remote docker bind mount limitation.
-DOCKERCURLID=$(docker run -d -v $TEST_CERT_VOL --net host --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v47 sleep 120)
+DOCKERCURLID=$(docker run -d -v $TEST_CERT_VOL --net host --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v50 sleep 120)
 # while we have something with actual curl binary do
 # Test for h2c upgrade (#562)
 docker exec $DOCKERSECVOLNAME /usr/bin/curl -v --http2 -m 10 -d foo42 http://localhost:8080/debug | tee >(cat 1>&2) | grep foo42

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -1,5 +1,5 @@
 # Concatenated after ../Dockerfile to create the tgz
-FROM docker.io/fortio/fortio.build:v47 as stage
+FROM docker.io/fortio/fortio.build:v50 as stage
 ARG archs="amd64 arm64 ppc64le s390x"
 ENV archs=${archs}
 # Build image defaults to build user, switch back to root for
@@ -11,7 +11,7 @@ COPY docs/fortio.1 usr/share/man/man1/fortio.1
 
 RUN mkdir -p /tgz usr/bin
 
-WORKDIR /go/src/fortio.org
+WORKDIR /build
 COPY . fortio
 # Check macos does not break
 RUN make -C fortio official-build BUILD_DIR=/build OFFICIAL_DIR=/tmp/fortio_mac GOOS=darwin GO_BIN=/usr/local/go/bin/go


### PR DESCRIPTION
bumped build image (go 1.19.3) also fix permissions in /go - also stop using /go/src/fortio.org as that's not needed since go mods are a thing. 

added govulncheck
