### PR TITLE
remove non idiomatic use of new() and use recommended var buf bytes.Buffer directly

### DIFF
--- a/fhttp/http_client.go
+++ b/fhttp/http_client.go
@@ -447,8 +447,8 @@ func (c *Client) ChangeURL(urlStr string) (err error) {
 // (where we don't care about the data and only the stats)
 // Deprecated: use StreamFetch instead.
 func (c *Client) Fetch(ctx context.Context) (int, []byte, int) {
-	buf := &bytes.Buffer{}
-	c.dataWriter = buf
+	var buf bytes.Buffer
+	c.dataWriter = &buf
 	status, _, _ := c.StreamFetch(ctx)
 	return status, buf.Bytes(), 0
 }
@@ -647,8 +647,8 @@ func NewStdClient(o *HTTPOptions) (*Client, error) {
 // To be used only for single fetches or when performance doesn't matter as the client is closed at the end.
 // Deprecated: use StreamURL instead.
 func FetchURL(url string) (int, []byte) {
-	w := &bytes.Buffer{}
-	code := StreamURL(url, w)
+	var w bytes.Buffer
+	code := StreamURL(url, &w)
 	return code, w.Bytes()
 }
 
@@ -665,8 +665,8 @@ func StreamURL(url string, w io.Writer) int {
 // To be used only for single fetches or when performance doesn't matter as the client is closed at the end.
 // Deprecated: use StreamFetch instead.
 func Fetch(httpOptions *HTTPOptions) (int, []byte) {
-	w := &bytes.Buffer{}
-	httpOptions.DataWriter = w
+	var w bytes.Buffer
+	httpOptions.DataWriter = &w
 	return StreamFetch(httpOptions), w.Bytes()
 }
 

--- a/fhttp/http_test.go
+++ b/fhttp/http_test.go
@@ -885,7 +885,7 @@ func TestPayloadForClient(t *testing.T) {
 			}
 			continue
 		}
-		buf := new(bytes.Buffer)
+		var buf bytes.Buffer // A Buffer needs no initialization. https://pkg.go.dev/bytes#Buffer
 		buf.ReadFrom(body)
 		payload := buf.Bytes()
 		if !bytes.Equal(payload, test.payload) {

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -202,14 +202,15 @@ type HistogramData struct {
 // NewHistogram creates a new histogram (sets up the buckets).
 // Divider value can not be zero, otherwise returns zero.
 func NewHistogram(offset float64, divider float64) *Histogram {
-	h := new(Histogram)
-	h.Offset = offset
 	if divider == 0 {
 		return nil
 	}
-	h.Divider = divider
-	h.Hdata = make([]int32, numBuckets)
-	return h
+	h := Histogram{
+		Offset:  offset,
+		Divider: divider,
+		Hdata:   make([]int32, numBuckets),
+	}
+	return &h
 }
 
 // Val2Bucket values are kept in two different structure


### PR DESCRIPTION
instead of pointer/new

cc @theckman (no comments needed, just cc re Gopher slack)
