### PR TITLE
switch to go 1.19.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ defaultEnv:
   &defaultEnv
   docker:
     # specify the version
-    - image: docker.io/fortio/fortio.build:v50@sha256:fe69c193d8ad40eb0d791984881f3678aead02660b8e3468c757f717892ada4c
+    - image: docker.io/fortio/fortio.build:v51@sha256:19c61def5203187354d7459781407c0d83895d20f100bfb6ff3a298c9f1cb2b6
   working_directory: /build/fortio
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v50@sha256:fe69c193d8ad40eb0d791984881f3678aead02660b8e3468c757f717892ada4c as build
+FROM docker.io/fortio/fortio.build:v51@sha256:19c61def5203187354d7459781407c0d83895d20f100bfb6ff3a298c9f1cb2b6 as build
 WORKDIR /build
 COPY . fortio
 ARG MODE=install

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,5 @@
 # Dependencies and linters for build:
-FROM golang:1.19.3
+FROM golang:1.19.4
 # Need gcc for -race test (and some linters though those work with CGO_ENABLED=0)
 RUN apt-get -y update && \
   apt-get --no-install-recommends -y upgrade && \

--- a/Dockerfile.echosrv
+++ b/Dockerfile.echosrv
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v50@sha256:fe69c193d8ad40eb0d791984881f3678aead02660b8e3468c757f717892ada4c as build
+FROM docker.io/fortio/fortio.build:v51@sha256:19c61def5203187354d7459781407c0d83895d20f100bfb6ff3a298c9f1cb2b6 as build
 WORKDIR /build
 COPY . fortio
 RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_TARGET=fortio.org/fortio/echosrv

--- a/Dockerfile.fcurl
+++ b/Dockerfile.fcurl
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v50@sha256:fe69c193d8ad40eb0d791984881f3678aead02660b8e3468c757f717892ada4c as build
+FROM docker.io/fortio/fortio.build:v51@sha256:19c61def5203187354d7459781407c0d83895d20f100bfb6ff3a298c9f1cb2b6 as build
 WORKDIR /build
 COPY . fortio
 RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_TARGET=fortio.org/fortio/fcurl

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 IMAGES=echosrv fcurl # plus the combo image / Dockerfile without ext.
 
 DOCKER_PREFIX := docker.io/fortio/fortio
-BUILD_IMAGE_TAG := v50@sha256:fe69c193d8ad40eb0d791984881f3678aead02660b8e3468c757f717892ada4c
+BUILD_IMAGE_TAG := v51@sha256:19c61def5203187354d7459781407c0d83895d20f100bfb6ff3a298c9f1cb2b6
 BUILDX_PLATFORMS := linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 BUILDX_POSTFIX :=
 ifeq '$(shell echo $(BUILDX_PLATFORMS) | awk -F "," "{print NF-1}")' '0'
@@ -111,6 +111,7 @@ update-build-image:
 
 # Get the sha (use after newly building a new build image) to put it back in BUILD_IMAGE_TAG
 build-image-sha:
+	docker pull $(BUILD_IMAGE)
 	docker inspect $(BUILD_IMAGE) | jq -r '.[0].RepoDigests[0]' | sed -e "s/^.*@/$(BUILD_IMAGE_TAG)@/"
 
 SED:=sed

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -141,7 +141,7 @@ fi
 PPROF_URL="$BASE_URL/debug/pprof/heap?debug=1"
 $CURL "$PPROF_URL" | grep -i TotalAlloc # should find this in memory profile
 # creating dummy container to hold a volume for test certs due to remote docker bind mount limitation.
-DOCKERCURLID=$(docker run -d -v $TEST_CERT_VOL --net host --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v50@sha256:fe69c193d8ad40eb0d791984881f3678aead02660b8e3468c757f717892ada4c sleep 120)
+DOCKERCURLID=$(docker run -d -v $TEST_CERT_VOL --net host --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v51@sha256:19c61def5203187354d7459781407c0d83895d20f100bfb6ff3a298c9f1cb2b6 sleep 120)
 # while we have something with actual curl binary do
 # Test for h2c upgrade (#562)
 docker exec $DOCKERSECVOLNAME /usr/bin/curl -v --http2 -m 10 -d foo42 http://localhost:8080/debug | tee >(cat 1>&2) | grep foo42

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -1,5 +1,5 @@
 # Concatenated after ../Dockerfile to create the tgz
-FROM docker.io/fortio/fortio.build:v50@sha256:fe69c193d8ad40eb0d791984881f3678aead02660b8e3468c757f717892ada4c as stage
+FROM docker.io/fortio/fortio.build:v51@sha256:19c61def5203187354d7459781407c0d83895d20f100bfb6ff3a298c9f1cb2b6 as stage
 ARG archs="amd64 arm64 ppc64le s390x"
 ENV archs=${archs}
 # Build image defaults to build user, switch back to root for


### PR DESCRIPTION
This done following steps in release/README.md

```
# bump to 51 then
make update-build-image
# get new sha (fixed that we need to pull first to do so)
make build-image-sha
# update all places where it's used
make update-build-image-tag SED=gsed
# check lint
make lint
```