### PR TITLE
Update release readme for new shared workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
           echo "Version $VERSION, Package version $PACKAGE_VERSION"
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # pin@v3
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # pin@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # linter config now comes from shared workflows
 .golangci.yml
+coverage.out*
 tmp/
 coverage.txt
 *.bak

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,4 +4,3 @@ coverage:
   round: nearest       # how coverage is rounded: down/up/nearest
   ignore:              # files and folders that will be removed during processing
     - "**.pb.go"
-    - "dflag/test_utils.go"

--- a/release/README.md
+++ b/release/README.md
@@ -1,6 +1,6 @@
 # How to make a fortio release
 
-- All the builds and docker, except the build image updates, are now fully automated through github actions based on tags
+- All the builds and docker, except the build image updates, are now fully automated through github actions based on tags and most if shared from org wide https://github.com/fortio/workflows#workflows except for goreleaser which isn't used here and we maintain our own build image (see for instance fortiotel for newer build fully using the shared workflows)
 
 - Make sure to use the same git tag format (e.g "v0.7.1" - note that there is `v` prefix in the tag, like many projects). Docker and internal version/tag is "0.7.1", the `v` is only for git tags.
 
@@ -22,7 +22,7 @@
 
 - To update the command line flags in the ../README.md; run the new `release/bumpRelease.sh 1.53.0` for instance
 
-- Update the homebrew tap `brew bump-formula-pr --tag v1.2.3 fortio`
+- Update the homebrew tap `brew bump-formula-pr --tag v1.2.3 fortio` (brew team usually does this fairly often on their own)
 
 
 ## How to change the build image
@@ -50,8 +50,8 @@ make update-build-image-tag SED=gsed
 
 Check the diff and make lint, webtest, etc and PR
 
-Regularly update pinned github actions
-using https://github.com/mheap/pin-github-action
+Dependabot will regularly update pinned github actions - to pin a new dependency:
+Use https://github.com/mheap/pin-github-action
 ```
 npm install -g pin-github-action
 ```


### PR DESCRIPTION
Also rebuild using updated workflows with pin
Also deleted the dockerhub hooks that were making the master CI fail (and thus the coverage) - will merge to reset that