### PR TITLE
use newer go 1.20.3 and corresponding new lints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ defaultEnv:
   &defaultEnv
   docker:
     # specify the version
-    - image: docker.io/fortio/fortio.build:v56@sha256:07d916612d89c95abf15f519d2d1afc91af6e58ca36bd6c67f584379f8ef0680
+    - image: docker.io/fortio/fortio.build:v57@sha256:12761387fdf486cad3b1b5c0a4a0ef44c6aaec4bf09e78f0027e60bc4d67d478
   working_directory: /build/fortio
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v56@sha256:07d916612d89c95abf15f519d2d1afc91af6e58ca36bd6c67f584379f8ef0680 as build
+FROM docker.io/fortio/fortio.build:v57@sha256:12761387fdf486cad3b1b5c0a4a0ef44c6aaec4bf09e78f0027e60bc4d67d478 as build
 WORKDIR /build
 COPY --chown=build:build . fortio
 ARG MODE=install

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,5 @@
 # Dependencies and linters for build:
-FROM golang:1.19.7
+FROM golang:1.20.3
 # Need gcc for -race test (and some linters though those work with CGO_ENABLED=0)
 RUN apt-get -y update && \
   apt-get --no-install-recommends -y upgrade && \

--- a/Dockerfile.echosrv
+++ b/Dockerfile.echosrv
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v56@sha256:07d916612d89c95abf15f519d2d1afc91af6e58ca36bd6c67f584379f8ef0680 as build
+FROM docker.io/fortio/fortio.build:v57@sha256:12761387fdf486cad3b1b5c0a4a0ef44c6aaec4bf09e78f0027e60bc4d67d478 as build
 WORKDIR /build
 COPY . fortio
 RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_TARGET=fortio.org/fortio/echosrv

--- a/Dockerfile.fcurl
+++ b/Dockerfile.fcurl
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v56@sha256:07d916612d89c95abf15f519d2d1afc91af6e58ca36bd6c67f584379f8ef0680 as build
+FROM docker.io/fortio/fortio.build:v57@sha256:12761387fdf486cad3b1b5c0a4a0ef44c6aaec4bf09e78f0027e60bc4d67d478 as build
 WORKDIR /build
 COPY . fortio
 RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_TARGET=fortio.org/fortio/fcurl

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 IMAGES=echosrv fcurl # plus the combo image / Dockerfile without ext.
 
 DOCKER_PREFIX := docker.io/fortio/fortio
-BUILD_IMAGE_TAG := v56@sha256:07d916612d89c95abf15f519d2d1afc91af6e58ca36bd6c67f584379f8ef0680
+BUILD_IMAGE_TAG := v57@sha256:12761387fdf486cad3b1b5c0a4a0ef44c6aaec4bf09e78f0027e60bc4d67d478
 BUILDX_PLATFORMS := linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 BUILDX_POSTFIX :=
 ifeq '$(shell echo $(BUILDX_PLATFORMS) | awk -F "," "{print NF-1}")' '0'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- 1.54.0 -->
