### PR TITLE
Use go1.24.12 and prep for 1.73.2 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ defaultEnv:
   &defaultEnv
   docker:
     # specify the version
-    - image: docker.io/fortio/fortio.build:v83@sha256:c5949fb8c0da04c7a122e806da28efec216028e7e40b976c1310f431e22092b2
+    - image: docker.io/fortio/fortio.build:v84@sha256:870da6fb8f8ef3afd7f2fc6c6fa74e5befa2a058d74a4fcda78b881c2656eefc
   working_directory: /build/fortio
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v83@sha256:c5949fb8c0da04c7a122e806da28efec216028e7e40b976c1310f431e22092b2 AS build
+FROM docker.io/fortio/fortio.build:v84@sha256:870da6fb8f8ef3afd7f2fc6c6fa74e5befa2a058d74a4fcda78b881c2656eefc AS build
 WORKDIR /build
 COPY --chown=build:build . fortio
 ARG MODE=install

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,5 @@
 # Dependencies and linters for build:
-FROM golang:1.24.11@sha256:54528d189affe7ce60840cad093d53360705d47d71ea74d62eef72c476242fe9
+FROM golang:1.24.12@sha256:3cf75037b466628dd35fe88065e475463bd5083075ff0a8962cbfb4327423ee3
 # Need gcc for -race test (and some linters though those work with CGO_ENABLED=0)
 RUN apt-get -y update && \
   apt-get --no-install-recommends -y upgrade && \
@@ -11,7 +11,7 @@ RUN gem install --no-document fpm
 RUN go version # check it's indeed the version we expect
 
 # golangci-lint
-# RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
+# RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 RUN golangci-lint version
 

--- a/Dockerfile.echosrv
+++ b/Dockerfile.echosrv
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v83@sha256:c5949fb8c0da04c7a122e806da28efec216028e7e40b976c1310f431e22092b2 AS build
+FROM docker.io/fortio/fortio.build:v84@sha256:870da6fb8f8ef3afd7f2fc6c6fa74e5befa2a058d74a4fcda78b881c2656eefc AS build
 WORKDIR /build
 COPY . fortio
 RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_TARGET=fortio.org/fortio/echosrv

--- a/Dockerfile.fcurl
+++ b/Dockerfile.fcurl
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v83@sha256:c5949fb8c0da04c7a122e806da28efec216028e7e40b976c1310f431e22092b2 AS build
+FROM docker.io/fortio/fortio.build:v84@sha256:870da6fb8f8ef3afd7f2fc6c6fa74e5befa2a058d74a4fcda78b881c2656eefc AS build
 WORKDIR /build
 COPY . fortio
 RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_TARGET=fortio.org/fortio/fcurl

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 IMAGES=echosrv fcurl # plus the combo image / Dockerfile without ext.
 
 DOCKER_PREFIX := docker.io/fortio/fortio
-BUILD_IMAGE_TAG := v83@sha256:c5949fb8c0da04c7a122e806da28efec216028e7e40b976c1310f431e22092b2
+BUILD_IMAGE_TAG := v84@sha256:870da6fb8f8ef3afd7f2fc6c6fa74e5befa2a058d74a4fcda78b881c2656eefc
 BUILDX_PLATFORMS := linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 BUILDX_POSTFIX :=
 ifeq '$(shell echo $(BUILDX_PLATFORMS) | awk -F "," "{print NF-1}")' '0'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- 1.73.1 -->
