### PR TITLE
fix special grpc metadata handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ You can install from source:
 The [releases](https://github.com/fortio/fortio/releases) page has binaries for many OS/architecture combinations (see assets):
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.40.0/fortio-linux_amd64-1.40.0.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.40.1/fortio-linux_amd64-1.40.1.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.40.0/fortio_1.40.0_amd64.deb
-dpkg -i fortio_1.40.0_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.40.1/fortio_1.40.1_amd64.deb
+dpkg -i fortio_1.40.1_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.40.0/fortio-1.40.0-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.40.1/fortio-1.40.1-1.x86_64.rpm
 # and more, see assets in release page
 ```
 
@@ -70,7 +70,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.40.0/fortio_win_1.40.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.40.1/fortio_win_1.40.1.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -119,7 +119,7 @@ Full list of command line flags (`fortio help`):
 <details>
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
-Φορτίο 1.40.0 usage:
+Φορτίο 1.40.1 usage:
     fortio command [flags] target
 where command is one of: load (load testing), server (starts ui, rest api,
  http-echo, redirect, proxies, tcp-echo, udp-echo and grpc ping servers),

--- a/fgrpc/grpcrunner.go
+++ b/fgrpc/grpcrunner.go
@@ -57,7 +57,7 @@ func Dial(o *GRPCRunnerOptions) (*grpc.ClientConn, error) {
 			return net.Dial(fnet.UnixDomainSocket, o.UnixDomainSocket)
 		}))
 	}
-	opts = append(opts, extractDialOptions(o.Metadata)...)
+	opts = append(opts, o.dialOptions...)
 	conn, err := grpc.Dial(serverAddr, opts...)
 	if err != nil {
 		log.Errf("failed to connect to %s with certificate %s and override %s: %v", serverAddr, o.CACert, o.CertOverride, err)
@@ -89,8 +89,8 @@ func (grpcstate *GRPCRunnerResults) Run(outCtx context.Context, t periodic.Threa
 	var err error
 	var res interface{}
 	status := grpc_health_v1.HealthCheckResponse_SERVING
-	if grpcstate.Metadata.Len() != 0 {
-		outCtx = metadata.NewOutgoingContext(outCtx, sanitize(grpcstate.Metadata))
+	if len(grpcstate.Metadata) != 0 { // filtered one
+		outCtx = metadata.NewOutgoingContext(outCtx, grpcstate.Metadata)
 	}
 	if grpcstate.Ping {
 		res, err = grpcstate.clientP.Ping(outCtx, &grpcstate.reqP)
@@ -121,15 +121,17 @@ type GRPCRunnerOptions struct {
 	periodic.RunnerOptions
 	fhttp.TLSOptions
 	Destination        string
-	Service            string        // Service to be checked when using grpc health check
-	Profiler           string        // file to save profiles to. defaults to no profiling
-	Payload            string        // Payload to be sent for grpc ping service
-	Streams            int           // number of streams. total go routines and data streams will be streams*numthreads.
-	Delay              time.Duration // Delay to be sent when using grpc ping service
-	CertOverride       string        // Override the cert virtual host of authority for testing
-	AllowInitialErrors bool          // whether initial errors don't cause an abort
-	UsePing            bool          // use our own Ping proto for grpc load instead of standard health check one.
-	Metadata           metadata.MD   // metadata that will be added to the request
+	Service            string            // Service to be checked when using grpc health check
+	Profiler           string            // file to save profiles to. defaults to no profiling
+	Payload            string            // Payload to be sent for grpc ping service
+	Streams            int               // number of streams. total go routines and data streams will be streams*numthreads.
+	Delay              time.Duration     // Delay to be sent when using grpc ping service
+	CertOverride       string            // Override the cert virtual host of authority for testing
+	AllowInitialErrors bool              // whether initial errors don't cause an abort
+	UsePing            bool              // use our own Ping proto for grpc load instead of standard health check one.
+	Metadata           metadata.MD       // input metadata that will be added to the request
+	dialOptions        []grpc.DialOption // grpc dial options extracted from Metadata (authority and user-agent extracted)
+	filteredMetadata   metadata.MD       // filtered version of Metadata metadata (without authority and user-agent)
 }
 
 // RunGRPCTest runs an http test and returns the aggregated stats.
@@ -160,11 +162,13 @@ func RunGRPCTest(o *GRPCRunnerOptions) (*GRPCRunnerResults, error) {
 	r := periodic.NewPeriodicRunner(&o.RunnerOptions)
 	defer r.Options().Abort()
 	numThreads := r.Options().NumThreads // may change
+	o.dialOptions, o.filteredMetadata = extractDialOptions(o.Metadata)
 	total := GRPCRunnerResults{
 		RetCodes:    make(HealthResultMap),
 		Destination: o.Destination,
 		Streams:     o.Streams,
 		Ping:        o.UsePing,
+		Metadata:    o.Metadata, // the original one
 	}
 	grpcstate := make([]GRPCRunnerResults, numThreads)
 	out := r.Options().Out // Important as the default value is set from nil to stdout inside NewPeriodicRunner
@@ -185,9 +189,9 @@ func RunGRPCTest(o *GRPCRunnerOptions) (*GRPCRunnerResults, error) {
 		grpcstate[i].Ping = o.UsePing
 		var err error
 		outCtx := context.Background()
-		if o.Metadata.Len() != 0 {
-			outCtx = metadata.NewOutgoingContext(outCtx, sanitize(o.Metadata))
-			grpcstate[i].Metadata = o.Metadata
+		if o.filteredMetadata.Len() != 0 {
+			outCtx = metadata.NewOutgoingContext(outCtx, o.filteredMetadata)
+			grpcstate[i].Metadata = o.filteredMetadata // the one used to send
 		}
 		if o.UsePing { //nolint:nestif
 			grpcstate[i].clientP = NewPingServerClient(conn)
@@ -313,7 +317,8 @@ func grpcDestination(dest string) (parsedDest string) {
 }
 
 // extractDialOptions extract special MD and convert them to dial options.
-func extractDialOptions(in metadata.MD) (out []grpc.DialOption) {
+func extractDialOptions(in metadata.MD) (out []grpc.DialOption, outMD metadata.MD) {
+	outMD = make(metadata.MD, len(in))
 	for k, v := range in {
 		switch k {
 		// Transfer these 2
@@ -321,21 +326,10 @@ func extractDialOptions(in metadata.MD) (out []grpc.DialOption) {
 			out = append(out, grpc.WithUserAgent(v[0]))
 		case "host":
 			out = append(out, grpc.WithAuthority(v[0]))
-		}
-	}
-	return out
-}
-
-// sanitize remove special MD pairs.
-func sanitize(md metadata.MD) metadata.MD {
-	// copy
-	cp := make(metadata.MD, len(md))
-	for k, v := range md {
-		switch k {
-		case "user-agent", "host":
 		default:
-			cp[k] = v
+			outMD[k] = v
 		}
 	}
-	return cp
+	log.Infof("Extracted dial options: %+v", out)
+	return out, outMD
 }

--- a/fgrpc/grpcrunner.go
+++ b/fgrpc/grpcrunner.go
@@ -162,7 +162,7 @@ func RunGRPCTest(o *GRPCRunnerOptions) (*GRPCRunnerResults, error) {
 	r := periodic.NewPeriodicRunner(&o.RunnerOptions)
 	defer r.Options().Abort()
 	numThreads := r.Options().NumThreads // may change
-	o.dialOptions, o.filteredMetadata = extractDialOptions(o.Metadata)
+	o.dialOptions, o.filteredMetadata = extractDialOptionsAndFilter(o.Metadata)
 	total := GRPCRunnerResults{
 		RetCodes:    make(HealthResultMap),
 		Destination: o.Destination,
@@ -316,8 +316,8 @@ func grpcDestination(dest string) (parsedDest string) {
 	return parsedDest
 }
 
-// extractDialOptions extract special MD and convert them to dial options.
-func extractDialOptions(in metadata.MD) (out []grpc.DialOption, outMD metadata.MD) {
+// extractDialOptionsAndFilter converts special MD into dial options and filters them in outMD.
+func extractDialOptionsAndFilter(in metadata.MD) (out []grpc.DialOption, outMD metadata.MD) {
 	outMD = make(metadata.MD, len(in))
 	for k, v := range in {
 		switch k {

--- a/fgrpc/grpcrunner_test.go
+++ b/fgrpc/grpcrunner_test.go
@@ -547,9 +547,9 @@ func TestHeaderHandling(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotOut, mdOut := extractDialOptions(tt.args.in)
+			gotOut, mdOut := extractDialOptionsAndFilter(tt.args.in)
 			if !reflect.DeepEqual(len(gotOut), tt.wantOutLen) {
-				t.Errorf("extractDialOptions() = %v, want %v", len(gotOut), tt.wantOutLen)
+				t.Errorf("extractDialOptionsAndFilter() = %v, want %v", len(gotOut), tt.wantOutLen)
 			}
 			if !reflect.DeepEqual(mdOut, tt.wantMD) {
 				t.Errorf("got md = %v, want %v", tt.args.in, tt.wantMD)

--- a/fgrpc/grpcrunner_test.go
+++ b/fgrpc/grpcrunner_test.go
@@ -397,10 +397,10 @@ func TestGRPCDestination(t *testing.T) {
 }
 
 type mdTestServer struct {
+	t       *testing.T
 	mdKey   string
 	mdValue string
 	health.Server
-	error
 }
 
 func (m *mdTestServer) Ping(ctx context.Context, _ *PingMessage) (*PingMessage, error) {
@@ -408,7 +408,7 @@ func (m *mdTestServer) Ping(ctx context.Context, _ *PingMessage) (*PingMessage, 
 	val := md.Get(m.mdKey)
 
 	if len(val) == 0 || val[0] != m.mdValue {
-		m.error = fmt.Errorf("metadata %s not found or value is not %s,actual value: %v", m.mdKey, m.mdValue, val)
+		m.t.Errorf("metadata %s not found or value is not %s,actual value: %v", m.mdKey, m.mdValue, val)
 	}
 	return &PingMessage{}, nil
 }
@@ -418,7 +418,7 @@ func (m *mdTestServer) Check(ctx context.Context, _ *grpc_health_v1.HealthCheckR
 	md, _ := metadata.FromIncomingContext(ctx)
 	val := md.Get(m.mdKey)
 	if len(val) == 0 || val[0] != m.mdValue {
-		m.error = fmt.Errorf("metadata %s not found or value is not %s,actual value: %v", m.mdKey, m.mdValue, val)
+		m.t.Errorf("metadata %q not found or value is not %q, actual value: %v", m.mdKey, m.mdValue, val)
 	}
 	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
 }
@@ -427,7 +427,7 @@ func (m *mdTestServer) Serve() *net.TCPAddr {
 	server := grpc.NewServer()
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		m.error = err
+		m.t.Fatal(err)
 		return nil
 	}
 	grpc_health_v1.RegisterHealthServer(server, m)
@@ -442,11 +442,8 @@ func (m *mdTestServer) Serve() *net.TCPAddr {
 }
 
 func TestGRPCRunnerWithMetadata(t *testing.T) {
-	server := &mdTestServer{}
+	server := &mdTestServer{t: t}
 	addr := server.Serve()
-	if server.error != nil {
-		t.Fatal(server.error)
-	}
 	tests := []struct {
 		name      string
 		key       string
@@ -476,7 +473,6 @@ func TestGRPCRunnerWithMetadata(t *testing.T) {
 			server.mdKey = test.serverKey
 		}
 		server.mdValue = test.value
-		server.error = nil
 		_, err := RunGRPCTest(&GRPCRunnerOptions{
 			Streams:     10,
 			Destination: addr.String(),
@@ -485,11 +481,9 @@ func TestGRPCRunnerWithMetadata(t *testing.T) {
 			},
 		})
 		if err != nil {
-			t.Errorf("Test case: %s failed , err: %v", test.name, err)
+			t.Errorf("Test case: %s failed, err: %v", test.name, err)
 		}
-		if server.error != nil {
-			t.Errorf("Test case: %s failed , err: %v", test.name, server.error)
-		}
+		// errors will be set by the server
 	}
 }
 
@@ -553,11 +547,11 @@ func TestHeaderHandling(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotOut := extractDialOptions(tt.args.in)
+			gotOut, mdOut := extractDialOptions(tt.args.in)
 			if !reflect.DeepEqual(len(gotOut), tt.wantOutLen) {
 				t.Errorf("extractDialOptions() = %v, want %v", len(gotOut), tt.wantOutLen)
 			}
-			if !reflect.DeepEqual(sanitize(tt.args.in), tt.wantMD) {
+			if !reflect.DeepEqual(mdOut, tt.wantMD) {
 				t.Errorf("got md = %v, want %v", tt.args.in, tt.wantMD)
 			}
 		})

--- a/fgrpc/pingsrv.go
+++ b/fgrpc/pingsrv.go
@@ -114,7 +114,7 @@ func PingServerTCP(port, cert, key, healthServiceName string, maxConcurrentStrea
 func PingClientCall(serverAddr string, n int, payload string, delay time.Duration, tlsOpts *fhttp.TLSOptions, md metadata.MD,
 ) (float64, error) {
 	o := GRPCRunnerOptions{Destination: serverAddr, TLSOptions: *tlsOpts, Metadata: md}
-	o.dialOptions, o.filteredMetadata = extractDialOptions(md)
+	o.dialOptions, o.filteredMetadata = extractDialOptionsAndFilter(md)
 	conn, err := Dial(&o) // somehow this never seem to error out, error comes later
 	if err != nil {
 		return -1, err // error already logged
@@ -178,7 +178,7 @@ type HealthResultMap map[string]int64
 func GrpcHealthCheck(serverAddr, svcname string, n int, tlsOpts *fhttp.TLSOptions, md metadata.MD) (*HealthResultMap, error) {
 	log.Infof("GrpcHealthCheck for %s svc '%s', %d iterations", serverAddr, svcname, n)
 	o := GRPCRunnerOptions{Destination: serverAddr, TLSOptions: *tlsOpts, Metadata: md}
-	o.dialOptions, o.filteredMetadata = extractDialOptions(md)
+	o.dialOptions, o.filteredMetadata = extractDialOptionsAndFilter(md)
 	conn, err := Dial(&o)
 	if err != nil {
 		return nil, err

--- a/fgrpc/pingsrv.go
+++ b/fgrpc/pingsrv.go
@@ -122,7 +122,7 @@ func PingClientCall(serverAddr string, n int, payload string, delay time.Duratio
 	cli := NewPingServerClient(conn)
 	outCtx := context.Background()
 	if md.Len() != 0 {
-		outCtx = metadata.NewOutgoingContext(outCtx, md)
+		outCtx = metadata.NewOutgoingContext(outCtx, sanitize(md))
 	}
 	// Warm up:
 	_, err = cli.Ping(outCtx, msg)
@@ -176,7 +176,7 @@ type HealthResultMap map[string]int64
 // service.
 func GrpcHealthCheck(serverAddr, svcname string, n int, tlsOpts *fhttp.TLSOptions, md metadata.MD) (*HealthResultMap, error) {
 	log.Infof("GrpcHealthCheck for %s svc '%s', %d iterations", serverAddr, svcname, n)
-	o := GRPCRunnerOptions{Destination: serverAddr, TLSOptions: *tlsOpts}
+	o := GRPCRunnerOptions{Destination: serverAddr, TLSOptions: *tlsOpts, Metadata: md}
 	conn, err := Dial(&o)
 	if err != nil {
 		return nil, err
@@ -188,7 +188,7 @@ func GrpcHealthCheck(serverAddr, svcname string, n int, tlsOpts *fhttp.TLSOption
 
 	outCtx := context.Background()
 	if md.Len() != 0 {
-		outCtx = metadata.NewOutgoingContext(outCtx, md)
+		outCtx = metadata.NewOutgoingContext(outCtx, sanitize(md))
 	}
 	for i := 1; i <= n; i++ {
 		start := time.Now()

--- a/fgrpc/pingsrv.go
+++ b/fgrpc/pingsrv.go
@@ -114,6 +114,7 @@ func PingServerTCP(port, cert, key, healthServiceName string, maxConcurrentStrea
 func PingClientCall(serverAddr string, n int, payload string, delay time.Duration, tlsOpts *fhttp.TLSOptions, md metadata.MD,
 ) (float64, error) {
 	o := GRPCRunnerOptions{Destination: serverAddr, TLSOptions: *tlsOpts, Metadata: md}
+	o.dialOptions, o.filteredMetadata = extractDialOptions(md)
 	conn, err := Dial(&o) // somehow this never seem to error out, error comes later
 	if err != nil {
 		return -1, err // error already logged
@@ -122,7 +123,7 @@ func PingClientCall(serverAddr string, n int, payload string, delay time.Duratio
 	cli := NewPingServerClient(conn)
 	outCtx := context.Background()
 	if md.Len() != 0 {
-		outCtx = metadata.NewOutgoingContext(outCtx, sanitize(md))
+		outCtx = metadata.NewOutgoingContext(outCtx, o.filteredMetadata)
 	}
 	// Warm up:
 	_, err = cli.Ping(outCtx, msg)
@@ -177,6 +178,7 @@ type HealthResultMap map[string]int64
 func GrpcHealthCheck(serverAddr, svcname string, n int, tlsOpts *fhttp.TLSOptions, md metadata.MD) (*HealthResultMap, error) {
 	log.Infof("GrpcHealthCheck for %s svc '%s', %d iterations", serverAddr, svcname, n)
 	o := GRPCRunnerOptions{Destination: serverAddr, TLSOptions: *tlsOpts, Metadata: md}
+	o.dialOptions, o.filteredMetadata = extractDialOptions(md)
 	conn, err := Dial(&o)
 	if err != nil {
 		return nil, err
@@ -188,7 +190,7 @@ func GrpcHealthCheck(serverAddr, svcname string, n int, tlsOpts *fhttp.TLSOption
 
 	outCtx := context.Background()
 	if md.Len() != 0 {
-		outCtx = metadata.NewOutgoingContext(outCtx, sanitize(md))
+		outCtx = metadata.NewOutgoingContext(outCtx, o.filteredMetadata)
 	}
 	for i := 1; i <= n; i++ {
 		start := time.Now()

--- a/fgrpc/pingsrv_test.go
+++ b/fgrpc/pingsrv_test.go
@@ -129,9 +129,6 @@ func TestSettingMetadata(t *testing.T) {
 	server := &mdTestServer{}
 	addr := server.Serve()
 	TLSInsecure := &fhttp.TLSOptions{Insecure: true}
-	if server.error != nil {
-		t.Fatal(server.error)
-	}
 	tests := []struct {
 		name      string
 		key       string
@@ -162,15 +159,11 @@ func TestSettingMetadata(t *testing.T) {
 			server.mdKey = test.serverKey
 		}
 		server.mdValue = test.value
-		server.error = nil
 		_, err := PingClientCall(addr.String(), 2, "", 0, TLSInsecure, metadata.MD{
 			test.key: []string{test.value},
 		})
 		if err != nil {
 			t.Errorf("PingClientCall test case: %s failed , err: %v", test.name, err)
-		}
-		if server.error != nil {
-			t.Errorf("PingClientCall test case: %s failed , err: %v", test.name, server.error)
 		}
 	}
 
@@ -180,15 +173,11 @@ func TestSettingMetadata(t *testing.T) {
 			server.mdKey = test.serverKey
 		}
 		server.mdValue = test.value
-		server.error = nil
 		_, err := GrpcHealthCheck(addr.String(), "", 2, TLSInsecure, metadata.MD{
 			test.key: []string{test.value},
 		})
 		if err != nil {
 			t.Errorf("GrpcHealthCheck test case: %s failed , err: %v", test.name, err)
-		}
-		if server.error != nil {
-			t.Errorf("GrpcHealthCheck test case: %s failed , err: %v", test.name, server.error)
 		}
 	}
 }

--- a/fgrpc/pingsrv_test.go
+++ b/fgrpc/pingsrv_test.go
@@ -133,9 +133,10 @@ func TestSettingMetadata(t *testing.T) {
 		t.Fatal(server.error)
 	}
 	tests := []struct {
-		name  string
-		key   string
-		value string
+		name      string
+		key       string
+		serverKey string
+		value     string
 	}{
 		{
 			name:  "valid metadata",
@@ -147,9 +148,19 @@ func TestSettingMetadata(t *testing.T) {
 			key:   "ghi",
 			value: "",
 		},
+		{
+			name:      "authority",
+			key:       "host",
+			serverKey: ":authority",
+			value:     "xyz",
+		},
 	}
+
 	for _, test := range tests {
 		server.mdKey = test.key
+		if test.serverKey != "" {
+			server.mdKey = test.serverKey
+		}
 		server.mdValue = test.value
 		server.error = nil
 		_, err := PingClientCall(addr.String(), 2, "", 0, TLSInsecure, metadata.MD{
@@ -165,6 +176,9 @@ func TestSettingMetadata(t *testing.T) {
 
 	for _, test := range tests {
 		server.mdKey = test.key
+		if test.serverKey != "" {
+			server.mdKey = test.serverKey
+		}
 		server.mdValue = test.value
 		server.error = nil
 		_, err := GrpcHealthCheck(addr.String(), "", 2, TLSInsecure, metadata.MD{


### PR DESCRIPTION
fix https://github.com/fortio/fortio/issues/700

There is a bug in the current handling of special grpc metadata (user-agent,host): 
The MD itself is modified in the Dial method so that other threads cannot read the original MD while establishing a connection 

Modifications to the MD are now moved outside of the Dial and need to be called separately when the request is sent