### PR TITLE
add new -pprof on flag to explictly allow pprof, off by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- 1.60.1 -->
+<!-- 1.60.2 -->
 # Fortio
 
 [![Awesome Go](https://fortio.org/mentioned-badge.svg)](https://github.com/avelino/awesome-go#networking)
@@ -60,13 +60,13 @@ You can install from source:
 The [releases](https://github.com/fortio/fortio/releases) page has binaries for many OS/architecture combinations (see assets):
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.60.1/fortio-linux_amd64-1.60.1.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.60.2/fortio-linux_amd64-1.60.2.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.60.1/fortio_1.60.1_amd64.deb
-dpkg -i fortio_1.60.1_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.60.2/fortio_1.60.2_amd64.deb
+dpkg -i fortio_1.60.2_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.60.1/fortio-1.60.1-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.60.2/fortio-1.60.2-1.x86_64.rpm
 # and more, see assets in release page
 ```
 
@@ -76,7 +76,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.60.1/fortio_win_1.60.1.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.60.2/fortio_win_1.60.2.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -128,7 +128,7 @@ Full list of command line flags (`fortio help`):
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
 <!-- USAGE_START -->
-Φορτίο 1.60.1 usage:
+Φορτίο 1.60.2 usage:
         fortio command [flags] target
 where command is one of: load (load testing), server (starts ui, rest api,
  http-echo, redirect, proxies, tcp-echo, udp-echo and grpc ping servers),
@@ -305,6 +305,8 @@ fails to keep up temporarily
 than -maxpayloadsizekb. Setting this switches http to POST.
   -ping
         grpc load test: use ping instead of health
+  -pprof
+        Enable pprof http endpoint in the Web UI handler server
   -profile file
         write .cpu and .mem profiles to file
   -proxy-all-headers

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -44,7 +44,7 @@ if [[ $? == 124 || $? == 0 ]]; then
   exit 1
 fi
 
-DOCKERID=$(docker run -d --ulimit nofile=$FILE_LIMIT --net host --name $DOCKERNAME fortio/fortio:webtest server -ui-path $FORTIO_UI_PREFIX -loglevel $LOGLEVEL -maxpayloadsizekb $MAXPAYLOAD -timeout=$TIMEOUT)
+DOCKERID=$(docker run -d --ulimit nofile=$FILE_LIMIT --net host --name $DOCKERNAME fortio/fortio:webtest server -ui-path $FORTIO_UI_PREFIX -loglevel $LOGLEVEL -maxpayloadsizekb $MAXPAYLOAD -timeout=$TIMEOUT -pprof)
 function cleanup {
   set +e # errors are ok during cleanup
 #  docker logs "$DOCKERID" # uncomment to debug
@@ -149,7 +149,7 @@ docker exec $DOCKERSECVOLNAME /usr/bin/curl -v --http2 -m 10 -d foo42 http://loc
 for f in ca.crt server.crt server.key; do docker cp "$PWD/cert-tmp/$f" "$DOCKERSECVOLNAME:$TEST_CERT_VOL/$f"; done
 # start server in secure grpc mode. uses non-default ports to avoid conflicts with fortio_server container.
 # mounts certs volume from dummy container.
-DOCKERSECID=$(docker run -d --ulimit nofile=$FILE_LIMIT --name $DOCKERSECNAME --volumes-from $DOCKERSECVOLNAME fortio/fortio:webtest server -cacert $TEST_CERT_VOL/ca.crt -cert $TEST_CERT_VOL/server.crt -key $TEST_CERT_VOL/server.key -grpc-port 8097 -http-port 8098 -redirect-port 8090 -loglevel $LOGLEVEL -pprof)
+DOCKERSECID=$(docker run -d --ulimit nofile=$FILE_LIMIT --name $DOCKERSECNAME --volumes-from $DOCKERSECVOLNAME fortio/fortio:webtest server -cacert $TEST_CERT_VOL/ca.crt -cert $TEST_CERT_VOL/server.crt -key $TEST_CERT_VOL/server.key -grpc-port 8097 -http-port 8098 -redirect-port 8090 -loglevel $LOGLEVEL)
 # run secure grpcping and load tests
 docker exec $DOCKERSECNAME $FORTIO_BIN_PATH grpcping -cacert $TEST_CERT_VOL/ca.crt localhost:8097
 docker exec $DOCKERSECNAME $FORTIO_BIN_PATH load -grpc -cacert $TEST_CERT_VOL/ca.crt localhost:8097

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -149,7 +149,7 @@ docker exec $DOCKERSECVOLNAME /usr/bin/curl -v --http2 -m 10 -d foo42 http://loc
 for f in ca.crt server.crt server.key; do docker cp "$PWD/cert-tmp/$f" "$DOCKERSECVOLNAME:$TEST_CERT_VOL/$f"; done
 # start server in secure grpc mode. uses non-default ports to avoid conflicts with fortio_server container.
 # mounts certs volume from dummy container.
-DOCKERSECID=$(docker run -d --ulimit nofile=$FILE_LIMIT --name $DOCKERSECNAME --volumes-from $DOCKERSECVOLNAME fortio/fortio:webtest server -cacert $TEST_CERT_VOL/ca.crt -cert $TEST_CERT_VOL/server.crt -key $TEST_CERT_VOL/server.key -grpc-port 8097 -http-port 8098 -redirect-port 8090 -loglevel $LOGLEVEL)
+DOCKERSECID=$(docker run -d --ulimit nofile=$FILE_LIMIT --name $DOCKERSECNAME --volumes-from $DOCKERSECVOLNAME fortio/fortio:webtest server -cacert $TEST_CERT_VOL/ca.crt -cert $TEST_CERT_VOL/server.crt -key $TEST_CERT_VOL/server.key -grpc-port 8097 -http-port 8098 -redirect-port 8090 -loglevel $LOGLEVEL -pprof)
 # run secure grpcping and load tests
 docker exec $DOCKERSECNAME $FORTIO_BIN_PATH grpcping -cacert $TEST_CERT_VOL/ca.crt localhost:8097
 docker exec $DOCKERSECNAME $FORTIO_BIN_PATH load -grpc -cacert $TEST_CERT_VOL/ca.crt localhost:8097
@@ -157,7 +157,8 @@ docker exec $DOCKERSECNAME $FORTIO_BIN_PATH load -grpc -cacert $TEST_CERT_VOL/ca
 docker stop "$DOCKERID"
 docker rm $DOCKERNAME
 DOCKERNAME=fortio_report
-DOCKERID=$(docker run -d --ulimit nofile=$FILE_LIMIT --name $DOCKERNAME fortio/fortio:webtest report -loglevel $LOGLEVEL)
+# Even with pprof the report mode won't have pprof endpoint
+DOCKERID=$(docker run -d --ulimit nofile=$FILE_LIMIT --name $DOCKERNAME fortio/fortio:webtest report -loglevel $LOGLEVEL -pprof)
 docker ps
 CURL="docker exec $DOCKERNAME $FORTIO_BIN_PATH curl -loglevel $LOGLEVEL"
 if $CURL "$PPROF_URL" ; then

--- a/fhttp/http_server.go
+++ b/fhttp/http_server.go
@@ -486,6 +486,7 @@ func ServeTCP(port, debugPath string) (*http.ServeMux, *net.TCPAddr) {
 
 // SetupPPROF add pprof to the mux (mirror the init() of http pprof).
 func SetupPPROF(mux *http.ServeMux) {
+	log.Warnf("pprof endpoints enabled on /debug/pprof/*")
 	mux.HandleFunc("/debug/pprof/", LogAndCall("pprof:index", pprof.Index))
 	mux.HandleFunc("/debug/pprof/cmdline", LogAndCall("pprof:cmdline", pprof.Cmdline))
 	mux.HandleFunc("/debug/pprof/profile", LogAndCall("pprof:profile", pprof.Profile))


### PR DESCRIPTION
Fixes #844. also refactored UI config so httpoptions isn't called twice (and thus not logging twice in log verbose)

<img width="925" alt="Screenshot 2023-09-28 at 5 06 47 PM" src="https://github.com/fortio/fortio/assets/3664595/607d5957-46d3-4e3a-97e6-e13cfd155112">

```
17:06:04.356 r1 [VRB] uihandler.go:669> Not serving pprof endpoint.
vs
17:06:17.401 r1 [WRN] http_server.go:489> pprof endpoints enabled on /debug/pprof/*
```

Note that while this removes /debug/pprof from the default UI it doesn't make /fortio safe to expose outside of restricted networks.