### PR TITLE
More gosec fixes, as detected by linter 1.61.0

### DIFF
--- a/bincommon/commonflags.go
+++ b/bincommon/commonflags.go
@@ -31,6 +31,7 @@ import (
 	"fortio.org/fortio/fnet"
 	"fortio.org/fortio/periodic"
 	"fortio.org/log"
+	"fortio.org/safecast"
 )
 
 // -- Support for multiple instances of -H flag on cmd line.
@@ -156,8 +157,8 @@ func FetchURL(o *fhttp.HTTPOptions) {
 		var data []byte
 		var headerI int
 		code, data, headerI = client.Fetch(context.Background())
-		dataLen = int64(len(data))
-		header = uint(headerI)
+		dataLen = safecast.MustConvert[int64](len(data))
+		header = safecast.MustConvert[uint](headerI)
 		if *curlHeadersStdout {
 			os.Stdout.Write(data)
 		} else {

--- a/fhttp/http_client.go
+++ b/fhttp/http_client.go
@@ -1165,7 +1165,7 @@ func (c *FastClient) readResponse(conn *DelayedErrorReader, socket net.Conn, reu
 						parsedHeaders = true
 						break
 					}
-					c.headerLen = uint(idx)
+					c.headerLen = safecast.MustConvert[uint](idx)
 					idx++
 				}
 				idx++


### PR DESCRIPTION
~~but that'll need o wait for build image update to show up~~
looks like we do get the linter stage through shared workflow gochecks
