### PR TITLE
Correct flag help text for -sequential-warmup, show number of fd and thread # on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,12 +26,13 @@ jobs:
           version: 20.10.12
       - checkout
       - run: make release-test
-  linters:
-    <<: *defaultEnv
-    steps:
-      - checkout
+# linters are now part of gochecks shared github action workflows (go checks)
+#  linters:
+    #<<: *defaultEnv
+    #steps:
+      #- checkout
       # If ran with default we get random errors because OOM killer kills some linters
-      - run: make local-lint DEBUG_LINTERS="--concurrency=2"
+      #- run: make local-lint DEBUG_LINTERS="--concurrency=2"
   # codecov:
   #   <<: *defaultEnv
   #   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,4 +48,4 @@ workflows:
       - unit-tests
       - release-tests
 #      - codecov
-      - linters
+#      - linters

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- 1.63.8 -->
+<!-- 1.63.9 -->
 # Fortio
 
 [![Awesome Go](https://fortio.org/mentioned-badge.svg)](https://github.com/avelino/awesome-go#networking)
@@ -60,13 +60,13 @@ You can install from source:
 The [releases](https://github.com/fortio/fortio/releases) page has binaries for many OS/architecture combinations (see assets):
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.63.8/fortio-linux_amd64-1.63.8.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.63.9/fortio-linux_amd64-1.63.9.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.63.8/fortio_1.63.8_amd64.deb
-dpkg -i fortio_1.63.8_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.63.9/fortio_1.63.9_amd64.deb
+dpkg -i fortio_1.63.9_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.63.8/fortio-1.63.8-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.63.9/fortio-1.63.9-1.x86_64.rpm
 # and more, see assets in release page
 ```
 
@@ -76,7 +76,7 @@ On a MacOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.63.8/fortio_win_1.63.8.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.63.9/fortio_win_1.63.9.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -130,7 +130,7 @@ Full list of command line flags (`fortio help`):
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
 <!-- USAGE_START -->
-Φορτίο 1.63.8 usage:
+Φορτίο 1.63.9 usage:
         fortio command [flags] target
 where command is one of: load (load testing), server (starts ui, rest api,
  http-echo, redirect, proxies, tcp-echo, udp-echo and grpc ping servers),
@@ -333,8 +333,8 @@ be in the form of host:port, ip:port, port or "disabled" to disable the feature.
   -s int
         Number of streams per grpc connection (default 1)
   -sequential-warmup
-        http(s) runner warmup done in parallel instead of sequentially. When set,
-restores pre 1.21 behavior
+        http(s) runner warmup done sequentially instead of parallel. When set, restores
+pre 1.21 behavior
   -server-idle-timeout value
         Default IdleTimeout for servers (default 30s)
   -static-dir path

--- a/bincommon/commonflags.go
+++ b/bincommon/commonflags.go
@@ -95,7 +95,7 @@ var (
 	RunIDFlag = flag.Int64("runid", 0, "Optional RunID to add to json result and auto save filename, to match server mode")
 	// HelpFlag is true if help/usage is being requested by the user.
 	warmupFlag = flag.Bool("sequential-warmup", false,
-		"http(s) runner warmup done in parallel instead of sequentially. When set, restores pre 1.21 behavior")
+		"http(s) runner warmup done sequentially instead of parallel. When set, restores pre 1.21 behavior")
 	curlHeadersStdout = flag.Bool("curl-stdout-headers", false,
 		"Restore pre 1.22 behavior where http headers of the fast client are output to stdout in curl mode. now stderr by default.")
 	// ConnectionReuseRange Dynamic string flag to set the max connection reuse range.

--- a/fhttp/http_client.go
+++ b/fhttp/http_client.go
@@ -36,6 +36,7 @@ import (
 	"fortio.org/fortio/jrpc"
 	"fortio.org/fortio/stats"
 	"fortio.org/log"
+	"fortio.org/scli"
 	"github.com/google/uuid"
 	"golang.org/x/net/http2"
 )
@@ -948,6 +949,7 @@ func (c *FastClient) connect(ctx context.Context) net.Conn {
 		c.connectStats.Record(time.Since(now).Seconds())
 		if err != nil {
 			log.S(log.Error, "Unable to connect", log.Attr("dest", c.dest), log.Attr("err", err),
+				log.Attr("numfd", scli.NumFD()),
 				log.Attr("thread", c.id), log.Attr("run", c.runID))
 			return nil
 		}

--- a/fhttp/httprunner.go
+++ b/fhttp/httprunner.go
@@ -162,7 +162,7 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 		if o.SequentialWarmup && o.Exactly <= 0 {
 			code, dataLen, headerSize := httpstate[i].client.StreamFetch(ctx)
 			if !o.AllowInitialErrors && !codeIsOK(code) {
-				codeErr := fmt.Errorf("error %d for %s (%d body bytes)", code, o.URL, dataLen)
+				codeErr := fmt.Errorf("error %d for %s (%d body bytes), thread# %d", code, o.URL, dataLen, i)
 				aborter.RecordStart()
 				return NewErrorResult(o, "initial http error", codeErr), codeErr
 			}


### PR DESCRIPTION
So for instance on mac one gets:
```
$ go run . load -t 10s -qps 10000 -c 16383 -uniform -sequential-warmup http://localhost:8080 
12:13:55.544 r1 [INF] scli.go:125> Starting, command="Φορτίο", version="dev  go1.22.3 arm64 darwin", go-max-procs=11
Fortio dev running at 10000 queries per second, 11->11 procs, for 10s: http://localhost:8080
12:13:55.544 r1 [INF] httprunner.go:121> Starting http test, run=0, url="http://localhost:8080", threads=16383, qps="10000.0", warmup="sequential", conn-reuse=""
12:13:59.317 r1 [ERR] http_client.go:951> Unable to connect, dest={"IP":"127.0.0.1","Port":8080,"Zone":""}, err="dial tcp 127.0.0.1:8080: connect: can't assign requested address", numfd=16312, thread=16303, run=0
Aborting because of error -1 for http://localhost:8080 (0 body bytes), thread# 16303
exit status 1
```