### PR TITLE
Avoid warmup grpc connection multiple times

### DIFF
--- a/fgrpc/grpcrunner.go
+++ b/fgrpc/grpcrunner.go
@@ -138,7 +138,7 @@ type GRPCRunnerOptions struct {
 
 // RunGRPCTest runs an http test and returns the aggregated stats.
 //
-//nolint:funlen, gocognit
+//nolint:funlen, gocognit, gocyclo
 func RunGRPCTest(o *GRPCRunnerOptions) (*GRPCRunnerResults, error) {
 	if o.Streams < 1 {
 		o.Streams = 1


### PR DESCRIPTION
Currently, each new grpc connection is used to send multiple warmup requests (when grpc-stream>0), which is unexpected, especially for scenarios where the server takes a long time to process, and the whole warmup process will consume a lot of time.