### PR TITLE
attempt at getting grpc health answer from a flat buffers server 

### DIFF
--- a/fgrpc/pingsrv.go
+++ b/fgrpc/pingsrv.go
@@ -28,7 +28,6 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/encoding/proto"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"


### PR DESCRIPTION
attempt at getting grpc health answer from a flat buffers server by (over) specifying the proto. but it doesn't help. 

changes the content-type from `application/grpc` to `application/grpc+proto` but that doesn't help the server use that to pick the right codec

```
(meta map[:authority:[localhost:8079] content-type:[application/grpc+proto] user-agent:[[fortio.org/fortio-dev](http://fortio.org/fortio-dev) grpc-go/1.54.0]])
```
from before it was 
```
(meta map[:authority:[localhost:8079] content-type:[application/grpc] user-agent:[[fortio.org/fortio-1.53.1](http://fortio.org/fortio-1.53.1) grpc-go/1.53.0]])
```
just for ref/not to be merged