### PR TITLE
Add number of goroutines to the debug/metrics endpoint

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -18,6 +18,7 @@ package metrics // import "fortio.org/fortio/metrics"
 import (
 	"io"
 	"net/http"
+	"runtime"
 	"strconv"
 
 	"fortio.org/fortio/rapi"
@@ -44,5 +45,10 @@ fortio_running `)
 # TYPE fortio_runs_total counter
 fortio_runs_total `)
 	_, _ = io.WriteString(w, strconv.FormatInt(total, 10))
+	_, _ = io.WriteString(w, `
+# HELP fortio_goroutines Current number of goroutines
+# TYPE fortio_goroutines gauge
+fortio_goroutines `)
+	_, _ = io.WriteString(w, strconv.FormatInt(int64(runtime.NumGoroutine()), 10))
 	_, _ = io.WriteString(w, "\n")
 }


### PR DESCRIPTION
Turns out one of the reason the std client is less efficient is also it uses 2 extra go routines per connection (read and write loops) - compared to basic fast client. So 3 to 1 factor.

Shown as
```prometheus
# HELP fortio_goroutines Current number of goroutines
# TYPE fortio_goroutines gauge
fortio_goroutines 108
```
