### PR TITLE
update to go1.20.6 - had to drop linux/ppc64le for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ defaultEnv:
   &defaultEnv
   docker:
     # specify the version
-    - image: docker.io/fortio/fortio.build:v59@sha256:735db577fe940063725cdac8dd2723875f147434f266cbdf0e6970b4fd9b1a07
+    - image: docker.io/fortio/fortio.build:v60@sha256:18c2427ade8e8867ec8e89a65702af479dd39fde15cee6899d08e387231fc090
   working_directory: /build/fortio
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v59@sha256:735db577fe940063725cdac8dd2723875f147434f266cbdf0e6970b4fd9b1a07 as build
+FROM docker.io/fortio/fortio.build:v60@sha256:18c2427ade8e8867ec8e89a65702af479dd39fde15cee6899d08e387231fc090 as build
 WORKDIR /build
 COPY --chown=build:build . fortio
 ARG MODE=install

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,10 +1,10 @@
 # Dependencies and linters for build:
-FROM golang:1.20.5@sha256:4b1fc02d16fca272e5e6e6adc98396219b43ef663a377eef4a97e881d364393f
+FROM golang:1.20.6@sha256:8e5a0067e6b387263a01d06b91ef1a983f90e9638564f6e25392fd2695f7ab6c
 # Need gcc for -race test (and some linters though those work with CGO_ENABLED=0)
 RUN apt-get -y update && \
   apt-get --no-install-recommends -y upgrade && \
   DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends -y install libc6-dev apt-transport-https ssh \
-  ruby-dev build-essential rpm gnupg zip netcat
+  ruby-dev build-essential rpm gnupg zip netcat-traditional
 
 # Install FPM
 RUN gem install --no-document fpm

--- a/Dockerfile.echosrv
+++ b/Dockerfile.echosrv
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v59@sha256:735db577fe940063725cdac8dd2723875f147434f266cbdf0e6970b4fd9b1a07 as build
+FROM docker.io/fortio/fortio.build:v60@sha256:18c2427ade8e8867ec8e89a65702af479dd39fde15cee6899d08e387231fc090 as build
 WORKDIR /build
 COPY . fortio
 RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_TARGET=fortio.org/fortio/echosrv

--- a/Dockerfile.fcurl
+++ b/Dockerfile.fcurl
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v59@sha256:735db577fe940063725cdac8dd2723875f147434f266cbdf0e6970b4fd9b1a07 as build
+FROM docker.io/fortio/fortio.build:v60@sha256:18c2427ade8e8867ec8e89a65702af479dd39fde15cee6899d08e387231fc090 as build
 WORKDIR /build
 COPY . fortio
 RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_TARGET=fortio.org/fortio/fcurl

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,12 @@
 IMAGES=echosrv fcurl # plus the combo image / Dockerfile without ext.
 
 DOCKER_PREFIX := docker.io/fortio/fortio
-BUILD_IMAGE_TAG := v59@sha256:735db577fe940063725cdac8dd2723875f147434f266cbdf0e6970b4fd9b1a07
-BUILDX_PLATFORMS := linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+BUILD_IMAGE_TAG := v60@sha256:18c2427ade8e8867ec8e89a65702af479dd39fde15cee6899d08e387231fc090
+# We can add back linux/ppc64le once we stop getting weird
+# Failed to fetch https://download.docker.com/linux/debian/dists/bullseye/stable/binary-ppc64el/Packages.bz2 File has unexpected size (22003 != 22785)
+# errors
+# BUILDX_PLATFORMS := linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+BUILDX_PLATFORMS := linux/amd64,linux/arm64,linux/s390x
 BUILDX_POSTFIX :=
 ifeq '$(shell echo $(BUILDX_PLATFORMS) | awk -F "," "{print NF-1}")' '0'
 	BUILDX_POSTFIX = --load

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- 1.57.0 -->
+<!-- 1.57.1 -->
 # Fortio
 
 [![Awesome Go](https://fortio.org/mentioned-badge.svg)](https://github.com/avelino/awesome-go#networking)
@@ -60,13 +60,13 @@ You can install from source:
 The [releases](https://github.com/fortio/fortio/releases) page has binaries for many OS/architecture combinations (see assets):
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.57.0/fortio-linux_amd64-1.57.0.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.57.1/fortio-linux_amd64-1.57.1.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.57.0/fortio_1.57.0_amd64.deb
-dpkg -i fortio_1.57.0_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.57.1/fortio_1.57.1_amd64.deb
+dpkg -i fortio_1.57.1_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.57.0/fortio-1.57.0-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.57.1/fortio-1.57.1-1.x86_64.rpm
 # and more, see assets in release page
 ```
 
@@ -76,7 +76,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.57.0/fortio_win_1.57.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.57.1/fortio_win_1.57.1.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -128,7 +128,7 @@ Full list of command line flags (`fortio help`):
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
 <!-- USAGE_START -->
-Φορτίο 1.57.0 usage:
+Φορτίο 1.57.1 usage:
         fortio command [flags] target
 where command is one of: load (load testing), server (starts ui, rest api,
  http-echo, redirect, proxies, tcp-echo, udp-echo and grpc ping servers),

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -140,7 +140,7 @@ fi
 PPROF_URL="$BASE_URL/debug/pprof/heap?debug=1"
 $CURL "$PPROF_URL" | grep -i TotalAlloc # should find this in memory profile
 # creating dummy container to hold a volume for test certs due to remote docker bind mount limitation.
-DOCKERCURLID=$(docker run -d -v $TEST_CERT_VOL --net host --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v59@sha256:735db577fe940063725cdac8dd2723875f147434f266cbdf0e6970b4fd9b1a07 sleep 120)
+DOCKERCURLID=$(docker run -d -v $TEST_CERT_VOL --net host --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v60@sha256:18c2427ade8e8867ec8e89a65702af479dd39fde15cee6899d08e387231fc090 sleep 120)
 # while we have something with actual curl binary do
 # Test for h2c upgrade (#562)
 docker exec $DOCKERSECVOLNAME /usr/bin/curl -v --http2 -m 10 -d foo42 http://localhost:8080/debug | tee >(cat 1>&2) | grep foo42

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -1,5 +1,5 @@
 # Concatenated after ../Dockerfile to create the tgz
-FROM docker.io/fortio/fortio.build:v59@sha256:735db577fe940063725cdac8dd2723875f147434f266cbdf0e6970b4fd9b1a07 as stage
+FROM docker.io/fortio/fortio.build:v60@sha256:18c2427ade8e8867ec8e89a65702af479dd39fde15cee6899d08e387231fc090 as stage
 ARG archs="amd64 arm64 ppc64le s390x"
 ENV archs=${archs}
 # Build image defaults to build user, switch back to root for


### PR DESCRIPTION
had to drop linux/ppc64le for now as there was some download corruption for these