+<!-- 1.54.1 -->
 # Fortio
 
 [![Awesome Go](https://fortio.org/mentioned-badge.svg)](https://github.com/avelino/awesome-go#networking)
@@ -60,13 +60,13 @@ You can install from source:
 The [releases](https://github.com/fortio/fortio/releases) page has binaries for many OS/architecture combinations (see assets):
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.54.0/fortio-linux_amd64-1.54.0.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.54.1/fortio-linux_amd64-1.54.1.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.54.0/fortio_1.54.0_amd64.deb
-dpkg -i fortio_1.54.0_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.54.1/fortio_1.54.1_amd64.deb
+dpkg -i fortio_1.54.1_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.54.0/fortio-1.54.0-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.54.1/fortio-1.54.1-1.x86_64.rpm
 # and more, see assets in release page
 ```
 
@@ -76,7 +76,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.54.0/fortio_win_1.54.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.54.1/fortio_win_1.54.1.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -127,7 +127,7 @@ Full list of command line flags (`fortio help`):
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
 <!-- USAGE_START -->
-Φορτίο 1.54.0 usage:
+Φορτίο 1.54.1 usage:
         fortio command [flags] target
 where command is one of: load (load testing), server (starts ui, rest api,
  http-echo, redirect, proxies, tcp-echo, udp-echo and grpc ping servers),

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -140,7 +140,7 @@ fi
 PPROF_URL="$BASE_URL/debug/pprof/heap?debug=1"
 $CURL "$PPROF_URL" | grep -i TotalAlloc # should find this in memory profile
 # creating dummy container to hold a volume for test certs due to remote docker bind mount limitation.
-DOCKERCURLID=$(docker run -d -v $TEST_CERT_VOL --net host --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v56@sha256:07d916612d89c95abf15f519d2d1afc91af6e58ca36bd6c67f584379f8ef0680 sleep 120)
+DOCKERCURLID=$(docker run -d -v $TEST_CERT_VOL --net host --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v57@sha256:12761387fdf486cad3b1b5c0a4a0ef44c6aaec4bf09e78f0027e60bc4d67d478 sleep 120)
 # while we have something with actual curl binary do
 # Test for h2c upgrade (#562)
 docker exec $DOCKERSECVOLNAME /usr/bin/curl -v --http2 -m 10 -d foo42 http://localhost:8080/debug | tee >(cat 1>&2) | grep foo42

--- a/bincommon/commonflags.go
+++ b/bincommon/commonflags.go
@@ -188,11 +188,7 @@ func TLSInsecure() bool {
 // and set in httpOpts.
 func ConnectionReuseRangeValidator(httpOpts *fhttp.HTTPOptions) func(string) error {
 	return func(value string) error {
-		if err := httpOpts.ValidateAndSetConnectionReuseRange(value); err != nil {
-			return err
-		}
-
-		return nil
+		return httpOpts.ValidateAndSetConnectionReuseRange(value)
 	}
 }
 

--- a/fnet/network_norace_test.go
+++ b/fnet/network_norace_test.go
@@ -42,6 +42,9 @@ func TestTCPEchoServerEOF(t *testing.T) {
 		eofStopFlag := (i%2 == 0)
 		in := io.NopCloser(strings.NewReader(strings.Repeat("x", 50000)))
 		var out ErroringWriter
-		fnet.NetCat(ctx, "localhost"+port, in, &out, eofStopFlag)
+		err := fnet.NetCat(ctx, "localhost"+port, in, &out, eofStopFlag)
+		if err == nil {
+			t.Errorf("NetCat expected to get error %v %v", eofStopFlag, err)
+		}
 	}
 }

--- a/fnet/network_test.go
+++ b/fnet/network_test.go
@@ -302,6 +302,7 @@ func TestNetCatErrors(t *testing.T) {
 func TestSetSocketBuffersError(t *testing.T) {
 	c := &net.UnixConn{}
 	fnet.SetSocketBuffers(c, 512, 256) // triggers 22:11:14 V network.go:245> Not setting socket options on non tcp socket <nil>
+	t.Logf("SetSocketBuffers on non tcp socket %v", c)
 }
 
 func TestSmallReadUntil(t *testing.T) {
@@ -584,6 +585,7 @@ func TestDNSCacheConcurrency(t *testing.T) {
 	}
 	wg.Wait()
 	fnet.FlagResolveIPType.Set("ip4")
+	t.Log("TestDNSCacheConcurrency done")
 }
 
 func TestBadValueForDNSMethod(t *testing.T) {

--- a/jrpc/jrpcServer.go
+++ b/jrpc/jrpcServer.go
@@ -89,7 +89,7 @@ func ReplyError(w http.ResponseWriter, extraMsg string, err error) error {
 //	if err != nil {
 //	    _ = jrpc.ReplyError(w, "request error", err)
 //	}
-func HandleCall[Q any](w http.ResponseWriter, r *http.Request) (*Q, error) {
+func HandleCall[Q any](r *http.Request) (*Q, error) {
 	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err

--- a/jrpc/jrpcServer.go
+++ b/jrpc/jrpcServer.go
@@ -82,17 +82,22 @@ func ReplyError(w http.ResponseWriter, extraMsg string, err error) error {
 	return ReplyClientError(w, NewErrorReply(extraMsg, err))
 }
 
-// HandleCall deserializes the expected type from the request body.
+// ProcessRequest deserializes the expected type from the request body.
 // Sample usage code:
 //
-//	req, err := jrpc.HandleCall[Request](w, r)
+//	req, err := jrpc.ProcessRequest[Request](w, r)
 //	if err != nil {
 //	    _ = jrpc.ReplyError(w, "request error", err)
 //	}
-func HandleCall[Q any](r *http.Request) (*Q, error) {
+func ProcessRequest[Q any](r *http.Request) (*Q, error) {
 	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
 	}
 	return Deserialize[Q](data)
+}
+
+// Deprecated: use ProcessRequest instead.
+func HandleCall[Q any](_ http.ResponseWriter, r *http.Request) (*Q, error) {
+	return ProcessRequest[Q](r)
 }

--- a/jrpc/jrpc_test.go
+++ b/jrpc/jrpc_test.go
@@ -83,7 +83,7 @@ func TestJPRC(t *testing.T) {
 			}
 			return
 		}
-		req, err := jrpc.HandleCall[Request](r)
+		req, err := jrpc.HandleCall[Request](w, r)
 		if err != nil {
 			err = jrpc.ReplyError(w, "request error", err)
 			if err != nil {
@@ -352,7 +352,7 @@ func (ErrReader) Read(_ []byte) (n int, err error) {
 
 func TestHandleCallError(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, "/", ErrReader{})
-	_, err := jrpc.HandleCall[jrpc.ServerReply](r)
+	_, err := jrpc.ProcessRequest[jrpc.ServerReply](r)
 	if err == nil {
 		t.Errorf("expected error, got nil")
 	}
@@ -422,7 +422,7 @@ func TestJPRCSlices(t *testing.T) {
 	mux, addr := fhttp.HTTPServer("test3", "0")
 	port := addr.(*net.TCPAddr).Port
 	mux.HandleFunc("/test-api-array", func(w http.ResponseWriter, r *http.Request) {
-		req, err := jrpc.HandleCall[SliceRequest](r)
+		req, err := jrpc.ProcessRequest[SliceRequest](r)
 		if err != nil {
 			err = jrpc.ReplyError(w, "request error", err)
 			if err != nil {

--- a/jrpc/jrpc_test.go
+++ b/jrpc/jrpc_test.go
@@ -83,7 +83,7 @@ func TestJPRC(t *testing.T) {
 			}
 			return
 		}
-		req, err := jrpc.HandleCall[Request](w, r)
+		req, err := jrpc.HandleCall[Request](r)
 		if err != nil {
 			err = jrpc.ReplyError(w, "request error", err)
 			if err != nil {
@@ -346,13 +346,13 @@ type ErrReader struct{}
 
 const ErrReaderMessage = "simulated IO error"
 
-func (ErrReader) Read(p []byte) (n int, err error) {
+func (ErrReader) Read(_ []byte) (n int, err error) {
 	return 0, errors.New(ErrReaderMessage)
 }
 
 func TestHandleCallError(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, "/", ErrReader{})
-	_, err := jrpc.HandleCall[jrpc.ServerReply](nil, r)
+	_, err := jrpc.HandleCall[jrpc.ServerReply](r)
 	if err == nil {
 		t.Errorf("expected error, got nil")
 	}
@@ -422,7 +422,7 @@ func TestJPRCSlices(t *testing.T) {
 	mux, addr := fhttp.HTTPServer("test3", "0")
 	port := addr.(*net.TCPAddr).Port
 	mux.HandleFunc("/test-api-array", func(w http.ResponseWriter, r *http.Request) {
-		req, err := jrpc.HandleCall[SliceRequest](w, r)
+		req, err := jrpc.HandleCall[SliceRequest](r)
 		if err != nil {
 			err = jrpc.ReplyError(w, "request error", err)
 			if err != nil {

--- a/periodic/periodic.go
+++ b/periodic/periodic.go
@@ -688,11 +688,12 @@ func NewFileAccessLoggerByType(filePath string, accessType AccessLoggerType) (Ac
 
 // Before each Run().
 func (a *fileAccessLogger) Start(ctx context.Context, threadID ThreadID, iter int64, startTime time.Time) context.Context {
+	log.Debugf("fileAccessLogger start thread %d iter %d, %v", threadID, iter, startTime)
 	return ctx
 }
 
 // Report logs a single request to a file.
-func (a *fileAccessLogger) Report(ctx context.Context, thread ThreadID, iter int64, time time.Time,
+func (a *fileAccessLogger) Report(_ context.Context, thread ThreadID, iter int64, time time.Time,
 	latency float64, status bool, details string,
 ) {
 	a.mu.Lock()

--- a/periodic/periodic_test.go
+++ b/periodic/periodic_test.go
@@ -239,15 +239,15 @@ type testAccessLogger struct {
 	success int64
 }
 
-func (t *testAccessLogger) Start(ctx context.Context, thread ThreadID, iter int64, time time.Time) context.Context {
+func (t *testAccessLogger) Start(ctx context.Context, _ ThreadID, _ int64, _ time.Time) context.Context {
 	t.Lock()
 	defer t.Unlock()
 	t.starts++
 	return ctx
 }
 
-func (t *testAccessLogger) Report(ctx context.Context, thread ThreadID, iter int64, time time.Time,
-	latency float64, status bool, details string,
+func (t *testAccessLogger) Report(_ context.Context, _ ThreadID, iter int64, _ time.Time,
+	_ float64, status bool, _ string,
 ) {
 	t.Lock()
 	defer t.Unlock()

--- a/rapi/restHandler_test.go
+++ b/rapi/restHandler_test.go
@@ -82,7 +82,7 @@ func GetErrorResult(t *testing.T, url string, jsonPayload string) *jrpc.ServerRe
 	return r
 }
 
-func hookTest(ho *fhttp.HTTPOptions, ro *periodic.RunnerOptions) {
+func hookTest(_ *fhttp.HTTPOptions, _ *periodic.RunnerOptions) {
 	// TODO: find something to mutate/test
 }
 

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -1,5 +1,5 @@
 # Concatenated after ../Dockerfile to create the tgz
-FROM docker.io/fortio/fortio.build:v56@sha256:07d916612d89c95abf15f519d2d1afc91af6e58ca36bd6c67f584379f8ef0680 as stage
+FROM docker.io/fortio/fortio.build:v57@sha256:12761387fdf486cad3b1b5c0a4a0ef44c6aaec4bf09e78f0027e60bc4d67d478 as stage
 ARG archs="amd64 arm64 ppc64le s390x"
 ENV archs=${archs}
 # Build image defaults to build user, switch back to root for

--- a/tcprunner/tcprunner.go
+++ b/tcprunner/tcprunner.go
@@ -48,7 +48,7 @@ type RunnerResults struct {
 
 // Run tests tcp request fetching. Main call being run at the target QPS.
 // To be set as the Function in RunnerOptions.
-func (tcpstate *RunnerResults) Run(ctx context.Context, t periodic.ThreadID) (bool, string) {
+func (tcpstate *RunnerResults) Run(_ context.Context, t periodic.ThreadID) (bool, string) {
 	log.Debugf("Calling in %d", t)
 	_, err := tcpstate.client.Fetch()
 	if err != nil {

--- a/udprunner/udprunner.go
+++ b/udprunner/udprunner.go
@@ -51,7 +51,7 @@ type RunnerResults struct {
 
 // Run tests udp request fetching. Main call being run at the target QPS.
 // To be set as the Function in RunnerOptions.
-func (udpstate *RunnerResults) Run(ctx context.Context, t periodic.ThreadID) (bool, string) {
+func (udpstate *RunnerResults) Run(_ context.Context, t periodic.ThreadID) (bool, string) {
 	log.Debugf("Calling in %d", t)
 	_, err := udpstate.client.Fetch()
 	if err != nil {


### PR DESCRIPTION
Note the linter identified an incompatible change needed:
```golang
func HandleCall[Q any](w http.ResponseWriter, r *http.Request) (*Q, error) {
```
to
```golang
func ProcessRequest[Q any](r *http.Request) (*Q, error) {
```

as HandleCall doesn't... handle it just unserializes. kept the old api as Deprecated for now.
