### PR TITLE
go1.19.7 + codeOK fix + streaming misses

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ defaultEnv:
   &defaultEnv
   docker:
     # specify the version
-    - image: docker.io/fortio/fortio.build:v54@sha256:4775038c3ace753978c8dfd99ebbd23607b61eeb0bf6c2bf2901d0485cc1870c
+    - image: docker.io/fortio/fortio.build:v56@sha256:07d916612d89c95abf15f519d2d1afc91af6e58ca36bd6c67f584379f8ef0680
   working_directory: /build/fortio
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v54@sha256:4775038c3ace753978c8dfd99ebbd23607b61eeb0bf6c2bf2901d0485cc1870c as build
+FROM docker.io/fortio/fortio.build:v56@sha256:07d916612d89c95abf15f519d2d1afc91af6e58ca36bd6c67f584379f8ef0680 as build
 WORKDIR /build
 COPY --chown=build:build . fortio
 ARG MODE=install

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,5 @@
 # Dependencies and linters for build:
-FROM golang:1.19.6
+FROM golang:1.19.7
 # Need gcc for -race test (and some linters though those work with CGO_ENABLED=0)
 RUN apt-get -y update && \
   apt-get --no-install-recommends -y upgrade && \

--- a/Dockerfile.echosrv
+++ b/Dockerfile.echosrv
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v54@sha256:4775038c3ace753978c8dfd99ebbd23607b61eeb0bf6c2bf2901d0485cc1870c as build
+FROM docker.io/fortio/fortio.build:v56@sha256:07d916612d89c95abf15f519d2d1afc91af6e58ca36bd6c67f584379f8ef0680 as build
 WORKDIR /build
 COPY . fortio
 RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_TARGET=fortio.org/fortio/echosrv

--- a/Dockerfile.fcurl
+++ b/Dockerfile.fcurl
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v54@sha256:4775038c3ace753978c8dfd99ebbd23607b61eeb0bf6c2bf2901d0485cc1870c as build
+FROM docker.io/fortio/fortio.build:v56@sha256:07d916612d89c95abf15f519d2d1afc91af6e58ca36bd6c67f584379f8ef0680 as build
 WORKDIR /build
 COPY . fortio
 RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_TARGET=fortio.org/fortio/fcurl

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,7 @@
 IMAGES=echosrv fcurl # plus the combo image / Dockerfile without ext.
 
 DOCKER_PREFIX := docker.io/fortio/fortio
-# Note to self: skip 55 (was built and push with unecessarily changing git config), so 56 is next
-BUILD_IMAGE_TAG := v54@sha256:4775038c3ace753978c8dfd99ebbd23607b61eeb0bf6c2bf2901d0485cc1870c
+BUILD_IMAGE_TAG := v56@sha256:07d916612d89c95abf15f519d2d1afc91af6e58ca36bd6c67f584379f8ef0680
 BUILDX_PLATFORMS := linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 BUILDX_POSTFIX :=
 ifeq '$(shell echo $(BUILDX_PLATFORMS) | awk -F "," "{print NF-1}")' '0'

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -140,7 +140,7 @@ fi
 PPROF_URL="$BASE_URL/debug/pprof/heap?debug=1"
 $CURL "$PPROF_URL" | grep -i TotalAlloc # should find this in memory profile
 # creating dummy container to hold a volume for test certs due to remote docker bind mount limitation.
-DOCKERCURLID=$(docker run -d -v $TEST_CERT_VOL --net host --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v54@sha256:4775038c3ace753978c8dfd99ebbd23607b61eeb0bf6c2bf2901d0485cc1870c sleep 120)
+DOCKERCURLID=$(docker run -d -v $TEST_CERT_VOL --net host --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v56@sha256:07d916612d89c95abf15f519d2d1afc91af6e58ca36bd6c67f584379f8ef0680 sleep 120)
 # while we have something with actual curl binary do
 # Test for h2c upgrade (#562)
 docker exec $DOCKERSECVOLNAME /usr/bin/curl -v --http2 -m 10 -d foo42 http://localhost:8080/debug | tee >(cat 1>&2) | grep foo42

--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -17,11 +17,11 @@ package fhttp
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 	"runtime"
 	"runtime/pprof"
 	"sort"
+	"strconv"
 	"sync"
 
 	"fortio.org/fortio/periodic"
@@ -59,20 +59,16 @@ type HTTPRunnerResults struct {
 // To be set as the Function in RunnerOptions.
 func (httpstate *HTTPRunnerResults) Run(ctx context.Context, t periodic.ThreadID) (bool, string) {
 	log.Debugf("Calling in %d", t)
-	code, body, headerSize := httpstate.client.Fetch(ctx)
-	size := len(body)
+	code, size, headerSize := httpstate.client.StreamFetch(ctx)
 	log.Debugf("Got in %3d hsz %d sz %d - will abort on %d", code, headerSize, size, httpstate.AbortOn)
 	httpstate.RetCodes[code]++
 	httpstate.sizes.Record(float64(size))
 	httpstate.headerSizes.Record(float64(headerSize))
 	if httpstate.AbortOn == code {
 		httpstate.aborter.Abort(false)
-		log.Infof("Aborted run because of code %d - data %s", code, DebugSummary(body, 1024))
+		log.Infof("Aborted run because of code %d - data len %d", code, size)
 	}
-	if code == http.StatusOK {
-		return true, "200"
-	}
-	return false, fmt.Sprint(code)
+	return codeIsOK(code), strconv.Itoa(code)
 }
 
 // HTTPRunnerOptions includes the base RunnerOptions plus http specific
@@ -158,12 +154,12 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 		for i := 0; i < numThreads; i++ {
 			i := i
 			warmup.Go(func() error {
-				code, data, headerSize := httpstate[i].client.Fetch(ctx)
+				code, dataLen, headerSize := httpstate[i].client.StreamFetch(ctx)
 				if !o.AllowInitialErrors && !codeIsOK(code) {
-					return fmt.Errorf("error %d for %s: %q", code, o.URL, string(data))
+					return fmt.Errorf("error %d for %s (%d bytes)", code, o.URL, dataLen)
 				}
 				if i == 0 && log.LogVerbose() {
-					log.LogVf("first hit of url %s: status %03d, headers %d, total %d\n%s\n", o.URL, code, headerSize, len(data), data)
+					log.LogVf("first hit of url %s: status %03d, headers %d, total %d", o.URL, code, headerSize, dataLen)
 				}
 				return nil
 			})

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -1,5 +1,5 @@
 # Concatenated after ../Dockerfile to create the tgz
-FROM docker.io/fortio/fortio.build:v54@sha256:4775038c3ace753978c8dfd99ebbd23607b61eeb0bf6c2bf2901d0485cc1870c as stage
+FROM docker.io/fortio/fortio.build:v56@sha256:07d916612d89c95abf15f519d2d1afc91af6e58ca36bd6c67f584379f8ef0680 as stage
 ARG archs="amd64 arm64 ppc64le s390x"
 ENV archs=${archs}
 # Build image defaults to build user, switch back to root for


### PR DESCRIPTION
- new go version
- refactor of client api usage from always returning the bytes to streaming data had 2 misses, including critical one in Run()
- code to tell access logger success/failure was hardcoded to 200s only instead of using same range as elsewhere
