### PR TITLE
fix timeout not used by proxy client in fetch2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- 1.63.0 -->
+<!-- 1.63.1 -->
 # Fortio
 
 [![Awesome Go](https://fortio.org/mentioned-badge.svg)](https://github.com/avelino/awesome-go#networking)
@@ -60,13 +60,13 @@ You can install from source:
 The [releases](https://github.com/fortio/fortio/releases) page has binaries for many OS/architecture combinations (see assets):
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.63.0/fortio-linux_amd64-1.63.0.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.63.1/fortio-linux_amd64-1.63.1.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.63.0/fortio_1.63.0_amd64.deb
-dpkg -i fortio_1.63.0_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.63.1/fortio_1.63.1_amd64.deb
+dpkg -i fortio_1.63.1_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.63.0/fortio-1.63.0-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.63.1/fortio-1.63.1-1.x86_64.rpm
 # and more, see assets in release page
 ```
 
@@ -76,7 +76,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.63.0/fortio_win_1.63.0.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.63.1/fortio_win_1.63.1.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -130,7 +130,7 @@ Full list of command line flags (`fortio help`):
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
 <!-- USAGE_START -->
-Φορτίο 1.63.0 usage:
+Φορτίο 1.63.1 usage:
         fortio command [flags] target
 where command is one of: load (load testing), server (starts ui, rest api,
  http-echo, redirect, proxies, tcp-echo, udp-echo and grpc ping servers),


### PR DESCRIPTION
Fix #874 

manual tested using port blocking as mentioned in the issue

verified that http://localhost:8080/fortio/fetch2/?url=https%3A%2F%2Funtrusted-root.badssl.com%2F&https-insecure=on works (as in you can continue to pass query args http opts)