### PR TITLE
don't normalize URL too early as this could be a tcp or udp runner

### DIFF
--- a/rapi/restHandler.go
+++ b/rapi/restHandler.go
@@ -264,8 +264,9 @@ func RESTRunHandler(w http.ResponseWriter, r *http.Request) { //nolint:funlen
 	ro.RunID = runid
 	log.Infof("New run id %d", runid)
 	httpopts := &fhttp.HTTPOptions{}
-	httpopts.HTTPReqTimeOut = timeout // to be normalized in init 0 replaced by default value
-	httpopts = httpopts.Init(url)
+	httpopts.HTTPReqTimeOut = timeout // to be normalized in init, 0 is replaced by default value (for all runners)
+	// We don't call Init because this could be a tcp:// or udp:// url. Was httpopts = httpopts.Init(url) - fixes #651
+	httpopts.URL = url
 	httpopts.DisableFastClient = stdClient
 	httpopts.SequentialWarmup = sequentialWarmup
 	httpopts.Insecure = httpsInsecure

--- a/ui/templates/main.html
+++ b/ui/templates/main.html
@@ -59,7 +59,7 @@
     <br />
     Payload:<br /><textarea name="payload" rows="5" cols="75" id="payload"></textarea><br />
     Load using:<br />
-    tcp/udp/http: <input type="radio" name="runner" value="http" checked/>
+    tcp/udp/http: <input type="radio" name="runner" value="http/tcp/udp" checked/>
     (https insecure:<input type="checkbox" name="https-insecure" />,
     standard go client instead of fastclient:<input type="checkbox" name="stdclient"/>,
     sequential warmup: <input type="checkbox" name="sequential-warmup"/>,

--- a/ui/uihandler.go
+++ b/ui/uihandler.go
@@ -183,8 +183,9 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		ro.RunID = runid
 	}
 	httpopts := &fhttp.HTTPOptions{}
-	httpopts.HTTPReqTimeOut = timeout // to be normalized in init 0 replaced by default value
-	httpopts = httpopts.Init(url)
+	// to be normalized in init 0 replaced by default value only in http runner, not here as this could be a tcp or udp runner
+	httpopts.URL = url // fixes #651
+	httpopts.HTTPReqTimeOut = timeout
 	httpopts.DisableFastClient = stdClient
 	httpopts.SequentialWarmup = sequentialWarmup
 	httpopts.Insecure = httpsInsecure


### PR DESCRIPTION
don't normalize URL too early as this could be a tcp or udp runner (for web ui/rapi calls)

avoids/fixes:
```
14:56:42 I uihandler.go:113> Starting http load request from [::1]:49334 for udp://localhost:1111
14:56:42 W http_client.go:152> Assuming http:// on missing scheme for 'udp://localhost:1111'
```

Fixes #651