### PR TITLE
refactor to use fortio.org/cli and scli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ VOLUME /var/lib/fortio
 WORKDIR /var/lib/fortio
 ENTRYPOINT ["/usr/bin/fortio"]
 # start the server mode (grpc ping on 8079, http echo and UI on 8080, redirector on 8081) by default
-CMD ["server", "-config", "/etc/fortio"]
+CMD ["server", "-config-dir", "/etc/fortio"]

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ Fortio components can be used a library even for unrelated projects, for instanc
 A recent addition is the new `jrpc` JSON Remote Procedure Calls library package ([docs](https://pkg.go.dev/fortio.org/fortio/jrpc)).
 
 We also have moved some of the library to their own toplevel package, like:
-- Dynamic flags: [fortio.org/dflag](https://github.com/fortio/dflag/#fortio-dynamic-flags-was-go-flagz)
+- Dynamic flags: [fortio.org/dflag](https://github.com/fortio/dflag#fortio-dynamic-flags)
 - Logger: [fortio.org/log](https://github.com/fortio/log#log)
 - Version helper: [fortio.org/version](https://github.com/fortio/version#version)
+- CLI helpers integrating the above to reduce toil making new tools [fortio.org/cli](https://github.com/fortio/cli#cli) and servers [fortio.org/scli](https://github.com/fortio/scli#scli) for arguments, flags, usage, dynamic config, etc...
 
 If you want to connect to fortio using https and fortio to provide real TLS certificates, or to multiplex grpc and regular http behind a single port, check out [Fortio Proxy](https://github.com/fortio/proxy#fortio-proxy).
 

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ You can install from source:
 The [releases](https://github.com/fortio/fortio/releases) page has binaries for many OS/architecture combinations (see assets):
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.50.1/fortio-linux_amd64-1.50.1.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.51.0/fortio-linux_amd64-1.51.0.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.50.1/fortio_1.50.1_amd64.deb
-dpkg -i fortio_1.50.1_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.51.0/fortio_1.51.0_amd64.deb
+dpkg -i fortio_1.51.0_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.50.1/fortio-1.50.1-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.51.0/fortio-1.51.0-1.x86_64.rpm
 # and more, see assets in release page
 ```
 
@@ -74,7 +74,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.50.1/fortio_win_1.50.1.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.51.0/fortio_win_1.51.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -124,7 +124,7 @@ Full list of command line flags (`fortio help`):
 <details>
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
-Φορτίο 1.50.1 usage:
+Φορτίο 1.51.0 usage:
         fortio command [flags] target
 where command is one of: load (load testing), server (starts ui, rest api,
  http-echo, redirect, proxies, tcp-echo, udp-echo and grpc ping servers),
@@ -139,19 +139,17 @@ or 1 of the special arguments
         fortio {help|version|buildinfo}
 flags:
   -H key:value
-        Additional http header(s) or grpc metadata. Multiple key:value pairs
-can be passed using multiple -H.
+        Additional http header(s) or grpc metadata. Multiple key:value pairs can be
+passed using multiple -H.
   -L    Follow redirects (implies -std-client) - do not use for load test
   -M value
-        Http multi proxy to run, e.g -M "localport1 baseDestURL1 baseDestURL2"
--M ...
+        Http multi proxy to run, e.g -M "localport1 baseDestURL1 baseDestURL2" -M ...
   -P value
-        Tcp proxies to run, e.g -P "localport1 dest_host1:dest_port1" -P
-"[::1]:0 www.google.com:443" ...
+        Tcp proxies to run, e.g -P "localport1 dest_host1:dest_port1" -P "[::1]:0
+www.google.com:443" ...
   -a    Automatically save JSON result with filename based on labels & timestamp
   -abort-on code
-        Http code that if encountered aborts the run. e.g. 503 or -1 for socket
-errors.
+        Http code that if encountered aborts the run. e.g. 503 or -1 for socket errors.
   -access-log-file path
         file path to log all requests to. Maybe have performance impacts
   -access-log-format format
@@ -159,13 +157,13 @@ errors.
   -allow-initial-errors
         Allow and don't abort on initial warmup errors
   -base-url URL
-        base URL used as prefix for data/index.tsv generation. (when empty, the
-url from the first request is used)
+        base URL used as prefix for data/index.tsv generation. (when empty, the url from
+the first request is used)
   -c int
         Number of connections/goroutine/threads (default 4)
   -cacert Path
-        Path to a custom CA certificate file to be used for the TLS client
-connections, if empty, use https:// prefix for standard internet/system CAs
+        Path to a custom CA certificate file to be used for the TLS client connections,
+if empty, use https:// prefix for standard internet/system CAs
   -calc-qps
         Calculate the qps based on number of requests (-n) and duration (-t)
   -cert Path
@@ -177,36 +175,36 @@ connections, if empty, use https:// prefix for standard internet/system CAs
   -config-port port
         Config port to open for dynamic flag UI/api
   -connection-reuse min:max
-        Range min:max for the max number of connections to reuse for each
-thread, default to unlimited. e.g. 10:30 means randomly choose a max connection
-reuse threshold between 10 and 30 requests.
+        Range min:max for the max number of connections to reuse for each thread, default
+to unlimited. e.g. 10:30 means randomly choose a max connection reuse threshold between
+10 and 30 requests.
   -content-type string
-        Sets http content type. Setting this value switches the request method
-from GET to POST.
+        Sets http content type. Setting this value switches the request method from GET
+to POST.
   -curl
         Just fetch the content once
   -curl-stdout-headers
-        Restore pre 1.22 behavior where http headers of the fast client are
-output to stdout in curl mode. now stderr by default.
+        Restore pre 1.22 behavior where http headers of the fast client are output to
+stdout in curl mode. now stderr by default.
   -data-dir Directory
         Directory where JSON results are stored/read (default ".")
   -dns-method method
-        When a name resolves to multiple ip, which method to pick: cached-rr
-for cached round robin, rnd for random, first for first answer (pre 1.30
-behavior), rr for round robin. (default cached-rr)
+        When a name resolves to multiple ip, which method to pick: cached-rr for cached
+round robin, rnd for random, first for first answer (pre 1.30 behavior), rr for round
+robin. (default cached-rr)
   -echo-debug-path URI
-        http echo server URI for debug, empty turns off that part (more secure)
-(default "/debug")
+        http echo server URI for debug, empty turns off that part (more secure) (default
+"/debug")
   -echo-server-default-params value
-        Default parameters/querystring to use if there isn't one provided
-explicitly. E.g "status=404&delay=3s"
+        Default parameters/querystring to use if there isn't one provided explicitly. E.g
+"status=404&delay=3s"
   -gomaxprocs int
         Setting for runtime.GOMAXPROCS, &lt;1 doesn't change the default
   -grpc
         Use GRPC (health check by default, add -ping for ping) for load testing
   -grpc-max-streams uint
-        MaxConcurrentStreams for the grpc server. Default (0) is to leave the
-option unset.
+        MaxConcurrentStreams for the grpc server. Default (0) is to leave the option
+unset.
   -grpc-ping-delay duration
         grpc ping delay in response
   -grpc-port port
@@ -216,20 +214,19 @@ option unset.
   -h2
         Attempt to use http2.0 / h2 (instead of http 1.1) with stdclient and TLS
   -halfclose
-        When not keepalive, whether to half close the connection (only for fast
-http)
+        When not keepalive, whether to half close the connection (only for fast http)
   -health
         grpc ping client mode: use health instead of ping
   -healthservice string
         which service string to pass to health check
   -http-port port
-        http echo server port. Can be in the form of host:port, ip:port, port
-or /unix/domain/path or "disabled". (default "8080")
+        http echo server port. Can be in the form of host:port, ip:port, port or
+/unix/domain/path or "disabled". (default "8080")
   -http1.0
         Use http1.0 (instead of http 1.1)
   -httpbufferkb kbytes
-        Size of the buffer (max data size) for the optimized http client in
-kbytes (default 128)
+        Size of the buffer (max data size) for the optimized http client in kbytes
+(default 128)
   -httpccch
         Check for Connection: Close Header
   -https-insecure
@@ -237,43 +234,40 @@ kbytes (default 128)
   -jitter
         set to true to de-synchronize parallel clients' by 10%
   -json path
-        Json output to provided file path or '-' for stdout (empty = no json
-output, unless -a is used)
+        Json output to provided file path or '-' for stdout (empty = no json output,
+unless -a is used)
   -k    Do not verify certs in https/tls/grpc connections
   -keepalive
         Keep connection alive (only for fast http 1.1) (default true)
   -key Path
         Path to the key file matching the -cert
   -labels string
-        Additional config data/labels to add to the resulting JSON, defaults to
-target URL and hostname
+        Additional config data/labels to add to the resulting JSON, defaults to target
+URL and hostname
   -log-errors
         Log http non 2xx/418 error codes as they occur (default true)
   -loglevel level
-        log level, one of [Debug Verbose Info Warning Error Critical Fatal]
-(default Info)
+        log level, one of [Debug Verbose Info Warning Error Critical Fatal] (default Info)
   -max-echo-delay value
-        Maximum sleep time for delay= echo server parameter. dynamic flag.
-(default 1.5s)
+        Maximum sleep time for delay= echo server parameter. dynamic flag. (default 1.5s)
   -maxpayloadsizekb Kbytes
-        MaxPayloadSize is the maximum size of payload to be generated by the
-EchoHandler size= argument. In Kbytes. (default 256)
+        MaxPayloadSize is the maximum size of payload to be generated by the EchoHandler
+size= argument. In Kbytes. (default 256)
   -multi-mirror-origin
-        Mirror the request url to the target for multi proxies (-M) (default
-true)
+        Mirror the request url to the target for multi proxies (-M) (default true)
   -multi-serial-mode
         Multi server (-M) requests one at a time instead of parallel mode
   -n int
-        Run for exactly this number of calls instead of duration. Default (0)
-is to use duration (-t). Default is 1 when used as grpc ping count.
+        Run for exactly this number of calls instead of duration. Default (0) is to use
+duration (-t). Default is 1 when used as grpc ping count.
   -nc-dont-stop-on-eof
         in netcat (nc) mode, don't abort as soon as remote side closes
   -no-reresolve
-        Keep the initial DNS resolution and don't re-resolve when making new
-connections (because of error or reuse limit reached)
+        Keep the initial DNS resolution and don't re-resolve when making new connections
+(because of error or reuse limit reached)
   -nocatchup
-        set to exact fixed qps and prevent fortio from trying to catchup when
-the target fails to keep up temporarily
+        set to exact fixed qps and prevent fortio from trying to catchup when the target
+fails to keep up temporarily
   -offset duration
         Offset of the histogram data
   -p string
@@ -281,18 +275,17 @@ the target fails to keep up temporarily
   -payload string
         Payload string to send along
   -payload-file path
-        File path to be use as payload (POST for http), replaces -payload when
-set.
+        File path to be use as payload (POST for http), replaces -payload when set.
   -payload-size int
-        Additional random payload size, replaces -payload when set > 0, must be
-smaller than -maxpayloadsizekb. Setting this switches http to POST.
+        Additional random payload size, replaces -payload when set > 0, must be smaller
+than -maxpayloadsizekb. Setting this switches http to POST.
   -ping
         grpc load test: use ping instead of health
   -profile file
         write .cpu and .mem profiles to file
   -proxy-all-headers
-        Determines if only tracing or all headers (and cookies) are copied from
-request on the fetch2 ui/server endpoint (default true)
+        Determines if only tracing or all headers (and cookies) are copied from request
+on the fetch2 ui/server endpoint (default true)
   -qps float
         Queries Per Seconds or 0 for no wait/max qps (default 8)
   -quiet
@@ -300,22 +293,20 @@ request on the fetch2 ui/server endpoint (default true)
   -r float
         Resolution of the histogram lowest buckets in seconds (default 0.001)
   -redirect-port port
-        Redirect all incoming traffic to https URL (need ingress to work
-properly). Can be in the form of host:port, ip:port, port or "disabled" to
-disable the feature. (default "8081")
+        Redirect all incoming traffic to https URL (need ingress to work properly). Can
+be in the form of host:port, ip:port, port or "disabled" to disable the feature. (default
+"8081")
   -resolve IP
         Resolve host name to this IP
   -resolve-ip-type type
-        Resolve type: ip4 for ipv4, ip6 for ipv6 only, use ip for both (default
-ip4)
+        Resolve type: ip4 for ipv4, ip6 for ipv6 only, use ip for both (default ip4)
   -runid int
-        Optional RunID to add to json result and auto save filename, to match
-server mode
+        Optional RunID to add to json result and auto save filename, to match server mode
   -s int
         Number of streams per grpc connection (default 1)
   -sequential-warmup
-        http(s) runner warmup done in parallel instead of sequentially. When
-set, restores pre 1.21 behavior
+        http(s) runner warmup done in parallel instead of sequentially. When set,
+restores pre 1.21 behavior
   -server-idle-timeout value
         Default IdleTimeout for servers (default 30s)
   -static-dir path
@@ -341,15 +332,15 @@ set, restores pre 1.21 behavior
   -udp-timeout duration
         Udp timeout (default 750ms)
   -ui-path URI
-        http server URI for UI, empty turns off that part (more secure)
-(default "/fortio/")
+        http server URI for UI, empty turns off that part (more secure) (default
+"/fortio/")
   -uniform
         set to true to de-synchronize parallel clients' requests uniformly
   -unix-socket path
         Unix domain socket path to use for physical connection
   -user user:password
-        User credentials for basic authentication (for http). Input data format
-should be user:password
+        User credentials for basic authentication (for http). Input data format should be
+user:password
 </pre>
 </details>
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ It can also fetch a single URL's for debugging when using the `curl` command (or
 Likewise you can establish a single TCP (or unix domain or UDP (use `udp://` prefix)) connection using the `nc` command (like the standalone netcat package).
 You can run just the redirector with `redirect` or just the tcp echo with `tcp-echo`.
 If you saved JSON results (using the web UI or directly from the command line), you can browse and graph those results using the `report` command.
-The `version` command will print version and build information, `fortio version -s` just the version.
+The `version` command will the short print versiob. `fortio buildinfo` will print the full
+build information.
 Lastly, you can learn which flags are available using `help` command.
 
 Most important flags for http load generation:
@@ -124,7 +125,7 @@ Full list of command line flags (`fortio help`):
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
 Φορτίο 1.50.1 usage:
-    fortio command [flags] target
+        fortio command [flags] target
 where command is one of: load (load testing), server (starts ui, rest api,
  http-echo, redirect, proxies, tcp-echo, udp-echo and grpc ping servers),
  tcp-echo (only the tcp-echo server), udp-echo (only udp-echo server),
@@ -134,7 +135,9 @@ where command is one of: load (load testing), server (starts ui, rest api,
  or version (prints the full version and build details).
 where target is a url (http load tests) or host:port (grpc health test),
  or tcp://host:port (tcp load test), or udp://host:port (udp load test).
-flags are:
+or 1 of the special arguments
+        fortio {help|version|buildinfo}
+flags:
   -H key:value
         Additional http header(s) or grpc metadata. Multiple key:value pairs
 can be passed using multiple -H.
@@ -169,9 +172,10 @@ connections, if empty, use https:// prefix for standard internet/system CAs
         Path to the certificate file to be used for client or server TLS
   -compression
         Enable http compression
-  -config path
-        Config directory path to watch for changes of dynamic flags (empty for
-no watch)
+  -config-dir directory
+        Config directory to watch for dynamic flag changes
+  -config-port port
+        Config port to open for dynamic flag UI/api
   -connection-reuse min:max
         Range min:max for the max number of connections to reuse for each
 thread, default to unlimited. e.g. 10:30 means randomly choose a max connection
@@ -292,7 +296,7 @@ request on the fetch2 ui/server endpoint (default true)
   -qps float
         Queries Per Seconds or 0 for no wait/max qps (default 8)
   -quiet
-        Quiet mode: sets the loglevel to Error and reduces the output.
+        Quiet mode, sets loglevel to Error (quietly) to reduces the output
   -r float
         Resolution of the histogram lowest buckets in seconds (default 0.001)
   -redirect-port port

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ It can also fetch a single URL's for debugging when using the `curl` command (or
 Likewise you can establish a single TCP (or unix domain or UDP (use `udp://` prefix)) connection using the `nc` command (like the standalone netcat package).
 You can run just the redirector with `redirect` or just the tcp echo with `tcp-echo`.
 If you saved JSON results (using the web UI or directly from the command line), you can browse and graph those results using the `report` command.
-The `version` command will the short print versiob. `fortio buildinfo` will print the full
+The `version` command will print the short print versiob. `fortio buildinfo` will print the full
 build information.
 Lastly, you can learn which flags are available using `help` command.
 

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -83,7 +83,7 @@ $CURL "${BASE_FORTIO}fetch/localhost:8080${FORTIO_UI_PREFIX}rest/run?url=http://
 # Check we can connect, and run a grpc QPS test against ourselves through fetch
 $CURL "${BASE_FORTIO}fetch/localhost:8080$FORTIO_UI_PREFIX?url=localhost:8079&load=Start&qps=-1&json=on&n=100&runner=grpc" | grep '"SERVING": 100'
 # Check we get the logo (need to remove the CR from raw headers)
-VERSION=$(docker exec $DOCKERNAME $FORTIO_BIN_PATH version -s)
+VERSION=$(docker exec $DOCKERNAME $FORTIO_BIN_PATH version)
 LOGO_TYPE=$($CURL "${BASE_FORTIO}${VERSION}/static/img/${LOGO}" 2>&1 >/dev/null | grep -i Content-Type: | tr -d '\r'| awk '{print $2}')
 if [ "$LOGO_TYPE" != "image/svg+xml" ]; then
   echo "Unexpected content type for the logo: $LOGO_TYPE"
@@ -104,7 +104,7 @@ if [ "$SIZE" -lt 8191 ] || [ "$SIZE" -gt 8400 ]; then
 fi
 
 # Check main, sync, browse pages
-VERSION=$(docker exec $DOCKERNAME $FORTIO_BIN_PATH version -s)
+VERSION=$(docker exec $DOCKERNAME $FORTIO_BIN_PATH version)
 LOGOPATH="${VERSION}/static/img/${LOGO}"
 for p in "" browse sync; do
   # Check the page doesn't 404s

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -104,7 +104,6 @@ if [ "$SIZE" -lt 8191 ] || [ "$SIZE" -gt 8400 ]; then
 fi
 
 # Check main, sync, browse pages
-VERSION=$(docker exec $DOCKERNAME $FORTIO_BIN_PATH version)
 LOGOPATH="${VERSION}/static/img/${LOGO}"
 for p in "" browse sync; do
   # Check the page doesn't 404s

--- a/bincommon/commonflags.go
+++ b/bincommon/commonflags.go
@@ -107,6 +107,8 @@ var (
 )
 
 // SharedMain is the common part of main from fortio_main and fcurl.
+// It sets up the common flags, the rest of usage/argument/flag handling
+// is now moved to the [fortio.org/cli] and [fortio.org/scli] packages.
 func SharedMain() {
 	flag.Var(&headersFlags, "H",
 		"Additional http header(s) or grpc metadata. Multiple `key:value` pairs can be passed using multiple -H.")

--- a/bincommon/commonflags.go
+++ b/bincommon/commonflags.go
@@ -129,7 +129,7 @@ func SharedMain() {
 	// MaxDelay is the maximum delay allowed for the echoserver responses.
 	// It is a dynamic flag with default value of 1.5s so we can test the default 1s timeout in envoy.
 	dflag.Flag("max-echo-delay", fhttp.MaxDelay)
-	// This sets up the logger's -loglevel as a dynamic flag.
+	// call [scli.ServerMain()] to complete the setup.
 }
 
 // FetchURL is fetching url content and exiting with 1 upon error.

--- a/cli/fortio_main.go
+++ b/cli/fortio_main.go
@@ -197,12 +197,12 @@ func FortioMain(hook bincommon.FortioHook) {
 		// fortiotel presets this.
 		cli.ProgramName = "Φορτίο"
 	}
+	bincommon.SharedMain()
 	cli.ArgsHelp = helpArgsString()
 	cli.CommandBeforeFlags = true
-	cli.MinArgs = 0
-	cli.MaxArgs = 1
-	bincommon.SharedMain()
-	scli.ServerMain()
+	cli.MinArgs = 0   // because `fortio server`s don't take any args
+	cli.MaxArgs = 1   // for load, curl etc... subcommands.
+	scli.ServerMain() // will Exit if there were arguments/flags errors.
 	fnet.ChangeMaxPayloadSize(*newMaxPayloadSizeKb * fnet.KILOBYTE)
 	percList, err := stats.ParsePercentiles(*percentilesFlag)
 	if err != nil {

--- a/cli/fortio_main.go
+++ b/cli/fortio_main.go
@@ -193,16 +193,19 @@ func FortioMain(hook bincommon.FortioHook) {
 	flag.Var(&proxiesFlags, "P",
 		"Tcp proxies to run, e.g -P \"localport1 dest_host1:dest_port1\" -P \"[::1]:0 www.google.com:443\" ...")
 	flag.Var(&httpMultiFlags, "M", "Http multi proxy to run, e.g -M \"localport1 baseDestURL1 baseDestURL2\" -M ...")
+	bincommon.SharedMain()
+
+	// Use the new [fortio.org/cli] package to handle usage, arguments and flags parsing.
 	if cli.ProgramName == "" {
 		// fortiotel presets this.
 		cli.ProgramName = "Φορτίο"
 	}
-	bincommon.SharedMain()
 	cli.ArgsHelp = helpArgsString()
 	cli.CommandBeforeFlags = true
 	cli.MinArgs = 0   // because `fortio server`s don't take any args
 	cli.MaxArgs = 1   // for load, curl etc... subcommands.
 	scli.ServerMain() // will Exit if there were arguments/flags errors.
+
 	fnet.ChangeMaxPayloadSize(*newMaxPayloadSizeKb * fnet.KILOBYTE)
 	percList, err := stats.ParsePercentiles(*percentilesFlag)
 	if err != nil {

--- a/cli/fortio_main.go
+++ b/cli/fortio_main.go
@@ -24,14 +24,13 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"path"
 	"runtime"
 	"strings"
 	"time"
 
-	"fortio.org/dflag/configmap"
+	"fortio.org/cli"
 	"fortio.org/fortio/bincommon"
 	"fortio.org/fortio/fgrpc"
 	"fortio.org/fortio/fhttp"
@@ -43,6 +42,7 @@ import (
 	"fortio.org/fortio/ui"
 	"fortio.org/fortio/version"
 	"fortio.org/log"
+	"fortio.org/scli"
 )
 
 // -- Start of support for multiple proxies (-P) flags on cmd line.
@@ -73,11 +73,9 @@ func (f *httpMultiFlagList) Set(value string) error {
 
 // -- End of -M support.
 
-// Usage is fortio's main cli Usage to a writer.
-func Usage(w io.Writer, msgs ...interface{}) {
-	_, _ = fmt.Fprintf(w, "Φορτίο %s usage:\n\t%s command [flags] target\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n",
-		version.Short(),
-		os.Args[0],
+// fortio's help/args message
+func helpArgsString() string {
+	return fmt.Sprintf("target\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s",
 		"where command is one of: load (load testing), server (starts ui, rest api,",
 		" http-echo, redirect, proxies, tcp-echo, udp-echo and grpc ping servers), ",
 		" tcp-echo (only the tcp-echo server), udp-echo (only udp-echo server),",
@@ -87,13 +85,6 @@ func Usage(w io.Writer, msgs ...interface{}) {
 		" or version (prints the full version and build details).",
 		"where target is a url (http load tests) or host:port (grpc health test),",
 		" or tcp://host:port (tcp load test), or udp://host:port (udp load test).")
-	bincommon.FlagsUsage(w, msgs...)
-}
-
-// Prints usage and error messages with StdErr writer.
-func usageErr(usage func(io.Writer, ...interface{}), msgs ...interface{}) {
-	usage(os.Stderr, msgs...)
-	os.Exit(1)
 }
 
 // Attention: every flag that is common to http client goes to bincommon/
@@ -191,42 +182,32 @@ var (
 
 // serverArgCheck always returns true after checking arguments length.
 // so it can be used with isServer = serverArgCheck() below.
-func serverArgCheck(usage func(io.Writer, ...interface{})) bool {
-	if len(flag.Args()) != 0 {
-		usageErr(usage, "Error: too many arguments (typo in a flag?)")
+func serverArgCheck() bool {
+	if len(flag.Args()) != 1 {
+		cli.ErrUsage("Error: too many arguments (typo in a flag?)")
 	}
 	return true
 }
 
 //nolint:funlen // well yes it's fairly long
-func FortioMain(usage func(io.Writer, ...interface{}), hook bincommon.FortioHook) {
+func FortioMain(hook bincommon.FortioHook) {
 	flag.Var(&proxiesFlags, "P",
 		"Tcp proxies to run, e.g -P \"localport1 dest_host1:dest_port1\" -P \"[::1]:0 www.google.com:443\" ...")
 	flag.Var(&httpMultiFlags, "M", "Http multi proxy to run, e.g -M \"localport1 baseDestURL1 baseDestURL2\" -M ...")
-	bincommon.SharedMain(usage)
-	if len(os.Args) < 2 {
-		usageErr(usage, "Error: need at least 1 command parameter")
+	if cli.ProgramName == "" {
+		// fortiotel presets this.
+		cli.ProgramName = "Φορτίο"
 	}
-	command := os.Args[1]
-	os.Args = append([]string{os.Args[0]}, os.Args[2:]...)
-	flag.Parse()
-	if *bincommon.HelpFlag {
-		usage(os.Stdout)
-		os.Exit(0)
-	}
-	if *bincommon.QuietFlag {
-		log.SetLogLevelQuiet(log.Error)
-	}
-	confDir := *bincommon.ConfigDirectoryFlag
-	if confDir != "" {
-		if _, err := configmap.Setup(flag.CommandLine, confDir); err != nil {
-			log.Critf("Unable to watch config/flag changes in %v: %v", confDir, err)
-		}
-	}
+	cli.ArgsHelp = helpArgsString()
+	cli.CommandBeforeFlags = true
+	cli.MinArgs = 0
+	cli.MaxArgs = 1
+	bincommon.SharedMain()
+	scli.ServerMain()
 	fnet.ChangeMaxPayloadSize(*newMaxPayloadSizeKb * fnet.KILOBYTE)
 	percList, err := stats.ParsePercentiles(*percentilesFlag)
 	if err != nil {
-		usageErr(usage, "Unable to extract percentiles from -p: ", err)
+		cli.ErrUsage("Unable to extract percentiles from -p: %v", err)
 	}
 	baseURL := strings.Trim(*baseURLFlag, " \t\n\r/") // remove trailing slash and other whitespace
 	sync := strings.TrimSpace(*syncFlag)
@@ -236,18 +217,18 @@ func FortioMain(usage func(io.Writer, ...interface{}), hook bincommon.FortioHook
 		}
 	}
 	isServer := false
-	switch command {
+	switch cli.Command {
 	case "curl":
-		fortioLoad(usage, true, nil, hook)
+		fortioLoad(true, nil, hook)
 	case "nc":
-		fortioNC(usage)
+		fortioNC()
 	case "load":
-		fortioLoad(usage, *curlFlag, percList, hook)
+		fortioLoad(*curlFlag, percList, hook)
 	case "redirect":
-		isServer = serverArgCheck(usage)
+		isServer = serverArgCheck()
 		fhttp.RedirectToHTTPS(*redirectFlag)
 	case "report":
-		isServer = serverArgCheck(usage)
+		isServer = serverArgCheck()
 		if *redirectFlag != disabled {
 			fhttp.RedirectToHTTPS(*redirectFlag)
 		}
@@ -255,20 +236,20 @@ func FortioMain(usage func(io.Writer, ...interface{}), hook bincommon.FortioHook
 			os.Exit(1) // error already logged
 		}
 	case "tcp-echo":
-		isServer = serverArgCheck(usage)
+		isServer = serverArgCheck()
 		fnet.TCPEchoServer("tcp-echo", *tcpPortFlag)
 		startProxies()
 	case "udp-echo":
-		isServer = serverArgCheck(usage)
+		isServer = serverArgCheck()
 		fnet.UDPEchoServer("udp-echo", *udpPortFlag, *udpAsyncFlag)
 		startProxies()
 	case "proxies":
-		isServer = serverArgCheck(usage)
+		isServer = serverArgCheck()
 		if startProxies() == 0 {
-			usageErr(usage, "Error: fortio proxies command needs at least one -P / -M flag")
+			cli.ErrUsage("Error: fortio proxies command needs at least one -P / -M flag")
 		}
 	case "server":
-		isServer = serverArgCheck(usage)
+		isServer = serverArgCheck()
 		if *tcpPortFlag != disabled {
 			fnet.TCPEchoServer("tcp-echo", *tcpPortFlag)
 		}
@@ -288,14 +269,11 @@ func FortioMain(usage func(io.Writer, ...interface{}), hook bincommon.FortioHook
 		}
 		startProxies()
 	case "grpcping":
-		grpcClient(usage)
+		grpcClient()
 	default:
-		usageErr(usage, "Error: unknown command ", command)
+		cli.ErrUsage("Error: unknown command %q", cli.Command)
 	}
 	if isServer {
-		if confDir == "" {
-			log.Infof("Note: not using dynamic flag watching (use -config to set watch directory)")
-		}
 		serverLoop(sync)
 	}
 }
@@ -345,10 +323,10 @@ func startProxies() int {
 	return numProxies
 }
 
-func fortioNC(usage func(io.Writer, ...interface{})) {
+func fortioNC() {
 	l := len(flag.Args())
 	if l != 1 && l != 2 {
-		usageErr(usage, "Error: fortio nc needs a host:port or host port destination")
+		cli.ErrUsage("Error: fortio nc needs a host:port or host port destination")
 	}
 	d := flag.Args()[0]
 	if l == 2 {
@@ -362,9 +340,9 @@ func fortioNC(usage func(io.Writer, ...interface{})) {
 }
 
 //nolint:funlen, gocognit // maybe refactor/shorten later.
-func fortioLoad(usage func(io.Writer, ...interface{}), justCurl bool, percList []float64, hook bincommon.FortioHook) {
+func fortioLoad(justCurl bool, percList []float64, hook bincommon.FortioHook) {
 	if len(flag.Args()) != 1 {
-		usageErr(usage, "Error: fortio load/curl needs a url or destination")
+		cli.ErrUsage("Error: fortio load/curl needs a url or destination")
 	}
 	httpOpts := bincommon.SharedHTTPOptions()
 	if justCurl {
@@ -381,7 +359,7 @@ func fortioLoad(usage func(io.Writer, ...interface{}), justCurl bool, percList [
 	qps := *qpsFlag // TODO possibly use translated <=0 to "max" from results/options normalization in periodic/
 	if *calcQPS {
 		if *exactlyFlag == 0 || *durationFlag <= 0 {
-			usageErr(usage, "Error: can't use `-calc-qps` without also specifying `-n` and `-t`")
+			cli.ErrUsage("Error: can't use `-calc-qps` without also specifying `-n` and `-t`")
 		}
 		qps = float64(*exactlyFlag) / durationFlag.Seconds()
 		log.LogVf("Calculated QPS to do %d request in %v: %f", *exactlyFlag, *durationFlag, qps)
@@ -527,9 +505,9 @@ func fortioLoad(usage func(io.Writer, ...interface{}), justCurl bool, percList [
 	}
 }
 
-func grpcClient(usage func(io.Writer, ...interface{})) {
+func grpcClient() {
 	if len(flag.Args()) != 1 {
-		usageErr(usage, "Error: fortio grpcping needs host argument in the form of host, host:port or ip:port")
+		cli.ErrUsage("Error: fortio grpcping needs host argument in the form of host, host:port or ip:port")
 	}
 	host := flag.Arg(0)
 	count := int(*exactlyFlag)

--- a/cli/fortio_main.go
+++ b/cli/fortio_main.go
@@ -73,7 +73,7 @@ func (f *httpMultiFlagList) Set(value string) error {
 
 // -- End of -M support.
 
-// fortio's help/args message
+// fortio's help/args message.
 func helpArgsString() string {
 	return fmt.Sprintf("target\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s",
 		"where command is one of: load (load testing), server (starts ui, rest api,",
@@ -189,7 +189,6 @@ func serverArgCheck() bool {
 	return true
 }
 
-//nolint:funlen // well yes it's fairly long
 func FortioMain(hook bincommon.FortioHook) {
 	flag.Var(&proxiesFlags, "P",
 		"Tcp proxies to run, e.g -P \"localport1 dest_host1:dest_port1\" -P \"[::1]:0 www.google.com:443\" ...")

--- a/cli/fortio_main.go
+++ b/cli/fortio_main.go
@@ -183,7 +183,7 @@ var (
 // serverArgCheck always returns true after checking arguments length.
 // so it can be used with isServer = serverArgCheck() below.
 func serverArgCheck() bool {
-	if len(flag.Args()) != 1 {
+	if len(flag.Args()) != 0 {
 		cli.ErrUsage("Error: too many arguments (typo in a flag?)")
 	}
 	return true

--- a/dflag/README.md
+++ b/dflag/README.md
@@ -1,2 +1,2 @@
 
-Fortio dflag has moved to [github.com/fortio/dflag](https://github.com/fortio/dflag#fortio-dynamic-flags-was-go-flagz)
+Fortio dflag has moved to [github.com/fortio/dflag](https://github.com/fortio/dflag#fortio-dynamic-flags)

--- a/fcurl/fcurl.go
+++ b/fcurl/fcurl.go
@@ -17,34 +17,16 @@ package main
 // Do not add any external dependencies we want to keep fortio minimal.
 
 import (
-	"flag"
-	"fmt"
-	"io"
-	"os"
-
+	"fortio.org/cli"
 	"fortio.org/fortio/bincommon"
-	"fortio.org/fortio/version"
-	"fortio.org/log"
 )
 
-// Prints usage.
-func usage(w io.Writer, msgs ...interface{}) {
-	_, _ = fmt.Fprintf(w, "Φορτίο fortio-curl %s usage:\n\t%s [flags] url\n",
-		version.Short(),
-		os.Args[0])
-	bincommon.FlagsUsage(w, msgs...)
-}
-
 func main() {
-	bincommon.SharedMain(usage)
-	if len(os.Args) < 2 {
-		usage(os.Stderr, "Error: need a url as parameter")
-		os.Exit(1)
-	}
-	flag.Parse()
-	if *bincommon.QuietFlag {
-		log.SetLogLevelQuiet(log.Error)
-	}
+	cli.ProgramName = "Φορτίο fortio-curl"
+	cli.ArgsHelp = "url"
+	cli.MinArgs = 1
+	bincommon.SharedMain()
+	cli.Main()
 	o := bincommon.SharedHTTPOptions()
 	bincommon.FetchURL(o)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,10 @@ go 1.18
 
 require (
 	fortio.org/assert v1.1.3
+	fortio.org/cli v1.1.0-pre1
 	fortio.org/dflag v1.4.2
 	fortio.org/log v1.2.2
+	fortio.org/scli v1.0.1
 	fortio.org/version v1.0.2
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	fortio.org/assert v1.1.3
-	fortio.org/cli v1.1.0-pre2
+	fortio.org/cli v1.1.0-pre3
 	fortio.org/dflag v1.4.2
 	fortio.org/log v1.2.2
 	fortio.org/scli v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	fortio.org/assert v1.1.3
-	fortio.org/cli v1.1.0-pre1
+	fortio.org/cli v1.1.0-pre2
 	fortio.org/dflag v1.4.2
 	fortio.org/log v1.2.2
 	fortio.org/scli v1.0.1
@@ -14,6 +14,15 @@ require (
 	golang.org/x/net v0.7.0
 	google.golang.org/grpc v1.53.0
 )
+
+// Local dev of dependencies changes
+// replace (
+// 	fortio.org/cli => ../cli
+// 	fortio.org/dflag => ../dflag
+// 	fortio.org/log => ../log
+// 	fortio.org/scli => ../scli
+// 	fortio.org/version => ../version
+// )
 
 require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.18
 
 require (
 	fortio.org/assert v1.1.3
-	fortio.org/cli v1.1.0-pre3
+	fortio.org/cli v1.1.0
 	fortio.org/dflag v1.4.2
 	fortio.org/log v1.2.2
-	fortio.org/scli v1.0.1
+	fortio.org/scli v1.1.0
 	fortio.org/version v1.0.2
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 fortio.org/assert v1.1.3 h1:zXm8xiNiKvq2xG/YQ3sONAg3287XUuklKIDdjyD9pyg=
 fortio.org/assert v1.1.3/go.mod h1:039mG+/iYDPO8Ibx8TrNuJCm2T2SuhwRI3uL9nHTTls=
-fortio.org/cli v1.1.0-pre1 h1:2TbnzyKya/cJx6eqBF2L8V9dnRckAwJ7+C9KQqDki7A=
-fortio.org/cli v1.1.0-pre1/go.mod h1:O3nVImKwJSvHKbMYWkqMbEagAXCS1xvSv1YbHwkKJjY=
+fortio.org/cli v1.1.0-pre2 h1:j324B6zp4d+e8OJ70zRhUSiO/CRJexLssbHAkciW/L0=
+fortio.org/cli v1.1.0-pre2/go.mod h1:O3nVImKwJSvHKbMYWkqMbEagAXCS1xvSv1YbHwkKJjY=
 fortio.org/dflag v1.4.2 h1:kkPNgmoGViSqh16Muf3BGt+qxPgsx+yfFGB/bpmiGqM=
 fortio.org/dflag v1.4.2/go.mod h1:pTEF7UEj6sHP9rj9gZG2GyhAGrrPJE4c6zOO7zB2yyI=
 fortio.org/log v1.2.2 h1:vs42JjNwiqbMbacittZjJE9+oi72Za6aekML9gKmILg=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 fortio.org/assert v1.1.3 h1:zXm8xiNiKvq2xG/YQ3sONAg3287XUuklKIDdjyD9pyg=
 fortio.org/assert v1.1.3/go.mod h1:039mG+/iYDPO8Ibx8TrNuJCm2T2SuhwRI3uL9nHTTls=
-fortio.org/cli v1.1.0-pre2 h1:j324B6zp4d+e8OJ70zRhUSiO/CRJexLssbHAkciW/L0=
-fortio.org/cli v1.1.0-pre2/go.mod h1:O3nVImKwJSvHKbMYWkqMbEagAXCS1xvSv1YbHwkKJjY=
+fortio.org/cli v1.1.0-pre3 h1:R/tpVHF/2b0XnTATyG3enNfaZx+IKZ52Xdx7CWNFSk0=
+fortio.org/cli v1.1.0-pre3/go.mod h1:O3nVImKwJSvHKbMYWkqMbEagAXCS1xvSv1YbHwkKJjY=
 fortio.org/dflag v1.4.2 h1:kkPNgmoGViSqh16Muf3BGt+qxPgsx+yfFGB/bpmiGqM=
 fortio.org/dflag v1.4.2/go.mod h1:pTEF7UEj6sHP9rj9gZG2GyhAGrrPJE4c6zOO7zB2yyI=
 fortio.org/log v1.2.2 h1:vs42JjNwiqbMbacittZjJE9+oi72Za6aekML9gKmILg=

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,13 @@
 fortio.org/assert v1.1.3 h1:zXm8xiNiKvq2xG/YQ3sONAg3287XUuklKIDdjyD9pyg=
 fortio.org/assert v1.1.3/go.mod h1:039mG+/iYDPO8Ibx8TrNuJCm2T2SuhwRI3uL9nHTTls=
-fortio.org/cli v1.1.0-pre3 h1:R/tpVHF/2b0XnTATyG3enNfaZx+IKZ52Xdx7CWNFSk0=
-fortio.org/cli v1.1.0-pre3/go.mod h1:O3nVImKwJSvHKbMYWkqMbEagAXCS1xvSv1YbHwkKJjY=
+fortio.org/cli v1.1.0 h1:ATIxi7DgA7WAexUCF8p5a0qlGYk48ZgkwSEDrvwXeN4=
+fortio.org/cli v1.1.0/go.mod h1:O3nVImKwJSvHKbMYWkqMbEagAXCS1xvSv1YbHwkKJjY=
 fortio.org/dflag v1.4.2 h1:kkPNgmoGViSqh16Muf3BGt+qxPgsx+yfFGB/bpmiGqM=
 fortio.org/dflag v1.4.2/go.mod h1:pTEF7UEj6sHP9rj9gZG2GyhAGrrPJE4c6zOO7zB2yyI=
 fortio.org/log v1.2.2 h1:vs42JjNwiqbMbacittZjJE9+oi72Za6aekML9gKmILg=
 fortio.org/log v1.2.2/go.mod h1:u/8/2lyczXq52aT5Nw6reD+3cR6m/EbS2jBiIYhgiTU=
-fortio.org/scli v1.0.1 h1:rasJTSMAb4/LrCvbmkppT8mFMSJynL6+zImeU5l1zFI=
-fortio.org/scli v1.0.1/go.mod h1:+CvOWZN8cXciHR3Eca9rTGZ1J2Xv9U3xKgSqtSG1hYs=
+fortio.org/scli v1.1.0 h1:vnnCH9tOnEtwJXLv9nytNvsXoAwBVktIh73mGackoX8=
+fortio.org/scli v1.1.0/go.mod h1:MJOVM2MgZjvan3BFwfqwj36YNH4OLRgO5PUK9it2m0Y=
 fortio.org/version v1.0.2 h1:8NwxdX58aoeKx7T5xAPO0xlUu1Hpk42nRz5s6e6eKZ0=
 fortio.org/version v1.0.2/go.mod h1:2JQp9Ax+tm6QKiGuzR5nJY63kFeANcgrZ0osoQFDVm0=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,13 @@
 fortio.org/assert v1.1.3 h1:zXm8xiNiKvq2xG/YQ3sONAg3287XUuklKIDdjyD9pyg=
 fortio.org/assert v1.1.3/go.mod h1:039mG+/iYDPO8Ibx8TrNuJCm2T2SuhwRI3uL9nHTTls=
+fortio.org/cli v1.1.0-pre1 h1:2TbnzyKya/cJx6eqBF2L8V9dnRckAwJ7+C9KQqDki7A=
+fortio.org/cli v1.1.0-pre1/go.mod h1:O3nVImKwJSvHKbMYWkqMbEagAXCS1xvSv1YbHwkKJjY=
 fortio.org/dflag v1.4.2 h1:kkPNgmoGViSqh16Muf3BGt+qxPgsx+yfFGB/bpmiGqM=
 fortio.org/dflag v1.4.2/go.mod h1:pTEF7UEj6sHP9rj9gZG2GyhAGrrPJE4c6zOO7zB2yyI=
 fortio.org/log v1.2.2 h1:vs42JjNwiqbMbacittZjJE9+oi72Za6aekML9gKmILg=
 fortio.org/log v1.2.2/go.mod h1:u/8/2lyczXq52aT5Nw6reD+3cR6m/EbS2jBiIYhgiTU=
+fortio.org/scli v1.0.1 h1:rasJTSMAb4/LrCvbmkppT8mFMSJynL6+zImeU5l1zFI=
+fortio.org/scli v1.0.1/go.mod h1:+CvOWZN8cXciHR3Eca9rTGZ1J2Xv9U3xKgSqtSG1hYs=
 fortio.org/version v1.0.2 h1:8NwxdX58aoeKx7T5xAPO0xlUu1Hpk42nRz5s6e6eKZ0=
 fortio.org/version v1.0.2/go.mod h1:2JQp9Ax+tm6QKiGuzR5nJY63kFeANcgrZ0osoQFDVm0=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=

--- a/main.go
+++ b/main.go
@@ -20,5 +20,5 @@ import "fortio.org/fortio/cli"
 // like fortiotel (fortio with opentelemetry)
 
 func main() {
-	cli.FortioMain(cli.Usage, nil /* no hook needed */)
+	cli.FortioMain(nil /* no hook needed */)
 }

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -24,7 +24,7 @@ RUN sh -c \
        make -C fortio official-build BUILD_DIR=/build GOARCH=${arch} OFFICIAL_DIR=/tmp/fortio_${arch}; \
     done'
 
-RUN cd fortio && /tmp/fortio_$(go env GOARCH)/fortio version -s > /tmp/version
+RUN cd fortio && /tmp/fortio_$(go env GOARCH)/fortio version > /tmp/version
 
 WORKDIR /stage
 

--- a/release/updateFlags.sh
+++ b/release/updateFlags.sh
@@ -15,4 +15,4 @@
 #
 # Extract fortio's help and rewrap it to 80 cols
 # TODO: do like fmt does to keep leading identation
-go run . help | expand | fold -s | sed -e "s/ $//" -e "s/</\&lt;/"
+go run . help | expand | fold -s -w 90 | sed -e "s/ $//" -e "s/</\&lt;/"

--- a/ui/templates/main.html
+++ b/ui/templates/main.html
@@ -61,7 +61,7 @@
     Load using:<br />
     tcp/udp/http: <input type="radio" name="runner" value="http/tcp/udp" checked/>
     (https insecure:<input type="checkbox" name="https-insecure" />,
-    standard go client instead of fastclient:<input type="checkbox" name="stdclient"/>,
+    standard go client instead of fastclient:<input type="checkbox" name="stdclient" checked/>,
     h2: <input type="checkbox" name="h2"/>,
     sequential warmup: <input type="checkbox" name="sequential-warmup"/>,
     resolve: <input type="text" name="resolve" size="12" value="" />)

--- a/ui/templates/main.html
+++ b/ui/templates/main.html
@@ -41,11 +41,11 @@
   <div>
     Title/Labels: <input type="text" name="labels" size="40" value="Fortio" /> (empty to skip title)<br />
     URL: <input type="text" name="url" size="80" value="http://{{.URLHostPort}}/echo?delay=250us:30,5ms:5&status=503:0.5,429:1.5" /> <br />
-    QPS: <input type="text" name="qps" size="6" value="1000" />
+    QPS: <input type="text" name="qps" size="6" value="100" />
     Duration: <input id="duration" type="text" name="t" size="6" value="3s" />
     or run until interrupted:<input type="checkbox" name="t" onchange="toggleDuration(this)" />
     or run for exactly <input type="text" name="n" size="6" value="" /> calls. <br />
-    Threads/Simultaneous connections: <input type="text" name="c" size="6" value="8" /> <br />
+    Threads/Simultaneous connections: <input type="text" name="c" size="6" value="10" /> <br />
     Connection reuse range: Min <input type="text" name="connection-reuse-range-min" size="6" value="" />
     Max <input type="text" name="connection-reuse-range-max" size="6" value="" />
     or Single value: <input type="text" name="connection-reuse-range-value" size="6" value="" /> <br />


### PR DESCRIPTION
Added support for subcommand in https://github.com/fortio/cli/releases/tag/v1.1.0 in order to re-use it here and not just in proxy, dnsping, multicurl, etc... and simplify the code

It has a few effects, most important "breaking" change is `-config` is now `-config-dir` and you need to use
`fortio buildinfo` to get the buildinfo instead of `version` before, new `version` replaces `version -s`

also made some changes to default web UI form values: use stdclient (because/for fortiotel) and lowered qps because people tend to forget to change that value when hitting real (slow) services

See the corresponding cleanup in fortiotel : https://github.com/fortio/fortiotel/pull/39/files