+<!-- 1.73.2 -->
 # Fortio
 
 [![Awesome Go](https://fortio.org/mentioned-badge.svg)](https://github.com/avelino/awesome-go#networking)
@@ -59,13 +59,13 @@ You can install from source:
 The [releases](https://github.com/fortio/fortio/releases) page has binaries for many OS/architecture combinations (see assets):
 
 ```shell
-curl -L https://github.com/fortio/fortio/releases/download/v1.73.1/fortio-linux_amd64-1.73.1.tgz \
+curl -L https://github.com/fortio/fortio/releases/download/v1.73.2/fortio-linux_amd64-1.73.2.tgz \
  | sudo tar -C / -xvzpf -
 # or the debian package
-wget https://github.com/fortio/fortio/releases/download/v1.73.1/fortio_1.73.1_amd64.deb
-dpkg -i fortio_1.73.1_amd64.deb
+wget https://github.com/fortio/fortio/releases/download/v1.73.2/fortio_1.73.2_amd64.deb
+dpkg -i fortio_1.73.2_amd64.deb
 # or the rpm
-rpm -i https://github.com/fortio/fortio/releases/download/v1.73.1/fortio-1.73.1-1.x86_64.rpm
+rpm -i https://github.com/fortio/fortio/releases/download/v1.73.2/fortio-1.73.2-1.x86_64.rpm
 # and more, see assets in release page
 ```
 
@@ -75,7 +75,7 @@ On macOS you can also install Fortio using [Homebrew](https://brew.sh/):
 brew install fortio
 ```
 
-On Windows, download https://github.com/fortio/fortio/releases/download/v1.73.1/fortio_win_1.73.1.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
+On Windows, download https://github.com/fortio/fortio/releases/download/v1.73.2/fortio_win_1.73.2.zip and extract `fortio.exe` to any location, then using the Windows Command Prompt:
 ```
 fortio.exe server
 ```
@@ -141,7 +141,7 @@ Full list of command line flags (`fortio help`):
 <!-- use release/updateFlags.sh to update this section -->
 <pre>
 <!-- USAGE_START -->
-Φορτίο 1.73.1 usage:
+Φορτίο 1.73.2 usage:
         fortio command [flags] target
 where command is one of: load (load testing), server (starts ui, rest api,
  http-echo, redirect, proxies, tcp-echo, udp-echo and grpc ping servers),

--- a/Webtest.sh
+++ b/Webtest.sh
@@ -140,7 +140,7 @@ fi
 PPROF_URL="$BASE_URL/debug/pprof/heap?debug=1"
 $CURL "$PPROF_URL" | grep -i TotalAlloc # should find this in memory profile
 # creating dummy container to hold a volume for test certs due to remote docker bind mount limitation.
-DOCKERCURLID=$(docker run -d -v $TEST_CERT_VOL --net host --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v83@sha256:c5949fb8c0da04c7a122e806da28efec216028e7e40b976c1310f431e22092b2 sleep 120)
+DOCKERCURLID=$(docker run -d -v $TEST_CERT_VOL --net host --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v84@sha256:870da6fb8f8ef3afd7f2fc6c6fa74e5befa2a058d74a4fcda78b881c2656eefc sleep 120)
 # while we have something with actual curl binary do
 # Test for h2c upgrade (#562)
 docker exec $DOCKERSECVOLNAME /usr/bin/curl -v --http2 -m 10 -d foo42 http://localhost:8080/debug | tee >(cat 1>&2) | grep foo42

--- a/fhttp/http_test.go
+++ b/fhttp/http_test.go
@@ -1268,7 +1268,7 @@ func TestEchoHeaders(t *testing.T) {
 		v.Add("header", pair.key+":"+pair.value)
 	}
 	// minimal manual encoding (only escape the space) + errors for coverage sake
-	var urls []string
+	urls := make([]string, 0, 2)
 	urls = append(urls,
 		fmt.Sprintf("http://localhost:%d/echo?size=10&header=Foo:Bar1&header=Foo:Bar2&header=X:Y&header=Z:abc+def:xyz&header=&header=Foo",
 			a.Port))

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -1,5 +1,5 @@
 # Concatenated after ../Dockerfile to create the tgz
-FROM docker.io/fortio/fortio.build:v83@sha256:c5949fb8c0da04c7a122e806da28efec216028e7e40b976c1310f431e22092b2 AS stage
+FROM docker.io/fortio/fortio.build:v84@sha256:870da6fb8f8ef3afd7f2fc6c6fa74e5befa2a058d74a4fcda78b881c2656eefc AS stage
 ARG archs="amd64 arm64 ppc64le s390x"
 ENV archs=${archs}
 # Build image defaults to build user, switch back to root for


### PR DESCRIPTION
While making the v84 build, I also mistakenly overode the previous fortio.build v83 (still there under the sha for history)
